### PR TITLE
docs(a2a): revise a2a tool section

### DIFF
--- a/docs/user-guide/concepts/multi-agent/agent-to-agent.md
+++ b/docs/user-guide/concepts/multi-agent/agent-to-agent.md
@@ -234,12 +234,11 @@ agent = Agent(tools=provider.tools)
 response = agent("pick an agent and make a sample call")
 logger.info(response)
 
-# Async usage
-async def main():
-    response = await agent.invoke_async("pick an agent and make a sample call")
-    logger.info(response)
-
-asyncio.run(main())
+# Alternative Async usage
+# async def main():
+#     response = await agent.invoke_async("pick an agent and make a sample call")
+#     logger.info(response)
+# asyncio.run(main())
 ```
 
 This approach allows your Strands agent to:


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
This is a minor refactor to only have one agent invocation running in the docs. Otherwise, the output is a bit confusing when run without changes.

This is a companion PR to https://github.com/strands-agents/tools/pull/165

## Type of Change
<!-- What kind of change are you making -->
- Content update/revision

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Areas Affected
<!-- List the pages/sections affected by this PR -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
