### PR TITLE
fixing inconsistent naming from Flask to FastAPI

### DIFF
--- a/docs/user-guide/deploy/deploy_to_aws_fargate.md
+++ b/docs/user-guide/deploy/deploy_to_aws_fargate.md
@@ -8,7 +8,7 @@ This guide discusses Fargate integration at a high level - for a complete exampl
 
 ## Creating Your Agent in Python
 
-The core of your Fargate deployment is a containerized Flask application that hosts your Strands Agents SDK agent. This Python application initializes your agent and processes incoming HTTP requests.
+The core of your Fargate deployment is a containerized FastAPI application that hosts your Strands Agents SDK agent. This Python application initializes your agent and processes incoming HTTP requests.
 
 The FastAPI application follows these steps:
 


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description

Correcting a typo in the docs as it is inconsistent with the remaining examples. 

## Type of Change
<!-- What kind of change are you making -->

- Typo/formatting fix in /user-guide/deploy/deploy_to_aws_fargate.md in section "## Creating Your Agent in Python" mentions a Flask application. While the referenced app in /examples/cdk/deploy_to_fargate/docker/app/app.py is using FastAPI library only

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

 Typo/formatting

## Areas Affected
<!-- List the pages/sections affected by this PR -->

/user-guide/deploy/deploy_to_aws_fargate.md

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

This is a single word change from Flask to FastAPI

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
