### PR TITLE
iterative events - update list

### DIFF
--- a/docs/user-guide/concepts/streaming/async-iterators.md
+++ b/docs/user-guide/concepts/streaming/async-iterators.md
@@ -1,6 +1,6 @@
 # Async Iterators for Streaming
 
-Strands Agents SDK provides support for asynchronous iterators through the `stream_async` method, enabling real-time streaming of agent responses in asynchronous environments like web servers, APIs, and other async applications.
+Strands Agents SDK provides support for asynchronous iterators through the [`stream_async`](../../../api-reference/agent.md#strands.agent.agent.Agent.stream_async) method, enabling real-time streaming of agent responses in asynchronous environments like web servers, APIs, and other async applications.
 
 > **Note**: If you want to use callbacks instead of async iterators, take a look at the [callback handlers](./callback-handlers.md) documentation. Async iterators are ideal for asynchronous frameworks like FastAPI, aiohttp, or Django Channels. For these environments, Strands Agents SDK offers the `stream_async` method which returns an asynchronous iterator.
 
@@ -27,6 +27,8 @@ async def process_streaming_response():
 asyncio.run(process_streaming_response())
 ```
 
+> Note, Strands also offers an [`invoke_async`](../../../api-reference/agent.md#strands.agent.agent.Agent.invoke_async) method for non-iterative async invocations.
+
 ## Event Types
 
 The async iterator yields the same event types as [callback handlers](callback-handlers.md#callback-handler-events), including:
@@ -34,7 +36,6 @@ The async iterator yields the same event types as [callback handlers](callback-h
 ### Text Generation Events
 
 - `data`: Text chunk from the model's output
-- `complete`: Boolean indicating if this is the final chunk
 - `delta`: Raw delta content from the model
 
 ### Tool Events
@@ -53,6 +54,7 @@ The async iterator yields the same event types as [callback handlers](callback-h
 - `event`: Raw event from the model stream
 - `force_stop`: True if the event loop was forced to stop
 - `force_stop_reason`: Reason for forced stop
+- `result`: The final [`AgentResult`](../../../api-reference/agent.md#strands.agent.agent_result.AgentResult)
 
 ### Reasoning Events
 
@@ -83,7 +85,7 @@ async def stream_response(request: PromptRequest):
             tools=[calculator, http_request],
             callback_handler=None
         )
-        
+
         try:
             async for event in agent.stream_async(request.prompt):
                 if "data" in event:
@@ -91,7 +93,7 @@ async def stream_response(request: PromptRequest):
                     yield event["data"]
         except Exception as e:
             yield f"Error: {str(e)}"
-    
+
     return StreamingResponse(
         generate(),
         media_type="text/plain"

--- a/docs/user-guide/concepts/streaming/callback-handlers.md
+++ b/docs/user-guide/concepts/streaming/callback-handlers.md
@@ -42,7 +42,6 @@ Callback handlers receive the same event types as [async iterators](./async-iter
 ### Text Generation Events
 
 - `data`: Text chunk from the model's output
-- `complete`: Boolean indicating if this is the final chunk
 - `delta`: Raw delta content from the model
 
 ### Tool Events
@@ -61,6 +60,7 @@ Callback handlers receive the same event types as [async iterators](./async-iter
 - `event`: Raw event from the model stream
 - `force_stop`: True if the event loop was forced to stop
 - `force_stop_reason`: Reason for forced stop
+- `result`: The final [`AgentResult`](../../../api-reference/agent.md#strands.agent.agent_result.AgentResult)
 
 ### Reasoning Events
 


### PR DESCRIPTION
## Description
For the async iterator and callbacks, we do not publish a `complete` event. We do however has a final AgentResult event now.

* Related Issue: https://github.com/strands-agents/sdk-python/issues/276

## Type of Change
- [ ] New content addition
- [x] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
