### PR TITLE
Add missing link in `mkdocs.yml` file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
     - Overview: examples/README.md
     - CLI Reference Agent Implementation: examples/python/cli-reference-agent.md
     - Weather Forecaster: examples/python/weather_forecaster.md
+    - Memory Agent: examples/python/memory_agent.md
     - File Operations: examples/python/file_operations.md
     - Agents Workflows: examples/python/agents_workflows.md
     - Knowledge-Base Workflow: examples/python/knowledge_base_agent.md


### PR DESCRIPTION
## Description

Forgot to add the link so that the page shows up on the sidebar on docs. Fixed it in this PR. 