### PR TITLE
fix(traces): add ' around pip install for the otel optional dependencies

### DIFF
--- a/docs/user-guide/observability-evaluation/traces.md
+++ b/docs/user-guide/observability-evaluation/traces.md
@@ -83,7 +83,7 @@ Strands natively integrates with OpenTelemetry, an industry standard for distrib
 
 ## Enabling Tracing
 
-!!! warning "To enable OTEL exporting, install Strands Agents with `otel` extra dependencies: `pip install strands-agents[otel]`"
+!!! warning "To enable OTEL exporting, install Strands Agents with `otel` extra dependencies: `pip install 'strands-agents[otel]'`"
 
 
 ### Environment Variables


### PR DESCRIPTION
## Description
fix(traces): add ' around pip install for the otel optional dependencies

## Type of Change
- Typo/formatting fix

## Motivation and Context
pip install requires `'` around optional dependencies when used with some shells like zsh

## Areas Affected
https://strandsagents.com/latest/documentation/docs/user-guide/observability-evaluation/traces/

## Screenshots
N/A

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
