### PR TITLE
[BUG] fix docs build due to misaligned strands versions in docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ mkdocs-macros-plugin~=1.3.7
 mkdocs-material~=9.6.12
 mkdocstrings-python~=1.16.10
 mkdocs-llmstxt~=0.2.0
-strands-agents~=0.2.0
+strands-agents


### PR DESCRIPTION
## Description
Docs build is breaking due to the API ref not finding the right class due to misaligned Strands versions. I am defaulting it to the latest PyPI version to avoid this issue in the future.

## Type of Change
- Bug fix

## Motivation and Context
Defaulting to the latest PyPI so docs will always build API ref to latest

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
