### PR TITLE
remove thread pool wrapper

### DIFF
--- a/docs/api-reference/tools.md
+++ b/docs/api-reference/tools.md
@@ -17,9 +17,6 @@
 ::: strands.tools.registry
     options:
       heading_level: 2
-::: strands.tools.thread_pool_executor
-    options:
-      heading_level: 2
 ::: strands.tools.watcher
     options:
       heading_level: 2

--- a/docs/user-guide/concepts/agents/agent-loop.md
+++ b/docs/user-guide/concepts/agents/agent-loop.md
@@ -52,7 +52,7 @@ def event_loop_cycle(
     messages: Messages,
     tool_config: Optional[ToolConfig],
     tool_handler: Optional[ToolHandler],
-    tool_execution_handler: Optional[ParallelToolExecutorInterface] = None,
+    thread_pool: Optional[ThreadPoolExecutor] = None,
     **kwargs: Any,
 ) -> Tuple[StopReason, Message, EventLoopMetrics, Any]:
     # ... implementation details ...


### PR DESCRIPTION
## Description
We are removing ThreadPoolWrapper is src as it is not offering any additional functionality on top of `concurrent.futures.ThreadPoolExecutor`. For more details see https://github.com/strands-agents/sdk-python/pull/339.

## Type of Change
- [ ] New content addition
- [x] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Motivation and Context
Simplify code base.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
