### PR TITLE
fix(hooks): clarify that hooks is accessible through agent object

### DIFF
--- a/docs/user-guide/concepts/agents/hooks.md
+++ b/docs/user-guide/concepts/agents/hooks.md
@@ -29,7 +29,7 @@ agent = Agent()
 def my_callback(event: BeforeInvocationEvent) -> None:
     print("Custom callback triggered")
 
-hooks.add_callback(BeforeInvocationEvent, my_callback)
+agent.hooks.add_callback(BeforeInvocationEvent, my_callback)
 ```
 
 ### Creating a Hook Provider


### PR DESCRIPTION

## Description
 Fix minor bug called out in https://github.com/strands-agents/docs/issues/196 where hooks is not defined, since it should be called using the agent object.


## Type of Change

- Typo/formatting fix

## Motivation and Context

https://github.com/strands-agents/docs/issues/196

## Areas Affected
<!-- List the pages/sections affected by this PR -->
https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/hooks/#registering-individual-hook-callbacks

## Screenshots


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [ ] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
