### PR TITLE
Serve llms.txt via mkdocs-llmstxt plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,7 +151,7 @@ plugins:
       sections:
         User Guide:
           - README.md
-          - user-guide/quickstart.md
+          - user-guide/**/*.md
           - user-guide/concepts/agents/*.md
           - user-guide/concepts/tools/*.md
           - user-guide/concepts/model-providers/*.md
@@ -161,7 +161,7 @@ plugins:
           - user-guide/observability-evaluation/*.md
           - user-guide/deploy/*.md
         Examples:
-          - examples/README.md
+          - examples/**/*.md
           - examples/python/*.md
           - examples/cdk/*/*.md
         API Reference:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Strands Agents SDK
 site_description: Documentation for Strands Agents, a simple-to-use, code-first, lightweight library for building AI agents
 site_dir: site
+site_url: https://strandsagents.com
 
 repo_url: https://github.com/strands-agents/sdk-python
 
@@ -145,6 +146,26 @@ plugins:
             docstring_style: google
             show_root_heading: true
             show_source: true
+  - llmstxt:
+      markdown_description: Documentation for Strands Agents, a simple-to-use, code-first, lightweight library for building AI agents
+      sections:
+        User Guide:
+          - README.md
+          - user-guide/quickstart.md
+          - user-guide/concepts/agents/*.md
+          - user-guide/concepts/tools/*.md
+          - user-guide/concepts/model-providers/*.md
+          - user-guide/concepts/streaming/*.md
+          - user-guide/concepts/multi-agent/*.md
+          - user-guide/safety-security/*.md
+          - user-guide/observability-evaluation/*.md
+          - user-guide/deploy/*.md
+        Examples:
+          - examples/README.md
+          - examples/python/*.md
+          - examples/cdk/*/*.md
+        API Reference:
+          - api-reference/*.md
 
 extra:
   social:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ mkdocs-macros-plugin~=1.3.7
 mkdocs-material~=9.6.12
 mkdocs-macros-plugin~=1.3.7
 mkdocstrings-python~=1.16.10
+mkdocs-llmstxt~=0.2.0
 strands-agents~=0.1.0


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
Using the mkdocs-llmstxt plugin, we can generate llms.txt which describes the project and points LLMs towards markdown twins of specific documentation hosted for humans as HTML. These twins are generated during the build process and served as *.md. See: https://llmstxt.org/ & https://pypi.org/project/mkdocs-llmstxt/

## Type of Change
New mkdocs plugin and hosted content (llms.txt & *.md files)

## Motivation and Context
Makes it easier for LLMs to understand Strands: https://llmstxt.org/

## Areas Affected
Changes mkdocs configuration and hosted content. 

## Screenshots
<img width="1010" alt="Screenshot 2025-05-27 at 9 13 00 PM" src="https://github.com/user-attachments/assets/24fcd4d0-232d-45ea-aab5-1ff99668bc82" />

## Checklist
<!-- Mark completed items with an [x] -->
- [x ] I have read the CONTRIBUTING document
- [x ] My changes follow the project's documentation style
- [x ] I have tested the documentation locally using `mkdocs serve`
- [x ] Links in the documentation are valid and working
- [x ] Images/diagrams are properly sized and formatted
- [x ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
