### PR TITLE
fix incorrect bedrock iam prefix

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -22,8 +22,8 @@ The [`BedrockModel`](../../../api-reference/models.md#strands.models.bedrock) cl
 
 To use Amazon Bedrock with Strands, your IAM user or role needs the following permissions:
 
-- `bedrock-runtime:InvokeModelWithResponseStream` (for streaming mode)
-- `bedrock-runtime:InvokeModel` (for non-streaming mode)
+- `bedrock:InvokeModelWithResponseStream` (for streaming mode)
+- `bedrock:InvokeModel` (for non-streaming mode)
 
 Here's a sample IAM policy that grants the necessary permissions:
 
@@ -34,8 +34,8 @@ Here's a sample IAM policy that grants the necessary permissions:
         {
             "Effect": "Allow",
             "Action": [
-                "bedrock-runtime:InvokeModelWithResponseStream",
-                "bedrock-runtime:InvokeModel"
+                "bedrock:InvokeModelWithResponseStream",
+                "bedrock:InvokeModel"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->

The documentation currently uses the IAM prefix `bedrock-runtime:`,  
but the correct prefix is `bedrock:`.

References:
- [Actions, resources, and condition keys for AWS services](https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html)
- [Actions, resources, and condition keys for Amazon Bedrock](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrock.html)
- [converse_stream](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse_stream.html)
## Type of Change
<!-- What kind of change are you making -->
- Bug fix

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

- - The "Getting Started" guide does not work due to the incorrect IAM prefix.

## Areas Affected
<!-- List the pages/sections affected by this PR -->

- Bedrock Model Provider page

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
