### PR TITLE
fix: Clarify that strands-agents-tools is community-driven package

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ Key features include:
 * **Lightweight and gets out of your way**: A simple agent loop that just works and is fully customizable.
 * **Production ready**: Full observability, tracing, and deployment options for running agents at scale.
 * **Model, provider, and deployment agnostic**: Strands supports many different models from many different providers.
-* **Powerful built-in tools**: Get started quickly with tools for a broad set of capabilities.
+* **Community-driven tools**: Get started quickly with a powerful set of community-contributed tools for a broad set of capabilities.
 * **Multi-agent and autonomous agents**: Apply advanced techniques to your AI systems like agent teams and agents that improve themselves over time.
 * **Conversational, non-conversational, streaming, and non-streaming**: Supports all types of agents for various workloads.
 * **Safety and security as a priority**: Run agents responsibly while protecting data.
@@ -54,7 +54,7 @@ Ready to learn more? Check out these resources:
 
 - [Quickstart](user-guide/quickstart.md) - A more detailed introduction to Strands Agents
 - [Examples](examples/README.md) - Examples for many use cases, types of agents, multi-agent systems, autonomous agents, and more
-- [Example Built-in Tools](user-guide/concepts/tools/example-tools-package.md) - The {{ link_strands_tools }} package provides many powerful example tools for your agents to use during development
+- [Community Supported Tools](user-guide/concepts/tools/community-tools-package.md) - The {{ link_strands_tools }} package is a community-driven project that provides a powerful set of tools for your agents to use
 - [Strands Agent Builder]({{ agent_builder_repo_home }}) - Use the accompanying {{ link_strands_builder }} agent builder to harness the power of LLMs to generate your own tools and agents
 
 !!! tip "Join Our Community"

