### PR TITLE
feat: add llama, ollama, and anthropic to quickstart in alphabetized order

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@
 
 ## Checklist
 <!-- Mark completed items with an [x] -->
-- [ ] I have read the [CONTRIBUTING](../docs/CONTRIBUTING.md) document
+- [ ] I have read the CONTRIBUTING document
 - [ ] My changes follow the project's documentation style
 - [ ] I have tested the documentation locally using `mkdocs serve`
 - [ ] Links in the documentation are valid and working

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -213,11 +213,11 @@ More details in the [Amazon Bedrock Model Provider](concepts/model-providers/ama
 
 Strands Agents supports several other model providers beyond Amazon Bedrock:
 
-- **Anthropic** - Direct API access to Claude models ([docs](concepts/model-providers/anthropic.md))
-- **LiteLLM** - Unified interface for OpenAI, Mistral, and other providers ([docs](concepts/model-providers/litellm.md))
-- **Llama API** - Access to Meta's Llama models ([docs](concepts/model-providers/llamaapi.md))
-- **Ollama** - Run models locally for privacy or offline use ([docs](concepts/model-providers/ollama.md))
-- **Custom Providers** - Build your own provider for specialized needs ([docs](concepts/model-providers/custom_model_provider.md))
+- **[Anthropic](concepts/model-providers/anthropic.md)** - Direct API access to Claude models
+- **[LiteLLM](concepts/model-providers/litellm.md)** - Unified interface for OpenAI, Mistral, and other providers
+- **[Llama API](concepts/model-providers/llamaapi.md)** - Access to Meta's Llama models
+- **[Ollama](concepts/model-providers/ollama.md)** - Run models locally for privacy or offline use
+- **[Custom Providers](concepts/model-providers/custom_model_provider.md)** - Build your own provider for specialized needs
 
 ## Capturing Streamed Data & Events
 

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -203,7 +203,11 @@ bedrock_model = BedrockModel(
 agent = Agent(model=bedrock_model)
 ```
 
+For the Amazon Bedrock model provider, see the [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) to configure credentials for your environment. For development, AWS credentials are typically defined in `AWS_` prefixed environment variables or configured with the `aws configure` CLI command.
+
 You will also need to enable model access in Amazon Bedrock for the models that you choose to use with your agents, following the [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to enable access.
+
+More details in the [Amazon Bedrock Model Provider](concepts/model-providers/amazon-bedrock.md) documentation.
 
 ### Anthropic
 
@@ -307,6 +311,8 @@ ollama_model = OllamaModel(
 
 agent = Agent(model=ollama_model)
 ```
+
+More details in the [Ollama Model Provider](concepts/model-providers/ollama.md) documentation.
 
 ### Custom Model Providers
 

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -209,128 +209,15 @@ You will also need to enable model access in Amazon Bedrock for the models that 
 
 More details in the [Amazon Bedrock Model Provider](concepts/model-providers/amazon-bedrock.md) documentation.
 
-### Anthropic
+### Additional Model Providers
 
-First install the `anthropic` python client:
+Strands Agents supports several other model providers beyond Amazon Bedrock:
 
-```bash
-pip install strands-agents[anthropic]
-```
-
-Next, import and initialize the `AnthropicModel` provider:
-
-```python
-from strands import Agent
-from strands.models.anthropic import AnthropicModel
-
-anthropic_model = AnthropicModel(
-    client_args={
-        "api_key": "<KEY>",
-    },
-    max_tokens=1028,
-    model_id="claude-3-7-sonnet-20250219",
-    params={
-        "temperature": 0.7,
-    }
-)
-
-agent = Agent(model=anthropic_model)
-```
-
-### LiteLLM
-
-LiteLLM is a unified interface for various LLM providers that allows you to interact with models from OpenAI and many others.
-
-First install the `litellm` python client:
-
-```bash
-pip install strands-agents[litellm]
-```
-
-Next, import and initialize the `LiteLLMModel` provider:
-
-```python
-from strands import Agent
-from strands.models.litellm import LiteLLMModel
-
-litellm_model = LiteLLMModel(
-    client_args={
-        "api_key": "<KEY>",
-    },
-    model_id="gpt-4o"
-)
-
-agent = Agent(model=litellm_model)
-```
-
-### Llama API
-
-Llama API is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.
-
-First install the `llamaapi` python client:
-```bash
-pip install strands-agents[llamaapi]
-```
-
-Next, import and initialize the `LlamaAPIModel` provider:
-
-```python
-from strands import Agent
-from strands.models.llamaapi import LLamaAPIModel
-
-model = LlamaAPIModel(
-    client_args={
-        "api_key": "<KEY>",
-    },
-    # **model_config
-    model_id="Llama-4-Maverick-17B-128E-Instruct-FP8",
-)
-
-agent = Agent(models=LLamaAPIModel)
-```
-
-### Ollama (Local Models)
-
-First install the `ollama` python client:
-
-```bash
-pip install strands-agents[ollama]
-```
-
-Next, import and initialize the `OllamaModel` provider:
-
-```python
-from strands import Agent
-from strands.models.ollama import OllamaModel
-
-ollama_model = OllamaModel(
-    host="http://localhost:11434"  # Ollama server address
-    model_id="llama3",  # Specify which model to use
-    temperature=0.3,
-)
-
-agent = Agent(model=ollama_model)
-```
-
-More details in the [Ollama Model Provider](concepts/model-providers/ollama.md) documentation.
-
-### Custom Model Providers
-
-We can even connect our agents to custom model providers to use any model from anywhere!
-
-```python
-from strands import Agent
-from your_company.models.custom_model import CustomModel
-
-custom_model = CustomModel(
-    model_id="your-model-id
-    temperature=0.3,
-)
-
-agent = Agent(model=custom_model)
-```
-
-See the [Custom Providers](concepts/model-providers/custom_model_provider.md) documentation for more information on creating your own model provider.
+- **Anthropic** - Direct API access to Claude models ([docs](concepts/model-providers/anthropic.md))
+- **LiteLLM** - Unified interface for OpenAI, Mistral, and other providers ([docs](concepts/model-providers/litellm.md))
+- **Llama API** - Access to Meta's Llama models ([docs](concepts/model-providers/llamaapi.md))
+- **Ollama** - Run models locally for privacy or offline use ([docs](concepts/model-providers/ollama.md))
+- **Custom Providers** - Build your own provider for specialized needs ([docs](concepts/model-providers/custom_model_provider.md))
 
 ## Capturing Streamed Data & Events
 

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -203,12 +203,87 @@ bedrock_model = BedrockModel(
 agent = Agent(model=bedrock_model)
 ```
 
-For the Amazon Bedrock model provider, see the [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) to configure credentials for your environment. For development, AWS credentials are typically defined in `AWS_` prefixed environment variables or configured with the `aws configure` CLI command.
-
 You will also need to enable model access in Amazon Bedrock for the models that you choose to use with your agents, following the [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to enable access.
 
-More details in the [Amazon Bedrock Model Provider](concepts/model-providers/amazon-bedrock.md) documentation.
+### Anthropic
 
+First install the `anthropic` python client:
+
+```bash
+pip install strands-agents[anthropic]
+```
+
+Next, import and initialize the `AnthropicModel` provider:
+
+```python
+from strands import Agent
+from strands.models.anthropic import AnthropicModel
+
+anthropic_model = AnthropicModel(
+    client_args={
+        "api_key": "<KEY>",
+    },
+    max_tokens=1028,
+    model_id="claude-3-7-sonnet-20250219",
+    params={
+        "temperature": 0.7,
+    }
+)
+
+agent = Agent(model=anthropic_model)
+```
+
+### LiteLLM
+
+LiteLLM is a unified interface for various LLM providers that allows you to interact with models from OpenAI and many others.
+
+First install the `litellm` python client:
+
+```bash
+pip install strands-agents[litellm]
+```
+
+Next, import and initialize the `LiteLLMModel` provider:
+
+```python
+from strands import Agent
+from strands.models.litellm import LiteLLMModel
+
+litellm_model = LiteLLMModel(
+    client_args={
+        "api_key": "<KEY>",
+    },
+    model_id="gpt-4o"
+)
+
+agent = Agent(model=litellm_model)
+```
+
+### Llama API
+
+Llama API is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.
+
+First install the `llamaapi` python client:
+```bash
+pip install strands-agents[llamaapi]
+```
+
+Next, import and initialize the `LlamaAPIModel` provider:
+
+```python
+from strands import Agent
+from strands.models.llamaapi import LLamaAPIModel
+
+model = LlamaAPIModel(
+    client_args={
+        "api_key": "<KEY>",
+    },
+    # **model_config
+    model_id="Llama-4-Maverick-17B-128E-Instruct-FP8",
+)
+
+agent = Agent(models=LLamaAPIModel)
+```
 
 ### Ollama (Local Models)
 
@@ -218,7 +293,7 @@ First install the `ollama` python client:
 pip install strands-agents[ollama]
 ```
 
-Next, import and intialize the `OllamaModel` provider:
+Next, import and initialize the `OllamaModel` provider:
 
 ```python
 from strands import Agent
@@ -232,8 +307,6 @@ ollama_model = OllamaModel(
 
 agent = Agent(model=ollama_model)
 ```
-
-More details in the [Ollama Model Provider](concepts/model-providers/ollama.md) documentation.
 
 ### Custom Model Providers
 


### PR DESCRIPTION
## Description

New providers have been added to Strands Agents. This PR adds them to the quickstart page. To reduce clutter in the quickstart section we removed all but the default provider, Bedrock. Instead we now provide a list of other providers which we will continue to add to.

Additionally, the contributing link was broken. So this PR synchronizes it with other repositories owned by the organization to just be text, and not a link.

## Type of Change
- Content update/revision

## Motivation and Context
New providers have been added and should be displayed front and center.

## Areas Affected
quickstart.md

## Screenshots
Updated screenshot
<img width="366" alt="Screenshot 2025-05-16 at 3 58 09 PM" src="https://github.com/user-attachments/assets/96b66e3d-490b-42e6-8fc4-48bbfc168deb" />

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the [CONTRIBUTING](../docs/CONTRIBUTING.md) document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass
nformation that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.