### PR TITLE
feat(tools): add class based python tools section

### DIFF
--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -1,10 +1,12 @@
 # Python Tools
 
-There are three approaches to defining python-based tools in Strands:
+There are four approaches to defining python-based tools in Strands:
 
 * **Python functions with the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator**: Transform regular Python functions into tools by adding a simple decorator. This approach leverages Python's docstrings and type hints to automatically generate tool specifications.
 
 * **Class-based tools with the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator**: Create tools within classes to maintain state and leverage object-oriented programming patterns.
+
+* **AgentTool class implementation**: Create tools by implementing the AgentTool class (or using PythonAgentTool) directly. This provides the most control over tool behavior and implementation.
 
 * **Python modules following a specific format**: Define tools by creating Python modules that contain a tool specification and a matching function. This approach gives you more control over the tool's definition and is useful for dependency-free implementations of tools.
 

--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -1,12 +1,10 @@
 # Python Tools
 
-There are four approaches to defining python-based tools in Strands:
+There are three approaches to defining python-based tools in Strands:
 
 * **Python functions with the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator**: Transform regular Python functions into tools by adding a simple decorator. This approach leverages Python's docstrings and type hints to automatically generate tool specifications.
 
 * **Class-based tools with the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator**: Create tools within classes to maintain state and leverage object-oriented programming patterns.
-
-* **AgentTool class implementation**: Create tools by implementing the AgentTool class (or using PythonAgentTool) directly. This provides the most control over tool behavior and implementation.
 
 * **Python modules following a specific format**: Define tools by creating Python modules that contain a tool specification and a matching function. This approach gives you more control over the tool's definition and is useful for dependency-free implementations of tools.
 