--- a/docs/user-guide/concepts/model-providers/writer.md
+++ b/docs/user-guide/concepts/model-providers/writer.md
@@ -115,7 +115,7 @@ agent = Agent(
 response = agent("Research our competitor's latest product launch and draft a summary email for the leadership team")
 ```
 
-> **Note**: The `web_search` and `email_sender` tools in this example are custom tools that you would need to define. See [Python Tools](../tools/python-tools.md) for guidance on creating custom tools, or use existing tools from the [strands_tools package](../tools/example-tools-package.md).
+> **Note**: The `web_search` and `email_sender` tools in this example are custom tools that you would need to define. See [Python Tools](../tools/python-tools.md) for guidance on creating custom tools, or use existing tools from the [strands_tools package](../tools/community-tools-package.md).
 
 ### Financial analysis with Palmyra Fin
 

--- a/docs/user-guide/concepts/multi-agent/graph.md
+++ b/docs/user-guide/concepts/multi-agent/graph.md
@@ -312,7 +312,7 @@ From [another_node_id]:
 
 ## Graphs as a Tool
 
-Agents can dynamically create and orchestrate graphs by using the `graph` tool available in the [Strands tools package](../tools/example-tools-package.md).
+Agents can dynamically create and orchestrate graphs by using the `graph` tool available in the [Strands tools package](../tools/community-tools-package.md).
 
 ```python
 from strands import Agent

--- a/docs/user-guide/concepts/multi-agent/swarm.md
+++ b/docs/user-guide/concepts/multi-agent/swarm.md
@@ -206,7 +206,7 @@ print(f"Token usage: {result.accumulated_usage}")
 
 ## Swarm as a Tool
 
-Agents can dynamically create and orchestrate swarms by using the `swarm` tool available in the [Strands tools package](../tools/example-tools-package.md).
+Agents can dynamically create and orchestrate swarms by using the `swarm` tool available in the [Strands tools package](../tools/community-tools-package.md).
 
 ```python
 from strands import Agent

--- a/docs/user-guide/concepts/tools/community-tools-package.md
+++ b/docs/user-guide/concepts/tools/community-tools-package.md
@@ -1,6 +1,6 @@
-# Example Built-in Tools
+# Community Built Tools
 
-Strands offers an optional example tools package [`strands-agents-tools`]({{ tools_pypi }}) which includes pre-built tools to get started quickly experimenting with agents and tools during development. The package is also open source and available on [GitHub]({{ tools_repo_home }}).
+Strands offers an optional, community-supported tools package [`strands-agents-tools`]({{ tools_pypi }}) which includes pre-built tools to get started quickly experimenting with agents and tools during development. The package is also open source and available on [GitHub]({{ tools_repo_home }}).
 
 Install the `strands-agents-tools` package by running:
 

--- a/docs/user-guide/concepts/tools/tools_overview.md
+++ b/docs/user-guide/concepts/tools/tools_overview.md
@@ -2,7 +2,7 @@
 
 Tools are the primary mechanism for extending agent capabilities, enabling them to perform actions beyond simple text generation. Tools allow agents to interact with external systems, access data, and manipulate their environment.
 
-Strands offers built-in example tools to get started quickly experimenting with agents and tools during development. For more information, see [Example Built-in Tools](example-tools-package.md).
+Strands Agents Tools is a community-driven project that provides a powerful set of tools for your agents to use. For more information, see [Strands Agents Tools](community-tools-package.md).
 
 ## Adding Tools to Agents
 
@@ -242,11 +242,11 @@ with sse_mcp_client:
 
 For more information on using MCP tools, see [MCP Tools](mcp-tools.md).
 
-### 3. Example Built-in Tools
+### 3. Community Built Tools
 
-For rapid prototyping and common tasks, Strands offers an optional [example built-in tools package]({{ tools_repo }}) with pre-built tools for development. These tools cover a wide variety of capabilities including File Operations, Shell & Local System control, Web & Network for API calls, and Agents & Workflows for orchestration.
+For rapid prototyping and common tasks, Strands offers a [community-supported tools package]({{ tools_repo }}) with pre-built tools for development. These tools cover a wide variety of capabilities including File Operations, Shell & Local System control, Web & Network for API calls, and Agents & Workflows for orchestration.
 
-For a complete list of available tools and their detailed descriptions, see [Example Built-in Tools](example-tools-package.md).
+For a complete list of available tools and their detailed descriptions, see [Community Tools Package](community-tools-package.md).
 
 ## Tool Design Best Practices
 

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -24,7 +24,7 @@ Next we'll install the `strands-agents` SDK package:
 pip install strands-agents
 ```
 
-The Strands Agents SDK additionally offers the [`strands-agents-tools`]({{ tools_pypi }}) ([GitHub]({{ tools_repo_home }})) and [`strands-agents-builder`]({{ agent_builder_pypi }}) ([GitHub]({{ agent_builder_repo_home }})) packages for development. The [`strands-agents-tools`]({{ tools_pypi }}) package provides many example tools that give your agents powerful abilities. The [`strands-agents-builder`]({{ agent_builder_pypi }}) package provides an agent that helps you to build your own Strands agents and tools.
+The Strands Agents SDK additionally offers the [`strands-agents-tools`]({{ tools_pypi }}) ([GitHub]({{ tools_repo_home }})) and [`strands-agents-builder`]({{ agent_builder_pypi }}) ([GitHub]({{ agent_builder_repo_home }})) packages for development. The [`strands-agents-tools`]({{ tools_pypi }}) package is a community-driven project that provides a set of tools for your agents to use, bridging the gap between large language models and practical applications. The [`strands-agents-builder`]({{ agent_builder_pypi }}) package provides an agent that helps you to build your own Strands agents and tools.
 
 
 Let's install those development packages too:
@@ -99,7 +99,7 @@ def letter_counter(word: str, letter: str) -> int:
 
     return word.lower().count(letter.lower())
 
-# Create an agent with tools from the strands-tools example tools package
+# Create an agent with tools from the community-driven strands-tools package
 # as well as our custom letter_counter tool
 agent = Agent(tools=[calculator, current_time, python_repl, letter_counter])
 
@@ -500,7 +500,7 @@ See the [Callback Handlers](concepts/streaming/callback-handlers.md) documentati
 Ready to learn more? Check out these resources:
 
 - [Examples](../examples/README.md) - Examples for many use cases, multi-agent systems, autonomous agents, and more
-- [Example Built-in Tools](concepts/tools/example-tools-package.md) - The `strands-agents-tools` package provides many powerful example tools for your agents to use during development
+- [Community Supported Tools](concepts/tools/community-tools-package.md) - The `strands-agents-tools` package provides many powerful example tools for your agents to use during development
 - [Strands Agent Builder]({{ agent_builder_repo_home }}) - Use the accompanying `strands-agents-builder` agent builder to harness the power of LLMs to generate your own tools and agents
 - [Agent Loop](concepts/agents/agent-loop.md) - Learn how Strands agents work under the hood
 - [State & Sessions](concepts/agents/state.md) - Understand how agents maintain context and state across a conversation or workflow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,7 @@ nav:
         - Overview: user-guide/concepts/tools/tools_overview.md
         - Python: user-guide/concepts/tools/python-tools.md
         - Model Context Protocol (MCP): user-guide/concepts/tools/mcp-tools.md
-        - Example Tools Package: user-guide/concepts/tools/example-tools-package.md
+        - Community Tools Package: user-guide/concepts/tools/community-tools-package.md
       - Model Providers:
         - Amazon Bedrock: user-guide/concepts/model-providers/amazon-bedrock.md
         - Anthropic: user-guide/concepts/model-providers/anthropic.md


### PR DESCRIPTION


<!-- Thank you for contributing to our documentation! -->

## Description

We've settled on community-driven as the wording for the package:

> Strands Agents Tools is a community-driven project that provides a powerful set of tools for your agents to use. It bridges the gap between large language models and practical applications by offering ready-to-use tools for file operations, system execution, API interactions, mathematical operations, and more.

So update all references from "example" to "community-driven"

## Type of Change
<!-- What kind of change are you making -->

- Content update/revision

## Motivation and Context

Our messaging was outdated - it pitched it as "example" which lead to user confusion

## Areas Affected

Any where we reference the package as "example"

## Screenshots

N/A

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
