### PR TITLE
Set the default redirect to latest

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -34,4 +34,4 @@ jobs:
           pip install -r requirements.txt
       - run: |
           mike deploy --push --update-aliases 0.1.x latest
-          mike set-default --push 0.1.x
+          mike set-default --push latest


### PR DESCRIPTION
We've had internal requests to redirect to latest by default

## Description

It makes more sense that the root page redirects to latest rather than 0.1.x so that when folks copy links, they're copying the latest docs.

People can always manually change to a specific version

Try it out at https://github.programdotrun.com/docs/

## Type of Change

- Structure/organization improvement

## Motivation and Context

Folks mentioned that linking to the latest docs page is difficult because they need to manually edit the url - now by default they'll get the latest urls and can manually change to 0.1.x if they so wish

## Areas Affected

The bare index url https://strandsagents.com/ would now redirect to https://strandsagents.com/latest/ instead of https://strandsagents.com/0.1.x/.  All other URLs will continue working

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
