### PR TITLE
a minor fix to structured_output example for running on window OS

### DIFF
--- a/docs/examples/python/structured_output.py
+++ b/docs/examples/python/structured_output.py
@@ -41,7 +41,7 @@ def multimodal_example():
         age: int
         occupation: str
 
-    with tempfile.NamedTemporaryFile() as person_file:
+    with tempfile.NamedTemporaryFile(delete=False) as person_file:
         person_file.write(b"John Smith is a 30-year old software engineer")
         person_file.flush()
 


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
This PR resolves a permission error that occurs when running the structured_output.py example on Windows operating systems.

## Type of Change
<!-- What kind of change are you making -->
- Bug fix

## Motivation and Context
When executing the multimodal example on Windows, a PermissionError: [Errno 13] Permission denied is encountered. This occurs because the code attempts to open the same temporary file twice simultaneously - once through the NamedTemporaryFile context manager and again with open(person_file.name, "rb").

Windows operating system enforces exclusive file access, preventing multiple handles from accessing the same file concurrently. This restriction causes the second file opening operation to fail with a permission error.

Adding delete=False to the NamedTemporaryFile constructor resolves this issue by allowing the file to remain accessible after the initial context manager releases its handle.

## Areas Affected
docs/examples/python/structured_output.py

## Screenshots

```
Structured Output Examples


--- Multi-Modal Example ---
Traceback (most recent call last):
  File "d:\D\AI\2025\ai-agent\opensource\docs\docs\examples\python\structured_output.py", line 162, in <module>
    multimodal_example()
  File "d:\D\AI\2025\ai-agent\opensource\docs\docs\examples\python\structured_output.py", line 48, in multimodal_example
    with open(person_file.name, "rb") as fp:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\~1\\AppData\\Local\\Temp\\tmpgzga20b7'
```

## Checklist
<!-- Mark completed items with an [x] -->
- [x ] I have read the CONTRIBUTING document
- [ x] My changes follow the project's documentation style
- [ x] I have tested the documentation locally using `mkdocs serve`
- [ x] Links in the documentation are valid and working
- [ x] Images/diagrams are properly sized and formatted
- [ x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
