### PR TITLE
Fix parenthesis in mcp-tools

### DIFF
--- a/docs/user-guide/concepts/tools/mcp-tools.md
+++ b/docs/user-guide/concepts/tools/mcp-tools.md
@@ -58,7 +58,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from strands import Agent
 from strands.tools.mcp.mcp_client import MCPClient
 
-streamable_http_mcp_client = MCPClient(lambda: streamablehttp_client("http://localhost:8000/mcp)")
+streamable_http_mcp_client = MCPClient(lambda: streamablehttp_client("http://localhost:8000/mcp"))
 
 # Create an agent with MCP tools
 with streamable_http_mcp_client:


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- What kind of change are you making -->

- Typo/formatting fix

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
There's an incorrect parenthesis in the example

## Areas Affected
<!-- List the pages/sections affected by this PR -->
docs/user-guide/concepts/tools/mcp-tools.md



## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
