### PR TITLE
tools - remove reference to max_parallel_tools

### DIFF
--- a/docs/user-guide/deploy/operating-agents-in-production.md
+++ b/docs/user-guide/deploy/operating-agents-in-production.md
@@ -89,26 +89,15 @@ For improved user experience in production applications, leverage streaming via 
 # For web applications
 async def stream_agent_response(prompt):
     agent = Agent(...)
-    
+
     ...
-    
+
     async for event in agent.stream_async(prompt):
         if "data" in event:
             yield event["data"]
 ```
 
 See [Async Iterators](../../user-guide/concepts/streaming/async-iterators.md) for more information.
-
-### Parallelism Settings
-
-Control parallelism for optimal resource utilization:
-
-```python
-# Limit parallel tool execution based on your infrastructure capacity
-agent = Agent(
-    max_parallel_tools=4  # Adjust based on available resources
-)
-```
 
 ### Error Handling
 

--- a/docs/user-guide/observability-evaluation/logs.md
+++ b/docs/user-guide/observability-evaluation/logs.md
@@ -56,14 +56,6 @@ result = agent("What is 125 * 37?")
 
 When running this code with logging enabled, you'll see logs from different components of the SDK as the agent processes the request, calls the calculator tool, and generates a response. The following sections show examples of these logs:
 
-### Agent Lifecycle
-
-Logs related to agent initialization and shutdown:
-
-```
-DEBUG | strands.agent.agent | thread pool executor shutdown complete
-```
-
 ### Tool Registry and Execution
 
 Logs related to tool discovery, registration, and execution:
@@ -85,8 +77,7 @@ WARNING | strands.tools.registry | tool_name=<invalid_tool> | spec validation fa
 DEBUG | strands.tools.registry | tool_name=<calculator> | loaded dynamic tool config
 
 # Tool execution
-DEBUG | strands.tools.executor | tool_name=<calculator> | executing tool with parameters: {"expression": "125 * 37"}
-DEBUG | strands.tools.executor | tool_count=<1> | submitted tasks to parallel executor
+DEBUG | strands.event_loop.event_loop | tool_use=<calculator_tool_use_id> | streaming
 
 # Tool hot reloading
 DEBUG | strands.tools.registry | tool_name=<calculator> | searching directories for tool


### PR DESCRIPTION
## Description
Tools are now executed concurrently if async and in a thread if sync. This is not configurable at the moment. Previously we supported a `max_parallel_tools` parameter to configure thread execution. This is gone, hence removing references in docs.

## Type of Change
- [ ] New content addition
- [x] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
