### PR TITLE
remove event_loop error_handler reference

### DIFF
--- a/docs/api-reference/event-loop.md
+++ b/docs/api-reference/event-loop.md
@@ -5,9 +5,6 @@
 ::: strands.event_loop.event_loop
     options:
       heading_level: 2
-::: strands.event_loop.error_handler
-    options:
-      heading_level: 2
 ::: strands.event_loop.message_processor
     options:
       heading_level: 2


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
A recent change in the sdk caused the docs to fail building: https://github.com/strands-agents/sdk-python/commit/3ae8d77687f25e4cff1d1f7f2df6d0937c7a152a#diff-9e2c3161d4288440581ed5f678fcbae69b35d6b865fd6e67413fc61d9af13197

This change fixes that

## Type of Change
- Bug fix


## Motivation and Context
Fixes build issue

## Areas Affected
Removes: strands.event_loop.error_handler

## Screenshots
N/A

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
We need a way to detect this in the sdk before merging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
