### PR TITLE
[DOCS] Fix incorrect model name in conversation management example

### DIFF
--- a/docs/user-guide/concepts/agents/conversation-management.md
+++ b/docs/user-guide/concepts/agents/conversation-management.md
@@ -149,7 +149,7 @@ from strands.models import AnthropicModel
 
 # Create a cheaper, faster model for summarization tasks
 summarization_model = AnthropicModel(
-    model_id="claude-haiku-4-20250514",  # More cost-effective for summarization
+    model_id="claude-3-5-haiku-20241022",  # More cost-effective for summarization
     max_tokens=1000,
     params={"temperature": 0.1}  # Low temperature for consistent summaries
 )


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
Fixed incorrect model name in conversation management documentation example. Updated `claude-haiku-4-20250514` (which doesn't exist) to the correct `claude-3-5-haiku-20241022` model name in the SummarizingConversationManager example.

## Type of Change
- [x] Bug fix
- [x] Typo/formatting fix

## Motivation and Context
The documentation contained an example using a non-existent model name `claude-haiku-4-20250514`. This would cause errors for users trying to follow the example code. The correct model name is `claude-3-5-haiku-20241022`, which is the actual Claude 3.5 Haiku model available from Anthropic. View full list [here](https://docs.anthropic.com/en/docs/about-claude/models/overview) 

## Areas Affected
- `docs/user-guide/concepts/agents/conversation-management.md` - Line 139 in the SummarizingConversationManager advanced configuration example

## Screenshots
N/A - Text-only change

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
This is a simple but important fix to ensure the documentation examples work correctly for users. The change maintains the same functionality while using the correct model identifier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
