### PR TITLE
Update knowledge_base_agent.md to fix the typo agent.use_llm() to agent.tool.use_llm()

### DIFF
--- a/docs/examples/python/knowledge_base_agent.md
+++ b/docs/examples/python/knowledge_base_agent.md
@@ -92,7 +92,7 @@ flowchart TD
        # Retrieve path
        result = agent.tool.memory(action="retrieve", query=query, min_score=0.4, max_results=9)
        # Generate response from retrieved information
-       answer = agent.use_llm(prompt=f"User question: \"{query}\"\n\nInformation from knowledge base:\n{result_str}...",
+       answer = agent.tool.use_llm(prompt=f"User question: \"{query}\"\n\nInformation from knowledge base:\n{result_str}...",
                              system_prompt=ANSWER_SYSTEM_PROMPT)
    ```
 


### PR DESCRIPTION
Conditional Execution Paths section is use agent.use_llm() which should be agent.tool.use_llm()

<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->
Documentation error, under the Conditional Execution Paths, Retrieve path should use agent.tool.use_llm() rather than agent.use_llm()

## Type of Change
<!-- What kind of change are you making -->

- Content update/revision



<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
it will throw error otherwise

## Areas Affected
<!-- List the pages/sections affected by this PR -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [ ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
