### PR TITLE
fix: Recommend aws-opentelemetry-distro 0.10.1 due to otel bug

### DIFF
--- a/docs/user-guide/deploy/deploy_to_bedrock_agentcore.md
+++ b/docs/user-guide/deploy/deploy_to_bedrock_agentcore.md
@@ -590,13 +590,13 @@ Before you can view metrics and traces, complete this one-time setup:
 
 Add to your `requirements.txt`:
 ```text
-aws-opentelemetry-distro>=0.10.0
+aws-opentelemetry-distro>=0.10.1
 boto3
 ```
 
 Or install directly:
 ```bash
-pip install aws-opentelemetry-distro>=0.10.0 boto3
+pip install aws-opentelemetry-distro>=0.10.1 boto3
 ```
 
 #### 2. Run With Auto-Instrumentation


### PR DESCRIPTION

## Description
Via strands-agents/sdk-python/issues/488 we identified that aws-opentelemetry-distro 0.10.0 was a cause of bugs in AgentCore, so ensure that the documentation guides folks to non-buggy implementations

I'm not recommending 0.11.0 because I haven't personally tested it

## Type of Change
<!-- What kind of change are you making -->
- Content update/revision


## Motivation and Context

Offline we were asked to update the docs to point to an updated version.

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
