### PR TITLE
concepts - agent loop - concurrent tool execution

### DIFF
--- a/docs/user-guide/concepts/agents/agent-loop.md
+++ b/docs/user-guide/concepts/agents/agent-loop.md
@@ -16,7 +16,7 @@ flowchart LR
         C --> D["Tool Execution"]
         D --> B
     end
-    
+
     Loop --> E[Response]
 ```
 
@@ -51,7 +51,6 @@ def event_loop_cycle(
     system_prompt: Optional[str],
     messages: Messages,
     tool_config: Optional[ToolConfig],
-    thread_pool: Optional[ThreadPoolExecutor] = None,
     **kwargs: Any,
 ) -> Tuple[StopReason, Message, EventLoopMetrics, Any]:
     # ... implementation details ...
@@ -75,18 +74,9 @@ The agent loop includes a tool execution system that:
 
 1. Validates tool requests from the model
 2. Looks up tools in the registry
-3. Executes tools with proper error handling
+3. Executes tools concurrently with proper error handling
 4. Captures and formats results
 5. Feeds results back to the model
-
-Tools can be executed in parallel or sequentially:
-
-```python
-# Configure maximum parallel tool execution
-agent = Agent(
-    max_parallel_tools=4  # Run up to 4 tools in parallel
-)
-```
 
 ## Detailed Flow
 
@@ -111,7 +101,6 @@ This initialization:
 
 - Creates a tool registry and registers tools
 - Sets up the conversation manager
-- Configures parallel processing capabilities
 - Initializes metrics collection
 
 ### 2. User Input Processing
@@ -160,7 +149,7 @@ The event loop:
 
 - Extracts and validates the tool request
 - Looks up the tool in the registry
-- Executes the tool (potentially in parallel with others)
+- Executes the tool
 - Captures the result and formats it
 
 ### 5. Tool Result Processing


### PR DESCRIPTION
## Description
Parallel tool execution is no longer configurable. By default, we run sync tools in a thread and async tools concurrently. 

## Type of Change
- [ ] New content addition
- [x] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
