### PR TITLE
docs(agent-loop): add troubleshooting to agent loop section

### DIFF
--- a/docs/user-guide/concepts/agents/agent-loop.md
+++ b/docs/user-guide/concepts/agents/agent-loop.md
@@ -192,7 +192,7 @@ The loop completes when the model generates a final text response or an exceptio
 
 ## Troubleshooting
 
-### MaxTokensReachedException
+### EventLoopMaxTokensReachedException
 
 This exception indicates that the agent has reached an unrecoverable state because the `max_tokens` stop reason was returned from the model provider. When this occurs, the agent cannot continue processing and the loop terminates.
 

--- a/docs/user-guide/concepts/agents/agent-loop.md
+++ b/docs/user-guide/concepts/agents/agent-loop.md
@@ -189,3 +189,17 @@ This recursive nature allows for complex workflows like:
 ### 7. Completion
 
 The loop completes when the model generates a final text response or an exception occurs that cannot be handled. At completion, metrics and traces are collected, conversation state is updated, and the final response is returned to the caller.
+
+## Troubleshooting
+
+### MaxTokensReachedException
+
+This exception indicates that the agent has reached an unrecoverable state because the `max_tokens` stop reason was returned from the model provider. When this occurs, the agent cannot continue processing and the loop terminates.
+
+**Common causes and solutions:**
+
+1. **Increase token limits**: If you have explicitly set a `max_tokens` limit in your model configuration, consider raising it to allow for longer responses.
+
+2. **Audit your tool specifications**: A frequent cause of this exception is tool specifications that prompt the model to return excessively large `toolUse` responses. Review your tools for large JSON schemas, tool specs with many fields or deeply nested structures can consume significant tokens. Also, consider long string requirements which may bloat the output (e.g., "provide a string that is 101k characters long").
+
+3. **Optimize tool design**: Consider breaking down complex tools into smaller, more focused tools, or simplifying tool input/output schemas to reduce token consumption.

--- a/docs/user-guide/concepts/agents/agent-loop.md
+++ b/docs/user-guide/concepts/agents/agent-loop.md
@@ -192,7 +192,7 @@ The loop completes when the model generates a final text response or an exceptio
 
 ## Troubleshooting
 
-### EventLoopMaxTokensReachedException
+### MaxTokensReachedException
 
 This exception indicates that the agent has reached an unrecoverable state because the `max_tokens` stop reason was returned from the model provider. When this occurs, the agent cannot continue processing and the loop terminates.
 


### PR DESCRIPTION
## Description

Documentation corresponding with https://github.com/strands-agents/sdk-python/pull/576

This adds guidance for the common problem of orphaned tool blocks which will now be caught and rethrown as a maxtokens exception

## Type of Change
- New content addition


## Motivation and Context
https://github.com/strands-agents/sdk-python/discussions/541

## Areas Affected

Agent-Loop


## Screenshots
<img width="669" height="384" alt="image" src="https://github.com/user-attachments/assets/560a71b7-169f-4801-8d30-43e4ed80cbda" />


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [n/a] Links in the documentation are valid and working
- [n/a] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
