### PR TITLE
feat: updates documentation with cache token metric

### DIFF
--- a/docs/user-guide/concepts/model-providers/custom_model_provider.md
+++ b/docs/user-guide/concepts/model-providers/custom_model_provider.md
@@ -222,6 +222,9 @@ Convert the event(s) returned by your model to the Strands Agents [StreamEvent](
         "inputTokens": 234, # Number of tokens sent in the request to the model..
         "outputTokens": 234, # Number of tokens that the model generated for the request.
         "totalTokens": 468 # Total number of tokens (input + output).
+        "cacheWriteInputTokens": 234 # Optional: Number of input tokens written to cache.
+        "cacheReadInputTokens": 0 # Optional: Number of input tokens read from cache.
+        
     }
 }
 ```

--- a/docs/user-guide/observability-evaluation/metrics.md
+++ b/docs/user-guide/observability-evaluation/metrics.md
@@ -6,7 +6,7 @@ Metrics are essential for understanding agent performance, optimizing behavior, 
 
 The Strands Agents SDK automatically tracks key metrics during agent execution:
 
-- **Token usage**: Input tokens, output tokens, and total tokens consumed
+- **Token usage**: Input tokens, output tokens, total tokens, and cache tokens consumed
 - **Performance metrics**: Latency and execution time measurements
 - **Tool usage**: Call counts, success rates, and execution times for each tool
 - **Event loop cycles**: Number of reasoning cycles and their durations


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->
Documentation for PR that adds exposes cache token usage in metric. 

## Type of Change
<!-- What kind of change are you making -->
- New content addition

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
My customer was asking about the cache token usage.

## Areas Affected
<!-- List the pages/sections affected by this PR -->
- observability-evaluation/metrics.md
- concepts/model-providers/custom_model_provider.md

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
