### PR TITLE
fix: Specify python version for dependency installs

### DIFF
--- a/docs/examples/cdk/deploy_to_ec2/README.md
+++ b/docs/examples/cdk/deploy_to_ec2/README.md
@@ -38,7 +38,7 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 pip install -r ./requirements.txt
 
 # Install Python dependencies for the app distribution
-pip install -r requirements.txt --platform manylinux2014_aarch64 --target ./packaging/_dependencies --only-binary=:all:
+pip install -r requirements.txt --python-version 3.12 --platform manylinux2014_aarch64 --target ./packaging/_dependencies --only-binary=:all:
 ```
 
 2. Bootstrap your AWS environment (if not already done):

--- a/docs/examples/cdk/deploy_to_lambda/.mise.toml
+++ b/docs/examples/cdk/deploy_to_lambda/.mise.toml
@@ -1,3 +1,0 @@
-[tools]
-python = "3.12"
-node = "22"

--- a/docs/examples/cdk/deploy_to_lambda/README.md
+++ b/docs/examples/cdk/deploy_to_lambda/README.md
@@ -35,7 +35,7 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 # Install Python dependencies for the local development
 pip install -r requirements.txt
 # Install Python dependencies for lambda with correct architecture
-pip install -r requirements.txt --platform manylinux2014_aarch64 --target ./packaging/_dependencies --only-binary=:all:
+pip install -r requirements.txt --python-version 3.12 --platform manylinux2014_aarch64 --target ./packaging/_dependencies --only-binary=:all:
 ```
 
 2. Package the lambda:

--- a/docs/user-guide/deploy/deploy_to_amazon_ec2.md
+++ b/docs/user-guide/deploy/deploy_to_amazon_ec2.md
@@ -222,7 +222,7 @@ To deploy your agent to EC2:
 npx cdk bootstrap
 
 # Package Python dependencies for the target architecture
-pip install -r requirements.txt --platform manylinux2014_aarch64 --target ./packaging/_dependencies --only-binary=:all:
+pip install -r requirements.txt --target ./packaging/_dependencies --python-version 3.12 --platform manylinux2014_aarch64 --only-binary=:all:
 
 # Deploy the stack
 npx cdk deploy


### PR DESCRIPTION
## Description

For lambda and EC2, specify the python version so that the correct binaries will be installed. Fixes #64

Also removed the mise.toml to be more consistent with other examples.

Tested by defaulting my python to 3.11 and then running through the lambda readme.

## Type of Change

Bug fix

## Motivation and Context

#64 was a reported issue

## Areas Affected

Lambda & EC2 examples

## Screenshots

N/A

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
