### PR TITLE
docs: add tools to example tools package page: memory, mem0_memory, cron, slack, speak

### DIFF
--- a/docs/user-guide/concepts/tools/example-tools-package.md
+++ b/docs/user-guide/concepts/tools/example-tools-package.md
@@ -12,26 +12,31 @@ pip install strands-agents-tools
 
 #### RAG & Memory
 - [`retrieve`]({{ tools_repo }}/src/strands_tools/retrieve.py): Semantically retrieve data from Amazon Bedrock Knowledge Bases for RAG, memory, and other purposes
+- [`memory`]({{ tools_repo }}/src/strands_tools/memory.py): Agent memory persistence in Amazon Bedrock Knowledge Bases
+- [`mem0_memory`]({{ tools_repo }}/src/strands_tools/mem0_memory.py): Agent memory and personalization built on top of [Mem0](https://mem0.ai)
 
 #### File Operations
-- [`editor`]({{ tools_repo }}/src/strands_tools/editor.py): Advanced file editing operations
+- [`editor`]({{ tools_repo }}/src/strands_tools/editor.py): File editing operations like line edits, search, and undo
 - [`file_read`]({{ tools_repo }}/src/strands_tools/file_read.py): Read and parse files
 - [`file_write`]({{ tools_repo }}/src/strands_tools/file_write.py): Create and modify files
 
 #### Shell & System
 - [`environment`]({{ tools_repo }}/src/strands_tools/environment.py): Manage environment variables
 - [`shell`]({{ tools_repo }}/src/strands_tools/shell.py): Execute shell commands
+- [`cron`]({{ tools_repo }}/src/strands_tools/cron.py): Task scheduling with cron jobs
 
 #### Code Interpretation
 - [`python_repl`]({{ tools_repo }}/src/strands_tools/python_repl.py): Run Python code
 
 #### Web & Network
 - [`http_request`]({{ tools_repo }}/src/strands_tools/http_request.py): Make API calls, fetch web data, and call local HTTP servers
+- [`slack`]({{ tools_repo }}/src/strands_tools/slack.py): Slack integration with real-time events, API access, and message sending
 
 #### Multi-modal
 - [`image_reader`]({{ tools_repo }}/src/strands_tools/image_reader.py): Process and analyze images
 - [`generate_image`]({{ tools_repo }}/src/strands_tools/generate_image.py): Create AI generated images with Amazon Bedrock
 - [`nova_reels`]({{ tools_repo }}/src/strands_tools/nova_reels.py): Create AI generated images with Nova Reels on Amazon Bedrock
+- [`speak`]({{ tools_repo }}/src/strands_tools/speak.py): Generate speech from text using macOS say command or Amazon Polly
 
 #### AWS Services
 - [`use_aws`]({{ tools_repo }}/src/strands_tools/use_aws.py): Interact with AWS services

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -170,7 +170,7 @@ agent("Hello!")
 
 ### Identifying a configured model 
 
-Strands defaults to the Bedrock model provider using Claude 3.7 Sonnet. The model your agent is using can be retrieved by accessing [`model.config`](/api-reference/types/#strands.types.models.Model.get_config):
+Strands defaults to the Bedrock model provider using Claude 3.7 Sonnet. The model your agent is using can be retrieved by accessing [`model.config`](../api-reference/types.md#strands.types.models.Model.get_config):
 
 ```python
 from strands import Agent


### PR DESCRIPTION
## Description
Document additional example tools:
* memory
* mem0_memory
* cron
* slack
* speak

## Type of Change
- New content addition
- Content update/revision

## Motivation and Context
Include additional tools.

## Areas Affected
https://strandsagents.com/0.1.x/user-guide/concepts/tools/example-tools-package/

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
