### PR TITLE
feat: Document invoking tools with hyphens

### DIFF
--- a/docs/user-guide/concepts/tools/tools_overview.md
+++ b/docs/user-guide/concepts/tools/tools_overview.md
@@ -76,6 +76,13 @@ Every tool added to an agent also becomes a method accessible directly on the ag
 result = agent.tool.file_read(path="/path/to/file.txt", mode="view")
 ```
 
+If a tool name contains hyphens, you can invoke the tool using underscores instead:
+
+```python
+# Directly invoke a tool named "read-all"
+result = agent.tool.read_all(path="/path/to/file.txt")
+```
+
 ## Building & Loading Tools
 
 ### 1. Python Tools

--- a/docs/user-guide/safety-security/guardrails.md
+++ b/docs/user-guide/safety-security/guardrails.md
@@ -64,4 +64,3 @@ Ollama doesn't currently provide native guardrail capabilities like Bedrock. Ins
 
 * [Amazon Bedrock Guardrails Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html)
 * [Allen Institute for AI: Guardrails Project](https://www.guardrailsai.com/docs)
-* [LangChain's LCEL Guard Integration](https://llm-guard.com/tutorials/notebooks/langchain/)


### PR DESCRIPTION

## Description

Documents the bugfix implemented in strands-agents/sdk-python#178 where underscores take the place of hyphens

## Type of Change

- Content update/revision

## Motivation and Context

This is the docs PR for https://github.com/strands-agents/sdk-python/pull/178

## Areas Affected

Direct method invocation of tools

## Screenshots

<img width="871" alt="Screenshot 2025-06-05 at 09 39 36" src="https://github.com/user-attachments/assets/3fda8f49-f1f4-4aaa-a399-410556d4e474" />

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
