### PR TITLE
fix pip install commands with extra's

### DIFF
--- a/docs/user-guide/concepts/model-providers/anthropic.md
+++ b/docs/user-guide/concepts/model-providers/anthropic.md
@@ -7,7 +7,7 @@
 Anthropic is configured as an optional dependency in Strands. To install, run:
 
 ```bash
-pip install strands-agents[anthropic]
+pip install 'strands-agents[anthropic]'
 ```
 
 ## Usage
@@ -56,7 +56,7 @@ The `model_config` configures the underlying model selected for inference. The s
 
 ### Module Not Found
 
-If you encounter the error `ModuleNotFoundError: No module named 'anthropic'`, this means you haven't installed the `anthropic` dependency in your environment. To fix, run `pip install strands-agents[anthropic]`.
+If you encounter the error `ModuleNotFoundError: No module named 'anthropic'`, this means you haven't installed the `anthropic` dependency in your environment. To fix, run `pip install 'strands-agents[anthropic]'`.
 
 ## References
 

--- a/docs/user-guide/concepts/model-providers/litellm.md
+++ b/docs/user-guide/concepts/model-providers/litellm.md
@@ -7,7 +7,7 @@
 LiteLLM is configured as an optional dependency in Strands Agents. To install, run:
 
 ```bash
-pip install strands-agents[litellm]
+pip install 'strands-agents[litellm]'
 ```
 
 ## Usage
@@ -55,7 +55,7 @@ The `model_config` configures the underlying model selected for inference. The s
 
 ### Module Not Found
 
-If you encounter the error `ModuleNotFoundError: No module named 'litellm'`, this means you haven't installed the `litellm` dependency in your environment. To fix, run `pip install strands-agents[litellm]`.
+If you encounter the error `ModuleNotFoundError: No module named 'litellm'`, this means you haven't installed the `litellm` dependency in your environment. To fix, run `pip install 'strands-agents[litellm]'`.
 
 ## References
 

--- a/docs/user-guide/concepts/model-providers/llamaapi.md
+++ b/docs/user-guide/concepts/model-providers/llamaapi.md
@@ -11,7 +11,7 @@ With Llama API, you get access to state-of-the-art AI capabilities through a dev
 Llama API is configured as an optional dependency in Strands Agents. To install, run:
 
 ```bash
-pip install strands-agents[llamaapi]
+pip install 'strands-agents[llamaapi]'
 ```
 
 ## Usage
@@ -61,7 +61,7 @@ The `model_config` configures the underlying model selected for inference. The s
 
 ### Module Not Found
 
-If you encounter the error `ModuleNotFoundError: No module named 'llamaapi'`, this means you haven't installed the `llamaapi` dependency in your environment. To fix, run `pip install strands-agents[llamaapi]`.
+If you encounter the error `ModuleNotFoundError: No module named 'llamaapi'`, this means you haven't installed the `llamaapi` dependency in your environment. To fix, run `pip install 'strands-agents[llamaapi]'`.
 
 ## References
 

--- a/docs/user-guide/concepts/model-providers/ollama.md
+++ b/docs/user-guide/concepts/model-providers/ollama.md
@@ -16,7 +16,7 @@ The [`OllamaModel`](../../../api-reference/models.md#strands.models.ollama) clas
 
 First install the python client into your python environment:
 ```bash
-pip install strands-agents[ollama]
+pip install 'strands-agents[ollama]'
 ```
 
 Next, you'll need to install and setup ollama itself.
@@ -231,7 +231,7 @@ response = agent("What's the square root of 144 plus the current time?")
 
 3. **Module Not Found**:
     - If you encounter the error `ModuleNotFoundError: No module named 'ollama'`, this means you haven't installed the `ollama` dependency in your python environment
-    - To fix, run `pip install strands-agents[ollama]`
+    - To fix, run `pip install 'strands-agents[ollama]'`
 
 ## Related Resources
 


### PR DESCRIPTION
## Description
Update pip install commands with extra's. Before the following commands shown fails:
```
pip install strands-agents[anthropic]
zsh: no matches found: strands-agents[anthropic]
```

Adding `'` around the import fixes this issue:
```
pip install 'strands-agents[anthropic]'
```

## Type of Change
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

Bug fix

## Motivation and Context
Issue with the documentation:
https://github.com/strands-agents/samples/issues/6

## Areas Affected
Pip install commands on pages:
- anthropic
- litellm
- llamaapi
- ollama
- 
## Screenshots
N/a

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
