### PR TITLE
Fix totalTokens access syntax in metrics.md example code

### DIFF
--- a/docs/user-guide/observability-evaluation/metrics.md
+++ b/docs/user-guide/observability-evaluation/metrics.md
@@ -24,7 +24,7 @@ agent = Agent(tools=[calculator])
 result = agent("What is the square root of 144?")
 
 # Access metrics through the AgentResult
-print(f"Total tokens: {result.metrics.accumulated_usage.totalTokens}")
+print(f"Total tokens: {result.metrics.accumulated_usage['totalTokens']}")
 print(f"Execution time: {sum(result.metrics.cycle_durations):.2f} seconds")
 print(f"Tools used: {list(result.metrics.tool_metrics.keys())}")
 ```


### PR DESCRIPTION
## Description
Updated the example code to use correct dictionary access notation for accumulated_usage['totalTokens'] instead of incorrect dot notation (accumulated_usage.totalTokens), as accumulated_usage is defined as a TypedDict in the metrics documentation


## Type of Change
<!-- What kind of change are you making -->
- Content update/revision
- Bug fix

## Motivation and Context
The original documentation showed incorrect syntax for accessing TypedDict properties in the code example. This could lead to runtime errors for users following the documentation. The fix ensures the code example correctly demonstrates how to access the accumulated_usage TypedDict properties.

## Areas Affected
docs/docs/user-guide/observability-evaluation/metrics.md

## Screenshots
N/A - Text change only

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
I used Strand Agents to help me identify the fix to this error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
