### PR TITLE
fix: update browser tool path in documentation

### DIFF
--- a/docs/user-guide/concepts/tools/example-tools-package.md
+++ b/docs/user-guide/concepts/tools/example-tools-package.md
@@ -69,7 +69,7 @@ pip install 'strands-agents-tools[use_computer]'
 #### Web & Network
 - [`http_request`]({{ tools_repo }}/src/strands_tools/http_request.py): Make API calls, fetch web data, and call local HTTP servers
 - [`slack`]({{ tools_repo }}/src/strands_tools/slack.py): Slack integration with real-time events, API access, and message sending
-- [`browser`]({{ tools_repo }}/src/strands_tools/browser.py): Automate web browser interactions
+- [`browser`]({{ tools_repo }}/src/strands_tools/browser/browser.py): Automate web browser interactions
 - [`rss`]({{ tools_repo }}/src/strands_tools/rss.py): Manage and process RSS feeds
 
 #### Multi-modal


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
On example tool package page, web and network section - https://strandsagents.com/latest/documentation/docs/user-guide/concepts/tools/example-tools-package/?h=browser#web-network

I changed that tool path to browser/browser.py (https://github.com/strands-agents/tools/blob/main/src/strands_tools/browser/browser.py)

## Type of Change
<!-- What kind of change are you making -->
- Content update/revision


## Motivation and Context
The link of browser tools is not found - https://github.com/strands-agents/tools/blob/main/src/strands_tools/browser.py

So, I changed that tool path to browser/browser.py (https://github.com/strands-agents/tools/blob/main/src/strands_tools/browser/browser.py)

## Areas Affected
1. https://strandsagents.com/latest/documentation/docs/user-guide/concepts/tools/example-tools-package/

## Screenshots

<img width="1137" height="366" alt="Image" src="https://github.com/user-attachments/assets/c5bae48f-9a4d-4f7a-88a1-c5dabd3d15ff" />

<img width="1818" height="509" alt="Image" src="https://github.com/user-attachments/assets/04b29c72-511d-46b4-8169-b7827afae092" />



<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document  
- [x] My changes follow the project's documentation style  
- [x] I have tested the documentation locally using `mkdocs serve`  
- [x] Links in the documentation are valid and working  
- [x] Images/diagrams are properly sized and formatted  
- [x] All new and existing tests pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.