### PR TITLE
Document how to use Cohere models through the OpenAI provider.

### DIFF
--- a/docs/user-guide/concepts/model-providers/cohere.md
+++ b/docs/user-guide/concepts/model-providers/cohere.md
@@ -1,0 +1,54 @@
+# Cohere
+
+[Cohere](https://cohere.com/) brings you cutting-edge multilingual models, advanced retrieval, and an AI workspace tailored for the modern enterprise — all within a single, secure platform. 
+
+## Installation
+
+The Strands Agents SDK provides access to Cohere models through the OpenAI compatiblity layer, configured as an optional dependency. To install, run:
+
+```bash
+pip install 'strands-agents[openai]'
+```
+
+## Usage
+
+After installing `openai`, you can import and initialize Cohere models as follows:
+
+```python
+from strands import Agent
+from strands.models.openai import OpenAIModel
+from strands_tools import calculator
+
+model = OpenAIModel(
+    client_args={
+        "base_url": "https://api.cohere.com/compatibility/v1",
+        "api_key": "<YOUR_KEY>",
+    },
+    model_id="command-a-03-2025",
+    stream=False,
+    params={
+        "stream_options": None
+    }
+)
+
+agent = Agent(model=model, tools=[calculator])
+agent("What is 2+2")
+```
+
+## Configuration
+
+### Client Configuration
+
+The `client_args` and `params` configure the underlying OpenAI client. For a complete list of available arguments, please refer to the [OpenAI](https://github.com/openai/openai-python) and [Cohere](https://docs.cohere.com/docs/compatibility-api#supported-parameters) sources.
+
+## Troubleshooting
+
+### Module Not Found
+
+If you encounter the error `ModuleNotFoundError: No module named 'openai'`, this means you haven't installed the `openai` dependency in your environment. To fix, run `pip install 'strands-agents[openai]'`.
+
+## References
+
+- [API](../../../api-reference/models.md)
+- [OpenAI](https://platform.openai.com/docs/overview)
+- [Cohere](https://docs.cohere.com/v2/cohere-documentation)


### PR DESCRIPTION
## Description
This PR adds Cohere as a model provider to the Strands documentation by describing how to use the pre-existing OpenAI model provider, as an alternative to a custom implementation proposed in https://github.com/strands-agents/sdk-python/pull/236. 

## Type of Change
- New content addition

## Motivation and Context
This approach minimizes the moving parts that need to be maintained to enable Strands to work with Cohere models over time, requiring only that Strands maintain the OpenAI provider and that Cohere maintain their compatibility layer with its API spec. 

## Areas Affected
https://strandsagents.com/latest/user-guide/concepts/model-providers

## Screenshots
<img width="1389" alt="Screenshot 2025-06-26 at 2 24 40 PM" src="https://github.com/user-attachments/assets/265eb79d-9b65-4872-9b7e-81cf444c4672" />

## Checklist
- [ X] I have read the CONTRIBUTING document
- [ X] My changes follow the project's documentation style
- [X ] I have tested the documentation locally using `mkdocs serve`
- [ X] Links in the documentation are valid and working
- [ X] Images/diagrams are properly sized and formatted
- [X ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