@@ -165,10 +163,6 @@ agent = Agent(
 ```
 
 When you use the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator on a class method, the method becomes bound to the class instance when instantiated. This means the tool function has access to the instance's attributes and can maintain state between invocations.
-
-### Using PythonAgentTool (Alternative Approach)
-
-While you can also use the `PythonAgentTool` class directly to create class-based tools, most use cases can be satisfied using the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator approach with class methods due to its simplicity and automatic schema generation.
 
 ## Python Modules as Tools
 

--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -4,9 +4,9 @@ There are three approaches to defining python-based tools in Strands:
 
 * **Python functions with the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator**: Transform regular Python functions into tools by adding a simple decorator. This approach leverages Python's docstrings and type hints to automatically generate tool specifications.
 
-* **Python modules following a specific format**: Define tools by creating Python modules that contain a tool specification and a matching function. This approach gives you more control over the tool's definition and is useful for dependency-free implementations of tools.
-
 * **Class-based tools with the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator**: Create tools within classes to maintain state and leverage object-oriented programming patterns.
+
+* **Python modules following a specific format**: Define tools by creating Python modules that contain a tool specification and a matching function. This approach gives you more control over the tool's definition and is useful for dependency-free implementations of tools.
 
 ## Python Tool Decorators
 
@@ -114,6 +114,59 @@ async def async_example():
 
 asyncio.run(async_example())
 ```
+
+## Class-Based Tools
+
+Class-based tools allow you to create tools that maintain state and leverage object-oriented programming patterns. This approach is useful when your tools need to share resources, maintain context between invocations, follow object-oriented design principles, customize tools before passing them to an agent, or create different tool configurations for different agents.
+
+### Example with Multiple Tools in a Class
+
+You can define multiple tools within the same class to create a cohesive set of related functionality:
+
+```python
+from strands import Agent, tool
+
+class DatabaseTools:
+    def __init__(self, connection_string):
+        self.connection = self._establish_connection(connection_string)
+        
+    def _establish_connection(self, connection_string):
+        # Set up database connection
+        return {"connected": True, "db": "example_db"}
+    
+    @tool
+    def query_database(self, sql: str) -> dict:
+        """Run a SQL query against the database.
+        
+        Args:
+            sql: The SQL query to execute
+        """
+        # Uses the shared connection
+        return {"results": f"Query results for: {sql}", "connection": self.connection}
+    
+    @tool
+    def insert_record(self, table: str, data: dict) -> str:
+        """Insert a new record into the database.
+        
+        Args:
+            table: The table name
+            data: The data to insert as a dictionary
+        """
+        # Also uses the shared connection
+        return f"Inserted data into {table}: {data}"
+
+# Usage
+db_tools = DatabaseTools("example_connection_string")
+agent = Agent(
+    tools=[db_tools.query_database, db_tools.insert_record]
+)
+```
+
+When you use the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator on a class method, the method becomes bound to the class instance when instantiated. This means the tool function has access to the instance's attributes and can maintain state between invocations.
+
+### Using PythonAgentTool (Alternative Approach)
+
+While you can also use the `PythonAgentTool` class directly to create class-based tools, most use cases can be satisfied using the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator approach with class methods due to its simplicity and automatic schema generation.
 
 ## Python Modules as Tools
 
@@ -283,99 +336,3 @@ When using the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator
 1. If you return a string or other simple value, it's wrapped as `{"text": str(result)}`
 2. If you return a dictionary with the proper [`ToolResult`](../../../api-reference/types.md#strands.types.tools.ToolResult) structure, it's used directly
 3. If an exception occurs, it's converted to an error response
-
-## Class-Based Tools
-
-Class-based tools allow you to create tools that maintain state and leverage object-oriented programming patterns. This approach is useful when your tools need to share resources, maintain context between invocations, or follow object-oriented design principles.
-
-### Basic Example
-
-Here's how to create a class-based tool using the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator:
-
-```python
-from strands import Agent, tool
-
-class Browser:
-    """Browser tool implementation using Playwright."""
-
-    def __init__(self):
-        self._started = False
-        self._sessions = {}
-        # Initialize other class-level resources or state
-
-    @tool
-    def browser(self, url: str, action: str = "navigate") -> str:
-        """Interact with a web browser.
-        
-        Args:
-            url: The URL to navigate to or interact with
-            action: The action to perform (navigate, click, etc.)
-        """
-        # Method implementation that can access class instance variables
-        # and maintain state between invocations
-        return f"Performed {action} on {url}"
-
-# Usage
-browser_instance = Browser()
-agent = Agent(
-    tools=[browser_instance.browser]  # Pass the bound method as a tool
-)
-```
-
-When you use the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator on a class method, the method becomes bound to the class instance when instantiated. This means the tool function has access to the instance's attributes and can maintain state between invocations.
-
-### Advantages of Class-Based Tools
-
-Class-based tools offer several advantages:
-
-1. **State Management**: Maintain context and resources between tool invocations
-2. **Resource Sharing**: Share resources efficiently across multiple tools in the same class
-3. **Encapsulation**: Group related tools and their supporting code together
-4. **Initialization Control**: Set up resources during class initialization rather than on each tool invocation
-
-### Example with Multiple Tools in a Class
-
-You can define multiple tools within the same class to create a cohesive set of related functionality:
-
-```python
-from strands import Agent, tool
-
-class DatabaseTools:
-    def __init__(self, connection_string):
-        self.connection = self._establish_connection(connection_string)
-        
-    def _establish_connection(self, connection_string):
-        # Set up database connection
-        return {"connected": True, "db": "example_db"}
-    
-    @tool
-    def query_database(self, sql: str) -> dict:
-        """Run a SQL query against the database.
-        
-        Args:
-            sql: The SQL query to execute
-        """
-        # Uses the shared connection
-        return {"results": f"Query results for: {sql}", "connection": self.connection}
-    
-    @tool
-    def insert_record(self, table: str, data: dict) -> str:
-        """Insert a new record into the database.
-        
-        Args:
-            table: The table name
-            data: The data to insert as a dictionary
-        """
-        # Also uses the shared connection
-        return f"Inserted data into {table}: {data}"
-
-# Usage
-db_tools = DatabaseTools("example_connection_string")
-agent = Agent(
-    tools=[db_tools.query_database, db_tools.insert_record]
-)
-```
-
-### Using PythonAgentTool (Alternative Approach)
-
-While you can also use the `PythonAgentTool` class directly to create class-based tools, most use cases can be satisfied using the [`@tool`](../../../api-reference/tools.md#strands.tools.decorator.tool) decorator approach with class methods due to its simplicity and automatic schema generation.


### PR DESCRIPTION
## Description

Several comments have been made about leveraging the tool decorator within classes. Strands already supports this use case and even implemented some of its tools using the strategy (e.g. [browser](https://github.com/strands-agents/tools/blob/main/src/strands_tools/browser/browser.py#L53)). We have not documented this, though, which leaves customers in the dark. This PR promotes the new class based approach.


## Type of Change
- Content update/revision


## Motivation and Context
PR for #110 which will allow us to close out https://github.com/strands-agents/sdk-python/pull/162

## Areas Affected
Tools


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
