### PR TITLE
fixing typos in different docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 ## Code of Conduct
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+For more information, see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
+Looking at the existing issues is a great way to find something to contribute to. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
 
 ## Code of Conduct

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -42,7 +42,7 @@ Available Python examples:
 - [File Operations](python/file_operations.md) - Example of agent with file manipulation capabilities
 - [MCP Calculator](python/mcp_calculator.md) - Example of agent with Model Context Protocol capabilities
 - [Meta Tooling](python/meta_tooling.md) - Example of Agent with Meta tooling capabilities 
-- [Multi-Agent Example](python/multi_agent_example/multi_agent_example.md) - Example of a of multi-agent system
+- [Multi-Agent Example](python/multi_agent_example/multi_agent_example.md) - Example of a multi-agent system
 - [Weather Forecaster](python/weather_forecaster.md) - Example of a weather forecasting agent with http_request capabilities
 
 ### CDK Examples

--- a/docs/examples/python/agents_workflows.md
+++ b/docs/examples/python/agents_workflows.md
@@ -19,7 +19,7 @@ The `http_request` tool enables the agent to make HTTP requests to retrieve info
 
 ## Workflow Architecture
 
-The Research Assistant example implements a three-agent workflow where each agent has a specific role and work together to complete tasks that require multiple steps of processing:
+The Research Assistant example implements a three-agent workflow where each agent has a specific role and works with other agents to complete tasks that require multiple steps of processing:
 
 1. **Researcher Agent**: Gathers information from web sources using http_request tool
 2. **Analyst Agent**: Verifies facts and identifies key insights from research findings

--- a/docs/examples/python/meta_tooling.md
+++ b/docs/examples/python/meta_tooling.md
@@ -14,7 +14,7 @@ Meta-tooling refers to the ability of an AI system to create new tools at runtim
 
 ## Tools Used Overview
 
-The meta-tooling agent use three primary tools to create and manage dynamic tools:
+The meta-tooling agent uses three primary tools to create and manage dynamic tools:
 
   1. `load_tool`: enables dynamic loading of Python tools at runtime, registering new tools with the agent's registry, enabling hot-reloading of capabilities, and validating tool specifications before loading.
   2. `editor`: allows creation and modification of tool code files with syntax highlighting, making precise string replacements in existing tools, inserting code at specific locations, finding and navigating to specific sections of code, and creating backups with undo capability before modifications.

--- a/docs/examples/python/multi_agent_example/multi_agent_example.md
+++ b/docs/examples/python/multi_agent_example/multi_agent_example.md
@@ -112,8 +112,8 @@ def math_assistant(query: str) -> str:
 **Each specialized agent has a distinct system prompt, and tools in its inventory, and follows this general pattern.
   - [Language Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/language_assistant.py) specializes in queries related to translation into different languages.
   - [Computer Scince Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/computer_science_assistant.py) specializes in queries related to writing, editing, running, code and explaining computer science concepts.
-  - [English Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/english_assistant.py) specializes in queries related to grammer, and english comprehension.
-  - [General Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/no_expertise.py) is a no specialty agent that aims to answer quries outside of the specific domains the agents are specialized in.
+  - [English Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/english_assistant.py) specializes in queries related to grammar, and english comprehension.
+  - [General Assistant](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/no_expertise.py) is a no specialty agent that aims to answer queries outside of the specific domains the agents are specialized in.
 
 ### 3. Tool-Agent Pattern
 

--- a/docs/user-guide/concepts/agents/context-management.md
+++ b/docs/user-guide/concepts/agents/context-management.md
@@ -22,7 +22,7 @@ The SDK provides a flexible system for context management through the [`Conversa
 
 2. [`reduce_context`](../../../api-reference/agent.md#strands.agent.conversation_manager.conversation_manager.ConversationManager.reduce_context): This method is called when the model's context window is exceeded (typically due to token limits). It implements the specific strategy for reducing the window size when necessary. The agent calls this method when it encounters a context window overflow exception, giving your implementation a chance to trim the conversation history before retrying.
 
-For managing conversations, you can either build your own custom solution or leverage one of Strands's provided managers.
+For managing conversations, you can either build your own custom solution or leverage one of Strands' provided managers.
 
 #### NullConversationManager
 

--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -32,7 +32,7 @@ The decorator extracts information from your function's docstring to create the 
 
 ### Loading Function-Decorated tools
 
-To use function based tool, simply pass the function to the agent:
+To use function-based tool, simply pass the function to the agent:
 
 ```python
 agent = Agent(

--- a/docs/user-guide/observability-evaluation/observability.md
+++ b/docs/user-guide/observability-evaluation/observability.md
@@ -85,7 +85,7 @@ With these components in place, a continuous improvement flywheel emerges which 
 
 * Incorporating user feedback and satisfaction metrics to inform product strategy
 * Leveraging traces to improve agent design and the underlying models
-* Detecting regressions and measuring the impact for new features
+* Detecting regressions and measuring the impact of new features
 
 ## Best Practices
 
@@ -97,4 +97,4 @@ With these components in place, a continuous improvement flywheel emerges which 
 
 ## Conclusion
 
-Effective observability is crucial for developing agents which reliably complete customers’ tasks. The key to success is treating observability not as an afterthought, but as a core component of agent engineering from day one. This investment will pay dividends in improved reliability, faster development cycles, and better customers experiences.
+Effective observability is crucial for developing agents which reliably complete customers’ tasks. The key to success is treating observability not as an afterthought, but as a core component of agent engineering from day one. This investment will pay dividends in improved reliability, faster development cycles, and better customer experiences.

--- a/docs/user-guide/observability-evaluation/traces.md
+++ b/docs/user-guide/observability-evaluation/traces.md
@@ -70,7 +70,7 @@ Each trace consists of multiple spans that represent different operations in you
 
 ## OpenTelemetry Integration
 
-Strands natively integrates with OpenTelemetry, an industry-standard for distributed tracing. This integration provides:
+Strands natively integrates with OpenTelemetry, an industry standard for distributed tracing. This integration provides:
 
 1. **Compatibility with existing observability tools**: Send traces to platforms like Jaeger, Grafana Tempo, AWS X-Ray, Datadog, and more
 2. **Standardized attribute naming**: Using the OpenTelemetry semantic conventions

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -327,7 +327,7 @@ Ready to learn more? Check out these resources:
 - [Strands Agent Builder]({{ agent_builder_repo_home }}) - Use the accompanying `strands-agents-builder` agent builder to harness the power of LLMs to generate your own tools and agents
 - [Agent Loop](concepts/agents/agent-loop.md) - Learn how Strands agents work under the hood
 - [Sessions & State](concepts/agents/sessions-state.md) - Understand how agents maintain context and state across a conversation or workflow
-- [Multi-agent](concepts/multi-agent/agents-as-tools.md) - Orchestrate multiple agents together in to one system, with each agent completing specialized tasks
+- [Multi-agent](concepts/multi-agent/agents-as-tools.md) - Orchestrate multiple agents together as one system, with each agent completing specialized tasks
 - [Workflows](concepts/workflows/code-defined-ai-workflows.md) - Integrate agents in to existing workflows and systems
 - [Observability & Evaluation](observability-evaluation/observability.md) - Understand how agents make decisions and improve them with data
 - [Operating Agents in Production](deploy/operating-agents-in-production.md) - Taking agents from development to production, operating them responsibly at scale


### PR DESCRIPTION
## Description

Fixing various typos in multiple files

## Type of Change

- Typo/formatting fix


## Motivation and Context

Improving quality of documentation and code comments

## Areas Affected

See commit diffs for all details

## Screenshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
