### PR TITLE
fix: Correct the syntax for mcp calculator tool call

### DIFF
--- a/docs/examples/python/mcp_calculator.md
+++ b/docs/examples/python/mcp_calculator.md
@@ -95,7 +95,10 @@ with streamable_http_mcp_client:
 
    # Create an agent with the MCP tools
    agent = Agent(tools=tools)
-   agent.add(x=125, y=375)
+   result = agent.tool.add(x=125, y=375)
+
+   # Process the result
+   print(f"Calculation result: {result['content'][0]['text']}")
 ```
 
 ### Sample Queries and Responses


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
Resolves [#22](https://github.com/strands-agents/docs/issues/22)

Fixes the syntax of the direct agent tool call in the mcp calculator example to use `agent.tool.add` instead of `agent.add`. 

## Type of Change
<!-- What kind of change are you making -->
Bug fix

<Enter type of change here>

## Motivation and Context
Fix the syntax in our public docs since the current example results in an error

## Areas Affected
https://strandsagents.com/0.1.x/examples/python/mcp_calculator/#explicit-tool-call-through-agent 

## Screenshots
Tested with a python class as described in the mcp example. First tested with the unchanged syntax, which results in: 
```
Traceback (most recent call last):
  File "/Users/shanaxml/workplace/strands_test.py", line 31, in <module>
    agent.add(x=125, y=375)
AttributeError: 'Agent' object has no attribute 'add'
```
Then, after the change:
```
Calculation result: 500
```
<img width="728" alt="Screenshot 2025-05-23 at 4 30 42 PM" src="https://github.com/user-attachments/assets/e5cbe311-fa9b-4730-a983-62127ab3e4d5" />

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
