### PR TITLE
Update docs to include non-streaming bedrock config

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -16,119 +16,30 @@ The [`BedrockModel`](../../../api-reference/models.md#strands.models.bedrock) cl
 
 1. **AWS Account**: You need an AWS account with access to Amazon Bedrock
 2. **Model Access**: Request access to your desired models in the Amazon Bedrock console
-3. **AWS Credentials**: Configure AWS credentials with appropriate permissions, including `bedrock:InvokeModelWithResponseStream`
+3. **AWS Credentials**: Configure AWS credentials with appropriate permissions
 
 #### Required IAM Permissions
 
 To use Amazon Bedrock with Strands, your IAM user or role needs the following permissions:
 
-- `bedrock:InvokeModelWithResponseStream`
+- `bedrock-runtime:InvokeModelWithResponseStream` (for streaming mode)
+- `bedrock-runtime:InvokeModel` (for non-streaming mode)
 
 Here's a sample IAM policy that grants the necessary permissions:
 
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": ["bedrock:InvokeModelWithResponseStream"],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-For production environments, it's recommended to scope down the `Resource` to specific model ARNs.
-
-#### Requesting Access to Bedrock Models
-
-Before you can use a model in Amazon Bedrock, you need to request access to it:
-
-1. Sign in to the AWS Management Console and open the Amazon Bedrock console
-2. In the navigation pane, choose **Model access**
-3. Choose **Manage model access**
-4. Select the checkbox next to each model you want to access
-5. Choose **Request model access**
-6. Review the terms and conditions, then select **I accept these terms**
-7. Choose **Request model access**
-
-The model access request is typically processed immediately. Once approved, the model status will change to "Access granted" in the console.
-
-For more details, see the [Amazon Bedrock documentation on modifying model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
-
-#### Setting Up AWS Credentials & Region
-
-Strands uses [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) (the AWS SDK for Python) to make calls to Amazon Bedrock. Boto3 has its own credential resolution system that determines which credentials to use when making requests to AWS.
-
-For development environments, configure credentials using one of these methods:
-
-**Option 1: AWS CLI**
-
-```bash
-aws configure
-```
-
-**Option 2: Environment Variables**
-
-```bash
-export AWS_ACCESS_KEY_ID=your_access_key
-export AWS_SECRET_ACCESS_KEY=your_secret_key
-export AWS_SESSION_TOKEN=your_session_token  # If using temporary credentials
-export AWS_REGION="us-west-2"  # Used if a custom Boto3 Session is not provided
-```
-
-**Option 3: Custom Boto3 Session**
-You can configure a custom [boto3 Session](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html) and pass it to the [`BedrockModel`](../../../api-reference/models.md#strands.models.bedrock):
-
-```python
-import boto3
-from strands.models import BedrockModel
-
-# Create a custom boto3 session
-session = boto3.Session(
-    aws_access_key_id='your_access_key',
-    aws_secret_access_key='your_secret_key',
-    aws_session_token='your_session_token',  # If using temporary credentials
-    region_name='us-west-2',
-    profile_name='your-profile'  # Optional: Use a specific profile
-)
-
-# Create a Bedrock model with the custom session
-bedrock_model = BedrockModel(
-    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-    boto_session=session
-)
-```
-
-For complete details on credential configuration and resolution, see the [boto3 credentials documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials).
-
-## Getting Started
-
-### Prerequisites
-
-1. **AWS Account**: You need an AWS account with access to Amazon Bedrock
-2. **Model Access**: Request access to your desired models in the Amazon Bedrock console
-3. **AWS Credentials**: Configure AWS credentials with appropriate permissions, including `bedrock:InvokeModelWithResponseStream`
-
-#### Required IAM Permissions
-
-To use Amazon Bedrock with Strands, your IAM user or role needs the following permissions:
-
-- `bedrock:InvokeModelWithResponseStream`
-
-Here's a sample IAM policy that grants the necessary permissions:
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": ["bedrock:InvokeModelWithResponseStream"],
-      "Resource": "*"
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "bedrock-runtime:InvokeModelWithResponseStream",
+                "bedrock-runtime:InvokeModel"
+            ],
+            "Resource": "*"
+        }
+    ]
 }
 ```
 
@@ -248,6 +159,7 @@ The [`BedrockModel`](../../../api-reference/models.md#strands.models.bedrock) su
 | [`boto_session`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html)                                                                                                 | Boto Session to use when creating the Boto3 Bedrock Client                                                     | Boto Session with region: "us-west-2"                                                                |
 | [`boto_client_config`](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html)                                                                                              | Botocore Configuration used when creating the Boto3 Bedrock Client                                             | -                                                                                                    |
 | [`region_name`](https://docs.aws.amazon.com/general/latest/gr/bedrock.html)                                                                                                                           | AWS region to use for the Bedrock service                                                                      | "us-west-2"                                                                                          |
+| [`streaming`](https://docs.aws.amazon.com/bedrock/latest/userguide/api-methods.html)                                                                                                                  | Flag to enable/disable streaming mode                                                                          | True                                                                                                 |
 | [`temperature`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html#API_runtime_InferenceConfiguration_Contents)                                          | Controls randomness (higher = more random)                                                                     | [Model-specific default](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html) |
 | [`max_tokens`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html#API_runtime_InferenceConfiguration_Contents)                                           | Maximum number of tokens to generate                                                                           | [Model-specific default](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html) |
 | [`top_p`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InferenceConfiguration.html#API_runtime_InferenceConfiguration_Contents)                                                | Controls diversity via nucleus sampling                                                                        | [Model-specific default](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html) |
@@ -298,6 +210,27 @@ response = agent("Write a short story about an AI assistant.")
 ```
 
 ## Advanced Features
+
+### Streaming vs Non-Streaming Mode
+
+Certain Amazon Bedrock models only support non-streaming tool use, so you can set the `streaming` configuration to false
+in order to use these models. Both modes provide the same event structure and functionality in your agent, as the non-streaming responses are converted to the streaming format internally.
+
+```python
+# Streaming model (default)
+streaming_model = BedrockModel(
+    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    streaming=True,  # This is the default
+)
+
+# Non-streaming model
+non_streaming_model = BedrockModel(
+    model_id="us.meta.llama3-2-90b-instruct-v1:0",
+    streaming=False,  # Disable streaming
+)
+```
+
+See the Amazon Bedrock documentation for [Supported models and model features](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html) to learn about the streaming support for different models.
 
 ### Multimodal Support
 

--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -79,6 +79,7 @@ aws configure
 export AWS_ACCESS_KEY_ID=your_access_key
 export AWS_SECRET_ACCESS_KEY=your_secret_key
 export AWS_SESSION_TOKEN=your_session_token  # If using temporary credentials
+export AWS_REGION="us-west-2"  # Used if a custom Boto3 Session is not provided
 ```
 
 **Option 3: Custom Boto3 Session**


### PR DESCRIPTION
## Description
Adding documentation for non-streaming support in bedrock

## Type of Change
<!-- What kind of change are you making -->
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

New content addition

## Motivation and Context
PR: https://github.com/strands-agents/sdk-python/pull/75

## Areas Affected
Bedrock model provider docs

## Screenshots
N/A

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
