### PR TITLE
Update structured output docs for model providers

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -577,6 +577,7 @@ Use:
 
 ```
 us.anthropic.claude-3-7-sonnet-20250219-v1:0
+```
 
 ## Related Resources
 

--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -511,6 +511,44 @@ response = agent("If a train travels at 120 km/h and needs to cover 450 km, how 
 
 > **Note**: Not all models support structured reasoning output. Check the [inference reasoning documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-reasoning.html) for details on supported models.
 
+### Structured Output
+
+Amazon Bedrock models support structured output through their tool calling capabilities. When you use [`Agent.structured_output()`](../../../api-reference/agent.md#strands.agent.agent.Agent.structured_output), the Strands SDK converts your Pydantic models to Bedrock's tool specification format.
+
+```python
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models import BedrockModel
+from typing import List, Optional
+
+class ProductAnalysis(BaseModel):
+    """Analyze product information from text."""
+    name: str = Field(description="Product name")
+    category: str = Field(description="Product category")
+    price: float = Field(description="Price in USD")
+    features: List[str] = Field(description="Key product features")
+    rating: Optional[float] = Field(description="Customer rating 1-5", ge=1, le=5)
+
+bedrock_model = BedrockModel()
+
+agent = Agent(model=bedrock_model)
+
+result = agent.structured_output(
+    ProductAnalysis,
+    """
+    Analyze this product: The UltraBook Pro is a premium laptop computer
+    priced at $1,299. It features a 15-inch 4K display, 16GB RAM, 512GB SSD,
+    and 12-hour battery life. Customer reviews average 4.5 stars.
+    """
+)
+
+print(f"Product: {result.name}")
+print(f"Category: {result.category}")
+print(f"Price: ${result.price}")
+print(f"Features: {result.features}")
+print(f"Rating: {result.rating}")
+```
+
 ## Troubleshooting
 
 ### Model access issue
@@ -539,7 +577,6 @@ Use:
 
 ```
 us.anthropic.claude-3-7-sonnet-20250219-v1:0
-```
 
 ## Related Resources
 

--- a/docs/user-guide/concepts/model-providers/anthropic.md
+++ b/docs/user-guide/concepts/model-providers/anthropic.md
@@ -58,6 +58,50 @@ The `model_config` configures the underlying model selected for inference. The s
 
 If you encounter the error `ModuleNotFoundError: No module named 'anthropic'`, this means you haven't installed the `anthropic` dependency in your environment. To fix, run `pip install 'strands-agents[anthropic]'`.
 
+## Advanced Features
+
+### Structured Output
+
+Anthropic's Claude models support structured output through their tool calling capabilities. When you use [`Agent.structured_output()`](../../../api-reference/agent.md#strands.agent.agent.Agent.structured_output), the Strands SDK converts your Pydantic models to Anthropic's tool specification format.
+
+```python
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models.anthropic import AnthropicModel
+
+class BookAnalysis(BaseModel):
+    """Analyze a book's key information."""
+    title: str = Field(description="The book's title")
+    author: str = Field(description="The book's author")
+    genre: str = Field(description="Primary genre or category")
+    summary: str = Field(description="Brief summary of the book")
+    rating: int = Field(description="Rating from 1-10", ge=1, le=10)
+
+model = AnthropicModel(
+    client_args={"api_key": "<KEY>"},
+    max_tokens=1024,
+    model_id="claude-3-7-sonnet-20250219",
+    params={"temperature": 0.2}  # Lower temperature for consistent structured output
+)
+
+agent = Agent(model=model)
+
+# Extract structured book information
+result = agent.structured_output(
+    BookAnalysis,
+    """
+    Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
+    It's a science fiction comedy about Arthur Dent's adventures through space
+    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.
+    """
+)
+
+print(f"Title: {result.title}")
+print(f"Author: {result.author}")
+print(f"Genre: {result.genre}")
+print(f"Rating: {result.rating}")
+```
+
 ## References
 
 - [API](../../../api-reference/models.md)

--- a/docs/user-guide/concepts/model-providers/anthropic.md
+++ b/docs/user-guide/concepts/model-providers/anthropic.md
@@ -78,15 +78,18 @@ class BookAnalysis(BaseModel):
     rating: int = Field(description="Rating from 1-10", ge=1, le=10)
 
 model = AnthropicModel(
-    client_args={"api_key": "<KEY>"},
-    max_tokens=1024,
+    client_args={
+        "api_key": "<KEY>",
+    },
+    max_tokens=1028,
     model_id="claude-3-7-sonnet-20250219",
-    params={"temperature": 0.2}  # Lower temperature for consistent structured output
+    params={
+        "temperature": 0.7,
+    }
 )
 
 agent = Agent(model=model)
 
-# Extract structured book information
 result = agent.structured_output(
     BookAnalysis,
     """

--- a/docs/user-guide/concepts/model-providers/litellm.md
+++ b/docs/user-guide/concepts/model-providers/litellm.md
@@ -57,6 +57,52 @@ The `model_config` configures the underlying model selected for inference. The s
 
 If you encounter the error `ModuleNotFoundError: No module named 'litellm'`, this means you haven't installed the `litellm` dependency in your environment. To fix, run `pip install 'strands-agents[litellm]'`.
 
+## Advanced Features
+
+### Structured Output
+
+LiteLLM supports structured output by proxying requests to underlying model providers that support tool calling. The availability of structured output depends on the specific model and provider you're using through LiteLLM.
+
+```python
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models.litellm import LiteLLMModel
+
+class TaskAnalysis(BaseModel):
+    """Analyze a task or project."""
+    title: str = Field(description="Task title")
+    priority: str = Field(description="Priority level: low, medium, high")
+    estimated_hours: float = Field(description="Estimated completion time in hours")
+    dependencies: List[str] = Field(description="Task dependencies")
+    status: str = Field(description="Current status")
+
+model = LiteLLMModel(
+    model_id="gpt-4o",  # OpenAI model through LiteLLM
+    params={
+        "temperature": 0.1,
+        "max_tokens": 1000
+    }
+)
+
+agent = Agent(model=model)
+
+# Extract structured task information
+result = agent.structured_output(
+    TaskAnalysis,
+    """
+    Analyze this project task: "Implement user authentication system"
+    This is a high-priority task that requires database setup and security review.
+    Estimated to take 16 hours. Currently in planning phase.
+    Depends on database schema design and security policy approval.
+    """
+)
+
+print(f"Task: {result.title}")
+print(f"Priority: {result.priority}")
+print(f"Hours: {result.estimated_hours}")
+print(f"Dependencies: {result.dependencies}")
+```
+
 ## References
 
 - [API](../../../api-reference/models.md)

--- a/docs/user-guide/concepts/model-providers/litellm.md
+++ b/docs/user-guide/concepts/model-providers/litellm.md
@@ -68,39 +68,33 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.litellm import LiteLLMModel
 
-class TaskAnalysis(BaseModel):
-    """Analyze a task or project."""
-    title: str = Field(description="Task title")
-    priority: str = Field(description="Priority level: low, medium, high")
-    estimated_hours: float = Field(description="Estimated completion time in hours")
-    dependencies: List[str] = Field(description="Task dependencies")
-    status: str = Field(description="Current status")
+class BookAnalysis(BaseModel):
+    """Analyze a book's key information."""
+    title: str = Field(description="The book's title")
+    author: str = Field(description="The book's author")
+    genre: str = Field(description="Primary genre or category")
+    summary: str = Field(description="Brief summary of the book")
+    rating: int = Field(description="Rating from 1-10", ge=1, le=10)
 
 model = LiteLLMModel(
-    model_id="gpt-4o",  # OpenAI model through LiteLLM
-    params={
-        "temperature": 0.1,
-        "max_tokens": 1000
-    }
+    model_id="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 )
 
 agent = Agent(model=model)
 
-# Extract structured task information
 result = agent.structured_output(
-    TaskAnalysis,
+    BookAnalysis,
     """
-    Analyze this project task: "Implement user authentication system"
-    This is a high-priority task that requires database setup and security review.
-    Estimated to take 16 hours. Currently in planning phase.
-    Depends on database schema design and security policy approval.
+    Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
+    It's a science fiction comedy about Arthur Dent's adventures through space
+    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.
     """
 )
 
-print(f"Task: {result.title}")
-print(f"Priority: {result.priority}")
-print(f"Hours: {result.estimated_hours}")
-print(f"Dependencies: {result.dependencies}")
+print(f"Title: {result.title}")
+print(f"Author: {result.author}")
+print(f"Genre: {result.genre}")
+print(f"Rating: {result.rating}")
 ```
 
 ## References

--- a/docs/user-guide/concepts/model-providers/llamaapi.md
+++ b/docs/user-guide/concepts/model-providers/llamaapi.md
@@ -63,6 +63,53 @@ The `model_config` configures the underlying model selected for inference. The s
 
 If you encounter the error `ModuleNotFoundError: No module named 'llamaapi'`, this means you haven't installed the `llamaapi` dependency in your environment. To fix, run `pip install 'strands-agents[llamaapi]'`.
 
+## Advanced Features
+
+### Structured Output
+
+Llama API models support structured output through their tool calling capabilities. When you use [`Agent.structured_output()`](../../../api-reference/agent.md#strands.agent.agent.Agent.structured_output), the Strands SDK converts your Pydantic models to tool specifications that Llama models can understand.
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from strands import Agent
+from strands.models.llamaapi import LlamaAPIModel
+
+class ResearchSummary(BaseModel):
+    """Summarize research findings."""
+    topic: str = Field(description="Main research topic")
+    key_findings: List[str] = Field(description="Primary research findings")
+    methodology: str = Field(description="Research methodology used")
+    confidence_level: float = Field(description="Confidence in findings 0-1", ge=0, le=1)
+    recommendations: List[str] = Field(description="Actionable recommendations")
+
+model = LlamaAPIModel(
+    client_args={"api_key": "<KEY>"},
+    model_id="Llama-4-Maverick-17B-128E-Instruct-FP8",
+    temperature=0.1,  # Low temperature for consistent structured output
+    max_completion_tokens=2000
+)
+
+agent = Agent(model=model)
+
+# Extract structured research summary
+result = agent.structured_output(
+    ResearchSummary,
+    """
+    Analyze this research: A study of 500 remote workers found that 
+    productivity increased by 23% when using structured daily schedules.
+    The study used time-tracking software and productivity metrics over 6 months.
+    Researchers recommend implementing structured work blocks and regular breaks.
+    """
+)
+
+print(f"Topic: {result.topic}")
+print(f"Key Findings: {result.key_findings}")
+print(f"Methodology: {result.methodology}")
+print(f"Confidence: {result.confidence_level}")
+print(f"Recommendations: {result.recommendations}")
+```
+
 ## References
 
 - [API](../../../api-reference/models.md)

--- a/docs/user-guide/concepts/model-providers/llamaapi.md
+++ b/docs/user-guide/concepts/model-providers/llamaapi.md
@@ -71,43 +71,37 @@ Llama API models support structured output through their tool calling capabiliti
 
 ```python
 from pydantic import BaseModel, Field
-from typing import List, Optional
 from strands import Agent
 from strands.models.llamaapi import LlamaAPIModel
 
-class ResearchSummary(BaseModel):
-    """Summarize research findings."""
-    topic: str = Field(description="Main research topic")
-    key_findings: List[str] = Field(description="Primary research findings")
-    methodology: str = Field(description="Research methodology used")
-    confidence_level: float = Field(description="Confidence in findings 0-1", ge=0, le=1)
-    recommendations: List[str] = Field(description="Actionable recommendations")
+class BookAnalysis(BaseModel):
+    """Analyze a book's key information."""
+    title: str = Field(description="The book's title")
+    author: str = Field(description="The book's author")
+    genre: str = Field(description="Primary genre or category")
+    summary: str = Field(description="Brief summary of the book")
+    rating: int = Field(description="Rating from 1-10", ge=1, le=10)
 
 model = LlamaAPIModel(
     client_args={"api_key": "<KEY>"},
     model_id="Llama-4-Maverick-17B-128E-Instruct-FP8",
-    temperature=0.1,  # Low temperature for consistent structured output
-    max_completion_tokens=2000
 )
 
 agent = Agent(model=model)
 
-# Extract structured research summary
 result = agent.structured_output(
-    ResearchSummary,
+    BookAnalysis,
     """
-    Analyze this research: A study of 500 remote workers found that 
-    productivity increased by 23% when using structured daily schedules.
-    The study used time-tracking software and productivity metrics over 6 months.
-    Researchers recommend implementing structured work blocks and regular breaks.
+    Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
+    It's a science fiction comedy about Arthur Dent's adventures through space
+    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.
     """
 )
 
-print(f"Topic: {result.topic}")
-print(f"Key Findings: {result.key_findings}")
-print(f"Methodology: {result.methodology}")
-print(f"Confidence: {result.confidence_level}")
-print(f"Recommendations: {result.recommendations}")
+print(f"Title: {result.title}")
+print(f"Author: {result.author}")
+print(f"Genre: {result.genre}")
+print(f"Rating: {result.rating}")
 ```
 
 ## References

--- a/docs/user-guide/concepts/model-providers/ollama.md
+++ b/docs/user-guide/concepts/model-providers/ollama.md
@@ -191,6 +191,52 @@ creative_agent = Agent(model=creative_model)
 factual_agent = Agent(model=factual_model)
 ```
 
+### Structured Output
+
+Ollama supports structured output for models that have tool calling capabilities. When you use [`Agent.structured_output()`](../../../api-reference/agent.md#strands.agent.agent.Agent.structured_output), the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.
+
+```python
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models.ollama import OllamaModel
+
+class CodeAnalysis(BaseModel):
+    """Analyze code structure and quality."""
+    language: str = Field(description="Programming language")
+    complexity: str = Field(description="Code complexity: low, medium, high")
+    issues: List[str] = Field(description="Potential issues or improvements")
+    score: int = Field(description="Code quality score 1-10", ge=1, le=10)
+
+# Use a model that supports tool calling
+ollama_model = OllamaModel(
+    host="http://localhost:11434",
+    model_id="llama3.1:8b",  # Tool-capable model
+    temperature=0.1  # Low temperature for consistent structured output
+)
+
+agent = Agent(model=ollama_model)
+
+# Extract structured code analysis
+result = agent.structured_output(
+    CodeAnalysis,
+    """
+    Analyze this Python function:
+    
+    def calculate_fibonacci(n):
+        if n <= 1:
+            return n
+        return calculate_fibonacci(n-1) + calculate_fibonacci(n-2)
+    
+    This is a recursive implementation of the Fibonacci sequence.
+    """
+)
+
+print(f"Language: {result.language}")
+print(f"Complexity: {result.complexity}")
+print(f"Issues: {result.issues}")
+print(f"Score: {result.score}")
+```
+
 ## Tool Support
 
 [Ollama models that support tool use](https://ollama.com/search?c=tools) can use tools through Strands's tool system:

--- a/docs/user-guide/concepts/model-providers/ollama.md
+++ b/docs/user-guide/concepts/model-providers/ollama.md
@@ -242,7 +242,7 @@ from strands_tools import calculator, current_time
 # Create an Ollama model
 ollama_model = OllamaModel(
     host="http://localhost:11434",
-    model_id="llama3.3"
+    model_id="llama3"
 )
 
 # Create an agent with tools

--- a/docs/user-guide/concepts/model-providers/ollama.md
+++ b/docs/user-guide/concepts/model-providers/ollama.md
@@ -200,41 +200,34 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.ollama import OllamaModel
 
-class CodeAnalysis(BaseModel):
-    """Analyze code structure and quality."""
-    language: str = Field(description="Programming language")
-    complexity: str = Field(description="Code complexity: low, medium, high")
-    issues: List[str] = Field(description="Potential issues or improvements")
-    score: int = Field(description="Code quality score 1-10", ge=1, le=10)
+class BookAnalysis(BaseModel):
+    """Analyze a book's key information."""
+    title: str = Field(description="The book's title")
+    author: str = Field(description="The book's author")
+    genre: str = Field(description="Primary genre or category")
+    summary: str = Field(description="Brief summary of the book")
+    rating: int = Field(description="Rating from 1-10", ge=1, le=10)
 
-# Use a model that supports tool calling
 ollama_model = OllamaModel(
     host="http://localhost:11434",
-    model_id="llama3.1:8b",  # Tool-capable model
-    temperature=0.1  # Low temperature for consistent structured output
+    model_id="llama3",
 )
 
 agent = Agent(model=ollama_model)
 
-# Extract structured code analysis
 result = agent.structured_output(
-    CodeAnalysis,
+    BookAnalysis,
     """
-    Analyze this Python function:
-    
-    def calculate_fibonacci(n):
-        if n <= 1:
-            return n
-        return calculate_fibonacci(n-1) + calculate_fibonacci(n-2)
-    
-    This is a recursive implementation of the Fibonacci sequence.
+    Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
+    It's a science fiction comedy about Arthur Dent's adventures through space
+    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.
     """
 )
 
-print(f"Language: {result.language}")
-print(f"Complexity: {result.complexity}")
-print(f"Issues: {result.issues}")
-print(f"Score: {result.score}")
+print(f"Title: {result.title}")
+print(f"Author: {result.author}")
+print(f"Genre: {result.genre}")
+print(f"Rating: {result.rating}")
 ```
 
 ## Tool Support
@@ -249,7 +242,7 @@ from strands_tools import calculator, current_time
 # Create an Ollama model
 ollama_model = OllamaModel(
     host="http://localhost:11434",
-    model_id="llama3"
+    model_id="llama3.3"
 )
 
 # Create an agent with tools

--- a/docs/user-guide/concepts/model-providers/openai.md
+++ b/docs/user-guide/concepts/model-providers/openai.md
@@ -89,12 +89,10 @@ class PersonInfo(BaseModel):
 model = OpenAIModel(
     client_args={"api_key": "<KEY>"},
     model_id="gpt-4o",
-    params={"temperature": 0.1}  # Lower temperature for more consistent structured output
 )
 
 agent = Agent(model=model)
 
-# Extract structured information
 result = agent.structured_output(
     PersonInfo,
     "John Smith is a 30-year-old software engineer working at a tech startup."

--- a/docs/user-guide/concepts/model-providers/openai.md
+++ b/docs/user-guide/concepts/model-providers/openai.md
@@ -69,6 +69,42 @@ The `model_config` configures the underlying model selected for inference. The s
 
 If you encounter the error `ModuleNotFoundError: No module named 'openai'`, this means you haven't installed the `openai` dependency in your environment. To fix, run `pip install 'strands-agents[openai]'`.
 
+## Advanced Features
+
+### Structured Output
+
+OpenAI models support structured output through their native tool calling capabilities. When you use [`Agent.structured_output()`](../../../api-reference/agent.md#strands.agent.agent.Agent.structured_output), the Strands SDK automatically converts your Pydantic models to OpenAI's function calling format.
+
+```python
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands.models.openai import OpenAIModel
+
+class PersonInfo(BaseModel):
+    """Extract person information from text."""
+    name: str = Field(description="Full name of the person")
+    age: int = Field(description="Age in years")
+    occupation: str = Field(description="Job or profession")
+
+model = OpenAIModel(
+    client_args={"api_key": "<KEY>"},
+    model_id="gpt-4o",
+    params={"temperature": 0.1}  # Lower temperature for more consistent structured output
+)
+
+agent = Agent(model=model)
+
+# Extract structured information
+result = agent.structured_output(
+    PersonInfo,
+    "John Smith is a 30-year-old software engineer working at a tech startup."
+)
+
+print(f"Name: {result.name}")      # "John Smith"
+print(f"Age: {result.age}")        # 30
+print(f"Job: {result.occupation}") # "software engineer"
+```
+
 ## References
 
 - [API](../../../api-reference/models.md)


### PR DESCRIPTION
## Description
Adding documentation on how to build structured_output in the Custom model provider docs, and updated existing model providers with info on how to use it.

https://github.com/strands-agents/docs/issues/95

## Type of Change
- Content update/revision


## Motivation and Context
Give users info on how to build the structured output feaature into their model providers

## Areas Affected
All Model Provider docs

## Screenshots
N/A

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
