### PR TITLE
demonstrate how to print the configured model_id

### DIFF
--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -168,6 +168,19 @@ agent("Hello!")
 
 ## Model Providers
 
+### Identifying a configured model 
+
+Strands defaults to the Bedrock model provider using Claude 3.7 Sonnet. The model your agent is using can be retrieved by accessing [`model.config`](/api-reference/types/#strands.types.models.Model.get_config):
+
+```python
+from strands import Agent
+
+agent = Agent()
+
+print(agent.model.config)
+# {'model_id': 'us.anthropic.claude-3-7-sonnet-20250219-v1:0'}
+```
+
 You can specify a different model in two ways:
 
 1. By passing a string model ID directly to the Agent constructor


### PR DESCRIPTION
## Description
<img width="774" alt="Screenshot 2025-05-17 at 8 10 05 AM" src="https://github.com/user-attachments/assets/0180e953-91d3-4f9c-803e-02f692cd0ca5" />


## Type of Change
Updated the quickstart with a handy call-out on how to print the model_id

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
