### PR TITLE
docs(welcome): default model changed to claude 4 sonnet

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,9 +28,9 @@ python -u agent.py
 
 That's it!
 
-> **Note**: To run this example hello world agent you will need to set up credentials for our model provider and enable model access. The default model provider is [Amazon Bedrock](user-guide/concepts/model-providers/amazon-bedrock.md) and the default model is Claude 3.7 Sonnet in the US Oregon (us-west-2) region.
+> **Note**: To run this example hello world agent you will need to set up credentials for our model provider and enable model access. The default model provider is [Amazon Bedrock](user-guide/concepts/model-providers/amazon-bedrock.md) and the default model is Claude 4 Sonnet in the US Oregon (us-west-2) region.
 
-> For the default Amazon Bedrock model provider, see the [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) for setting up AWS credentials. Typically for development, AWS credentials are defined in `AWS_` prefixed environment variables or configured with `aws configure`. You will also need to enable Claude 3.7 model access in Amazon Bedrock, following the [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to enable access.
+> For the default Amazon Bedrock model provider, see the [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) for setting up AWS credentials. Typically for development, AWS credentials are defined in `AWS_` prefixed environment variables or configured with `aws configure`. You will also need to enable Claude 4 Sonnet model access in Amazon Bedrock, following the [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to enable access.
 
 > Different model providers can be configured for agents by following the [quickstart guide](user-guide/quickstart.md#model-providers).
 

--- a/docs/examples/python/meta_tooling.md
+++ b/docs/examples/python/meta_tooling.md
@@ -47,7 +47,7 @@ The system prompt guides the agent in proper tool creation. The [TOOL_BUILDER_SY
 
   -  **Tool Naming Convention**: Provides the naming convention to use when building new custom tools.
 
-  -  **Tool Structure**: Enforces a standardized structure for all tools, making it possible for the agent to generate valid tools based on the `TOOL_SPEC` [provided](https://strandsagents.com/latest/user-guide/concepts/tools/python-tools/#python-modules-as-tools). 
+  -  **Tool Structure**: Enforces a standardized structure for all tools, making it possible for the agent to generate valid tools based on the `TOOL_SPEC` [provided](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/tools/python-tools/#python-modules-as-tools). 
 
 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ mkdocs-macros-plugin~=1.3.7
 mkdocs-material~=9.6.12
 mkdocstrings-python~=1.16.10
 mkdocs-llmstxt~=0.2.0
-strands-agents~=0.3.0
+strands-agents>=1.0.0


### PR DESCRIPTION
## Description
default model changed to claude 4 sonnet

## Type of Change
- Content update/revision

## Motivation and Context
Default model changed to Claude 4 Sonnet with v1.0.0

## Areas Affected
Welcome page. All other references are already updated: https://github.com/search?q=repo%3Astrands-agents%2Fdocs%203.7&type=code

## Screenshots
N/A

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
