### PR TITLE
docs: update context management doc with should_truncate_results flag

### DIFF
--- a/docs/user-guide/concepts/agents/context-management.md
+++ b/docs/user-guide/concepts/agents/context-management.md
@@ -52,6 +52,7 @@ from strands.agent.conversation_manager import SlidingWindowConversationManager
 # Create a conversation manager with custom window size
 conversation_manager = SlidingWindowConversationManager(
     window_size=20,  # Maximum number of messages to keep
+    should_truncate_results=True, # Enable truncating the tool result when a message is too large for the model's context window 
 )
 
 agent = Agent(
@@ -64,3 +65,4 @@ Key features of the `SlidingWindowConversationManager`:
 - **Maintains Window Size**: Automatically removes messages from the window if the number of messages exceeds the limit.
 - **Dangling Message Cleanup**: Removes incomplete message sequences to maintain valid conversation state.
 - **Overflow Trimming**: In the case of a context window overflow, it will trim the oldest messages from history until the request fits in the models context window.
+- **Configurable Tool Result Truncation**: Enable / disable truncation of tool results when the message exceeds context window limits. When `should_truncate_results=True` (default), large results are truncated with a placeholder message. When `False`, full results are preserved but more historical messages may be removed.


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
Documentation update for `should_truncate_results` parameter in SlidingWindowConversationManager.

Related pr: https://github.com/strands-agents/sdk-python/pull/192

## Type of Change
- Content update/revision

Update description of `should_truncate_results` parameter in SlidingWindowConversationManager.

## Motivation and Context
Related issue: https://github.com/strands-agents/sdk-python/issues/167
Allow customer to disable truncating the tool result when a message is too large. The message histories will be reduced instead.

## Areas Affected
SlidingWindowConversationManager

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
