### PR TITLE
Add Windows compatibility guidance for MCP stdio connections

### DIFF
--- a/docs/user-guide/concepts/tools/mcp-tools.md
+++ b/docs/user-guide/concepts/tools/mcp-tools.md
@@ -18,8 +18,26 @@ from strands import Agent
 from strands.tools.mcp import MCPClient
 
 # Connect to an MCP server using stdio transport
+# Note: uvx command syntax differs by platform
+
+# For macOS/Linux:
 stdio_mcp_client = MCPClient(lambda: stdio_client(
-    StdioServerParameters(command="uvx", args=["awslabs.aws-documentation-mcp-server@latest"])
+    StdioServerParameters(
+        command="uvx", 
+        args=["awslabs.aws-documentation-mcp-server@latest"]
+    )
+))
+
+# For Windows:
+stdio_mcp_client = MCPClient(lambda: stdio_client(
+    StdioServerParameters(
+        command="uvx", 
+        args=[
+            "--from", 
+            "awslabs.aws-documentation-mcp-server@latest", 
+            "awslabs.aws-documentation-mcp-server.exe"
+        ]
+    )
 ))
 
 # Create an agent with MCP tools


### PR DESCRIPTION
## Problem
The current MCP stdio documentation only shows the Unix/Linux variant of the `uvx` command, causing Windows users to encounter `MCPClientInitializationError: background thread did not start in 30 seconds` when following the examples.

## Solution
- Added platform-specific examples showing the correct `uvx` command syntax for both Windows and macOS/Linux
- Used multi-line array formatting for better readability across different screen sizes
- Added explanatory comments to clarify platform differences

## Changes
- **Windows**: Requires `--from` flag and `.exe` extension: `["--from", "package@version", "package.exe"]`
- **macOS/Linux**: Uses simple format: `["package@version"]`

## Testing
- [x] Verified Windows example resolves the reported timeout issue
- [x] Confirmed macOS/Linux example maintains backward compatibility

Related to strands-agents/sdk-python#71 (provides workaround until framework fix is implemented)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
