### PR TITLE
Update docs to point at strands to v0.2.0

### DIFF
--- a/docs/api-reference/event-loop.md
+++ b/docs/api-reference/event-loop.md
@@ -5,9 +5,6 @@
 ::: strands.event_loop.event_loop
     options:
       heading_level: 2
-::: strands.event_loop.error_handler
-    options:
-      heading_level: 2
 ::: strands.event_loop.message_processor
     options:
       heading_level: 2

--- a/docs/api-reference/tools.md
+++ b/docs/api-reference/tools.md
@@ -17,9 +17,6 @@
 ::: strands.tools.registry
     options:
       heading_level: 2
-::: strands.tools.thread_pool_executor
-    options:
-      heading_level: 2
 ::: strands.tools.watcher
     options:
       heading_level: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ mkdocs-macros-plugin~=1.3.7
 mkdocs-material~=9.6.12
 mkdocstrings-python~=1.16.10
 mkdocs-llmstxt~=0.2.0
-strands-agents~=0.1.0
+strands-agents~=0.2.0


### PR DESCRIPTION


## Description

Update to strands to v0.2.0 instead of pointing to v0.1.0 and also update associated class documentation that no longer exists.

## Type of Change

- Bug fix


## Motivation and Context

Stale docs

## Areas Affected

Stale docs

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
