### PR TITLE
Add lychee link checker as GitHub wrokflow

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - '.github/workflows/check-links.yaml'
+      - '.lycheeignore'
 
   repository_dispatch:
 

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,0 +1,29 @@
+name: Links
+
+on:
+
+  repository_dispatch:
+
+  workflow_dispatch:
+
+  schedule:
+    - cron: "00 09 * * *"
+
+jobs:
+  check_links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -2,6 +2,10 @@ name: Links
 
 on:
 
+  push:
+    paths:
+      - '.github/workflows/check-links.yaml'
+
   repository_dispatch:
 
   workflow_dispatch:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+https://locahost*
+https://127.0.0.1*
+http://locahost*
+http://127.0.0.1*


### PR DESCRIPTION
## Description

Adding a GitHub workflow running Lychee action to have a daily check of links (to find 404. 403, etc.)  in the documentation

## Type of Change

- Other (please describe):

See above: adding a workflow to check validity of url links

## Motivation and Context

As you'll see on first run (or in my fork), there are already some incorrect links in the doc. This workflow will detect them so that they can get fixed.

## Areas Affected

Global quality of documents

## Screenshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes

The 2nd step of the workflow automatically opens an issue in the project when incorrect links have been found. To get it to work in the repo, proper token will have to be granted to this workflow. 

See https://github.com/lycheeverse/lychee-action : *"When used in conjunction with [Create Issue From File](https://github.com/peter-evans/create-issue-from-file), issues will be opened when the action finds link problems (make sure to specify the issues: write permission in the [workflow](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions) or the [job](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions))"*

See also https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
