### PR TITLE
fix: Add callouts for lambda not using streaming and lambda-dependencies installation

### DIFF
--- a/docs/user-guide/deploy/deploy_to_aws_lambda.md
+++ b/docs/user-guide/deploy/deploy_to_aws_lambda.md
@@ -6,6 +6,10 @@ If you're not familiar with the AWS CDK, check out the [official documentation](
 
 This guide discusses Lambda integration at a high level - for a complete example project deploying to Lambda, check out the [`deploy_to_lambda` sample project on GitHub][project_code].
 
+!!! note
+
+    This Lambda deployment example does not implement response streaming as described in the [Async Iterators for Streaming](../concepts/streaming/async-iterators.md) documentation. If you need streaming capabilities, consider using the [AWS Fargate deployment](deploy_to_aws_fargate.md) approach which does implement streaming responses.
+
 ## Creating Your Agent in Python
 
 The core of your Lambda deployment is the agent handler code. This Python script initializes your Strands Agents SDK agent and processes incoming requests. 
@@ -95,6 +99,23 @@ weatherFunction.addToRolePolicy(
 ```
 
 The dependencies are packaged and pulled in via a Lambda layer separately from the application code. By separating your dependencies into a layer, your application code remains small and enables you to view or edit your function code directly in the Lambda console.
+
+!!! info "Installing Dependencies with the Correct Architecture"
+    
+    When deploying to AWS Lambda, it's important to install dependencies that match the target Lambda architecture. Because the example above uses ARM64 architecture, dependencies must be installed specifically for this architecture:
+    
+    ```shell
+    # Install Python dependencies for lambda with correct architecture
+    pip install -r requirements.txt \
+        --python-version 3.12 \
+        --platform manylinux2014_aarch64 \
+        --target ./packaging/_dependencies \
+        --only-binary=:all:
+    ```
+    
+    This ensures that all binary dependencies are compatible with the Lambda ARM64 environment regardless of the operating-system used for development.
+
+    Failing to match the architecture can result in runtime errors when the Lambda function executes.
 
 ### Packaging Your Code
 


### PR DESCRIPTION


## Description

We've received feedback that for lambda deployments, two points are confusing:

 - Installing the right version of the dependencies for lambda on different OSes
 - Whether or not streaming of responses can be done from lambda

So add two clarifying points on those

## Type of Change
<!-- What kind of change are you making -->
New content addition

## Motivation and Context

We've received multiple questions about these two areas

## Screenshots

Introduction section:

<img width="892" alt="screenshot_972" src="https://github.com/user-attachments/assets/43fd9be2-aa75-4fc4-b48f-a494e4711040" />

Infrastructure section:

<img width="964" alt="screenshot_973" src="https://github.com/user-attachments/assets/efdaf574-9484-4c6d-90f1-03f6bdac01a7" />

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
