### PR TITLE
Remove message_processor from api-reference

### DIFF
--- a/docs/api-reference/event-loop.md
+++ b/docs/api-reference/event-loop.md
@@ -5,9 +5,6 @@
 ::: strands.event_loop.event_loop
     options:
       heading_level: 2
-::: strands.event_loop.message_processor
-    options:
-      heading_level: 2
 ::: strands.event_loop.streaming
     options:
       heading_level: 2

--- a/docs/user-guide/observability-evaluation/logs.md
+++ b/docs/user-guide/observability-evaluation/logs.md
@@ -99,7 +99,6 @@ DEBUG | strands.tools.registry | tool_name=<calculator> | successfully reloaded 
 Logs related to the event loop processing:
 
 ```
-DEBUG | strands.event_loop.message_processor | message_index=<3> | replaced content with context message
 ERROR | strands.event_loop.error_handler | an exception occurred in event_loop_cycle | ContextWindowOverflowException
 DEBUG | strands.event_loop.error_handler | message_index=<5> | found message with tool results at index
 ```


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
Recently removed message_processor from sdk, so fixing the docs buid.

## Type of Change
<!-- What kind of change are you making -->
- Bug fix


## Motivation and Context
bug fix for build

## Areas Affected
N/A

## Screenshots
https://unshure.github.io/docs/latest/

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
