### PR TITLE
docs(multiagent): add API reference section for strands.multiagent.swarm module

### DIFF
--- a/docs/api-reference/multiagent.md
+++ b/docs/api-reference/multiagent.md
@@ -8,6 +8,9 @@
 ::: strands.multiagent.graph
     options:
       heading_level: 2
+::: strands.multiagent.swarm
+    options:
+      heading_level: 2
 ::: strands.multiagent.a2a
     options:
       heading_level: 2


### PR DESCRIPTION
## Description
add API reference section for strands.multiagent.swarm module

## Type of Change
- New content addition

## Motivation and Context
document Swarm in API reference (https://github.com/strands-agents/sdk-python/pull/416)

## Areas Affected
https://strandsagents.com/latest/api-reference/multiagent/ (pending deployment)

## Screenshots
N/A

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
