### PR TITLE
fix: Call-out that direct method calls must used keyword arguments

### DIFF
--- a/docs/user-guide/concepts/tools/tools_overview.md
+++ b/docs/user-guide/concepts/tools/tools_overview.md
@@ -76,6 +76,13 @@ Every tool added to an agent also becomes a method accessible directly on the ag
 result = agent.tool.file_read(path="/path/to/file.txt", mode="view")
 ```
 
+When calling tools directly as methods, always use keyword arguments - positional arguments are *not* supported for direct method calls:
+
+```python
+# This will NOT work - positional arguments are not supported
+result = agent.tool.file_read("/path/to/file.txt", "view")  # ❌ Don't do this
+```
+
 If a tool name contains hyphens, you can invoke the tool using underscores instead:
 
 ```python


### PR DESCRIPTION


<!-- Thank you for contributing to our documentation! -->

## Description
Follow-up to #194 where examples were not using keyword arguments and thus not working correctly.

## Type of Change
<!-- What kind of change are you making -->

- Content update/revision


<Enter type of change here>

## Motivation and Context

strands-agents/tools#194 revealed that our docs should call out to always use keyword parameters

## Areas Affected

Tools overview

## Screenshots

N/A

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
