### PR TITLE
models - move abstract class

### DIFF
--- a/docs/api-reference/handlers.md
+++ b/docs/api-reference/handlers.md
@@ -5,6 +5,3 @@
 ::: strands.handlers.callback_handler
     options:
       heading_level: 2
-::: strands.handlers.tool_handler
-    options:
-      heading_level: 2

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -2,6 +2,9 @@
     options:
       heading_level: 1
       members: false
+::: strands.models.model
+    options:
+      heading_level: 2
 ::: strands.models.bedrock
     options:
       heading_level: 2

--- a/docs/api-reference/types.md
+++ b/docs/api-reference/types.md
@@ -17,9 +17,6 @@
 ::: strands.types.media
     options:
       heading_level: 2
-::: strands.types.models
-    options:
-      heading_level: 2
 ::: strands.types.streaming
     options:
       heading_level: 2

--- a/docs/user-guide/concepts/agents/agent-loop.md
+++ b/docs/user-guide/concepts/agents/agent-loop.md
@@ -51,7 +51,6 @@ def event_loop_cycle(
     system_prompt: Optional[str],
     messages: Messages,
     tool_config: Optional[ToolConfig],
-    tool_handler: Optional[ToolHandler],
     thread_pool: Optional[ThreadPoolExecutor] = None,
     **kwargs: Any,
 ) -> Tuple[StopReason, Message, EventLoopMetrics, Any]:

--- a/docs/user-guide/concepts/model-providers/custom_model_provider.md
+++ b/docs/user-guide/concepts/model-providers/custom_model_provider.md
@@ -64,7 +64,7 @@ from typing_extensions import Unpack
 
 from custom.model import CustomModelClient
 
-from strands.types.models import Model
+from strands.models import Model
 from strands.types.content import Messages
 from strands.types.streaming import StreamEvent
 from strands.types.tools import ToolSpec

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -168,9 +168,9 @@ agent("Hello!")
 
 ## Model Providers
 
-### Identifying a configured model 
+### Identifying a configured model
 
-Strands defaults to the Bedrock model provider using Claude 3.7 Sonnet. The model your agent is using can be retrieved by accessing [`model.config`](../api-reference/types.md#strands.types.models.Model.get_config):
+Strands defaults to the Bedrock model provider using Claude 3.7 Sonnet. The model your agent is using can be retrieved by accessing [`model.config`](../api-reference/models.md#strands.models.model.Model.get_config):
 
 ```python
 from strands import Agent


### PR DESCRIPTION
## Description
We have moved the abstract model class from types into the models subpackage. For more details, please see https://github.com/strands-agents/sdk-python/pull/409.

Note, the workflow is failing with the error:
```
ERROR   -  mkdocstrings: strands.models.model could not be found
ERROR   -  Error reading page 'api-reference/models.md':
ERROR   -  Could not collect 'strands.models.model'
```
This will be resolved once the above PR is released into PyPI.

## Type of Change
- [ ] New content addition
- [x] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
