### PR TITLE
[docs] add Mistral AI provider documentation(Do not merge)

### DIFF
--- a/docs/user-guide/concepts/model-providers/mistral.md
+++ b/docs/user-guide/concepts/model-providers/mistral.md
@@ -1,0 +1,89 @@
+# Mistral AI
+
+[Mistral AI](https://mistral.ai/)  is a research lab building the best open source models in the world.
+
+Mistral AI offers both premier models and free models, driving innovation and convenience for the developer community. Mistral AI models are state-of-the-art for their multilingual, code generation, maths, and advanced reasoning capabilities.
+
+## Installation
+
+Mistral API is configured as an optional dependency in Strands Agents. To install, run:
+
+```bash
+pip install 'strands-agents[mistral]'
+```
+
+## Usage
+
+After installing `mistral`, you can import and initialize Strands Agents' Mistral API provider as follows:
+
+```python
+from strands import Agent
+from strands.models.mistral import MistralModel
+from strands_tools import calculator
+
+model = MistralModel(
+    api_key="<YOUR_MISTRAL_API_KEY>",
+    # **model_config
+    model_id="mistral-large-latest",
+)
+
+agent = Agent(model=model, tools=[calculator])
+response = agent("What is 2+2")
+print(response)
+```
+
+## Configuration
+
+### Client Configuration
+
+The `client_args` configure the underlying Mistral client. You can pass additional arguments to customize the client behavior:
+
+```python
+model = MistralModel(
+    api_key="<YOUR_MISTRAL_API_KEY>",
+    client_args={
+        "timeout": 30,
+        # Additional client configuration options
+    },
+    model_id="mistral-large-latest"
+)
+```
+
+For a complete list of available client arguments, please refer to the Mistral AI [documentation](https://docs.mistral.ai/).
+
+### Model Configuration
+
+The `model_config` configures the underlying model selected for inference. The supported configurations are:
+
+| Parameter | Description | Example | Options |
+|-----------|-------------|---------|---------|
+| `model_id` | ID of a Mistral model to use | `mistral-large-latest` | [reference](https://docs.mistral.ai/getting-started/models/) |
+| `max_tokens` | Maximum number of tokens to generate in the response | `1000` | Positive integer |
+| `temperature` | Controls randomness in generation (0.0 to 1.0) | `0.7` | Float between 0.0 and 1.0 |
+| `top_p` | Controls diversity via nucleus sampling | `0.9` | Float between 0.0 and 1.0 |
+| `stream` | Whether to enable streaming responses | `true` | `true` or `false` |
+
+## Environment Variables
+
+You can set your Mistral API key as an environment variable instead of passing it directly:
+
+```bash
+export MISTRAL_API_KEY="your_api_key_here"
+```
+
+Then initialize the model without the API key parameter:
+
+```python
+model = MistralModel(model_id="mistral-large-latest")
+```
+
+## Troubleshooting
+
+### Module Not Found
+
+If you encounter the error `ModuleNotFoundError: No module named 'mistralai'`, this means you haven't installed the `mistral` dependency in your environment. To fix, run `pip install 'strands-agents[mistral]'`.
+
+## References
+
+- [API Reference](../../../api-reference/models.md)
+- [Mistral AI Documentation](https://docs.mistral.ai/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
         - Anthropic: user-guide/concepts/model-providers/anthropic.md
         - LiteLLM: user-guide/concepts/model-providers/litellm.md
         - LlamaAPI: user-guide/concepts/model-providers/llamaapi.md
+        - MistralAI: user-guide/concepts/model-providers/mistral.md
         - Ollama: user-guide/concepts/model-providers/ollama.md
         - OpenAI: user-guide/concepts/model-providers/openai.md
         - Custom Providers: user-guide/concepts/model-providers/custom_model_provider.md


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- What kind of change are you making -->
- New content addition

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Add documentation support for Mistral AI Provider

## Areas Affected
<!-- List the pages/sections affected by this PR -->
The model provider page


## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [ ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->
This PR is related to: https://github.com/strands-agents/sdk-python/pull/284
The test to check documentation for this doc are failing as the Mistral model in strands-sdk is not merged yet
Getting this error:
```ERROR   -  mkdocstrings: strands.models.mistral could not be found
ERROR   -  Error reading page 'api-reference/models.md':
ERROR   -  Could not collect 'strands.models.mistral'

Aborted with a BuildError!```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
