### PR TITLE
docs(streaming): document redactedContent event type

### DIFF
--- a/docs/user-guide/concepts/streaming/async-iterators.md
+++ b/docs/user-guide/concepts/streaming/async-iterators.md
@@ -59,6 +59,7 @@ The async iterator yields the same event types as [callback handlers](callback-h
 - `reasoning`: True for reasoning events
 - `reasoningText`: Text from reasoning process
 - `reasoning_signature`: Signature from reasoning process
+- `redactedContent`: Reasoning content redacted by the model
 
 ## FastAPI Example
 

--- a/docs/user-guide/concepts/streaming/callback-handlers.md
+++ b/docs/user-guide/concepts/streaming/callback-handlers.md
@@ -67,6 +67,7 @@ Callback handlers receive the same event types as [async iterators](./async-iter
 - `reasoning`: True for reasoning events
 - `reasoningText`: Text from reasoning process
 - `reasoning_signature`: Signature from reasoning process
+- `redactedContent`: Reasoning content redacted by the model
 
 ## Default Callback Handler
 


### PR DESCRIPTION
## Description
document redactedContent event type introduced in https://github.com/strands-agents/sdk-python/issues/99

## Type of Change
- Content update/revision

## Motivation and Context
New SDK feature.

## Areas Affected
- Streaming / Async Iterators
- Streaming / Callback Handlers

## Screenshots
N/A

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
