### PR TITLE
feat: Switch to manually building docs

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -1,11 +1,7 @@
 name: Build GitHub Pages
-on:
-  push:
-    branches:
-      - main
-  repository_dispatch:
-    types:
-      - sdk-push
+# Until we have a branching strategy defined for bug fixes or features that are not 
+# yet published to pypi, we've decided to manually publish docs when publishing to pypi
+on:  workflow_dispatch
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION


## Description

We want to switch to manually building docs, so that we don't publish docs for bug fixes or doc changes before we publish to pypi

## Type of Change
<!-- What kind of change are you making -->

- Other: Feature/Refactor


## Motivation and Context

The current situation:

 - When a bugfix or feature is merged to the SDK, it doesn't get published to consumer until we publish to pypi
 - When a doc change is merged to the SDK it's published immediately

This means that doc changes for bugs or features are published before the corresponding changes are ready to be consumed, leading to customer confusion.  Until we start branching for docs, we're going to switch to manually publishing docs

## Areas Affected

Doc publishing

## Screenshots


## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes

Will need to update the MCM to account for this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
