### PR TITLE
chore: update docs to reflect auto-loading and reloading tools

### DIFF
--- a/docs/user-guide/concepts/tools/tools_overview.md
+++ b/docs/user-guide/concepts/tools/tools_overview.md
@@ -44,12 +44,12 @@ agent = Agent(tools=["/path/to/my_tool.py"])
 
 Tools placed in your current working directory `./tools/` can be automatically loaded at agent initialization, and automatically reloaded when modified. This can be really useful when developing and debugging tools: simply modify the tool code and any agents using that tool will reload it to use the latest modifications!
 
-Automatic loading and reloading of tools in the `./tools/` directory is enabled by default with the `load_tools_from_directory=True` parameter passed to `Agent` during initialization. To disable this behavior, simply set `load_tools_from_directory=False`:
+Automatic loading and reloading of tools in the `./tools/` directory is disabled by default. To enable this behavior, set `load_tools_from_directory=True` when initializing your agent:
 
 ```python
 from strands import Agent
 
-agent = Agent(load_tools_from_directory=False)
+agent = Agent(load_tools_from_directory=True)
 ```
 
 ## Using Tools


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description

In https://github.com/strands-agents/sdk-python/pull/419 we updated `load_tools_from_directory` to default to False. This PR updates documentation to reflect the new default.

API Reference on https://strandsagents.com/latest/api-reference/agent/ will automatically be updated once 419 is merged.

## Type of Change
- Content update/revision

## Motivation and Context
A default was switched from True to False and now must be reflected in the documentation.

## Areas Affected
<!-- List the pages/sections affected by this PR -->

## Screenshots

OLD
<img width="859" height="338" alt="image" src="https://github.com/user-attachments/assets/026a2a16-a763-408a-8fa8-25b12bb00ddd" />

NEW


<img width="589" height="231" alt="image" src="https://github.com/user-attachments/assets/4450b4e3-8405-4333-a777-17332645e0b2" />


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
