### PR TITLE
Revert "Serve llms.txt via mkdocs-llmstxt plugin (#72)"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,6 @@
 site_name: Strands Agents SDK
 site_description: Documentation for Strands Agents, a simple-to-use, code-first, lightweight library for building AI agents
 site_dir: site
-site_url: https://strandsagents.com
 
 repo_url: https://github.com/strands-agents/sdk-python
 
@@ -147,26 +146,6 @@ plugins:
             docstring_style: google
             show_root_heading: true
             show_source: true
-  - llmstxt:
-      markdown_description: Documentation for Strands Agents, a simple-to-use, code-first, lightweight library for building AI agents
-      sections:
-        User Guide:
-          - README.md
-          - user-guide/**/*.md
-          - user-guide/concepts/agents/*.md
-          - user-guide/concepts/tools/*.md
-          - user-guide/concepts/model-providers/*.md
-          - user-guide/concepts/streaming/*.md
-          - user-guide/concepts/multi-agent/*.md
-          - user-guide/safety-security/*.md
-          - user-guide/observability-evaluation/*.md
-          - user-guide/deploy/*.md
-        Examples:
-          - examples/**/*.md
-          - examples/python/*.md
-          - examples/cdk/*/*.md
-        API Reference:
-          - api-reference/*.md
 
 extra:
   social:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ mkdocs-macros-plugin~=1.3.7
 mkdocs-material~=9.6.12
 mkdocs-macros-plugin~=1.3.7
 mkdocstrings-python~=1.16.10
-mkdocs-llmstxt~=0.2.0
 strands-agents~=0.1.0


### PR DESCRIPTION
## Description
This commit appears to have broken the mermaid diagrams. We are reverting while we investigate.

Here is an example of what the diagrams look like now:

![image](https://github.com/user-attachments/assets/6cc63c2b-8d3b-44f7-b66b-264385ac54ca)


## Type of Change
- [ ] New content addition
- [ ] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [x] Bug fix
- [ ] Other (please describe):

## Motivation and Context
Fix broken mermaid diagrams.

## Screenshots
Results after running `mkdocs build` locally with the commit reverted:

![image](https://github.com/user-attachments/assets/adfc7659-a19e-4709-b1e3-e9d75623d2ed)

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
