### PR TITLE
Fix inaccuracy in tools documentation

### DIFF
--- a/docs/user-guide/concepts/tools/example-tools-package.md
+++ b/docs/user-guide/concepts/tools/example-tools-package.md
@@ -31,7 +31,7 @@ pip install strands-agents-tools
 #### Multi-modal
 - [`image_reader`]({{ tools_repo }}/src/strands_tools/image_reader.py): Process and analyze images
 - [`generate_image`]({{ tools_repo }}/src/strands_tools/generate_image.py): Create AI generated images with Amazon Bedrock
-- [`nova_reels`]({{ tools_repo }}/src/strands_tools/nova_reels.py): Create AI generated images with Nova Reels on Amazon Bedrock
+- [`nova_reels`]({{ tools_repo }}/src/strands_tools/nova_reels.py): Create AI generated videos with Nova Reels on Amazon Bedrock
 
 #### AWS Services
 - [`use_aws`]({{ tools_repo }}/src/strands_tools/use_aws.py): Interact with AWS services


### PR DESCRIPTION
## Description
This PR fixes an inaccuracy in the "Available Tools" documentation, replacing "create AI generated images with Nova Reels" with "create AI generated videos with Nova Reels"

## Motivation and Context
Amazon Nova Reels is a video generation model

## Areas Affected
Page: Example Built-in Tools
File: docs/user-guide/concepts/tools/example-tools-package.md

## Screenshots
n/a

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [n/a] Links in the documentation are valid and working
- [n/a] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
n/a

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
