### PR TITLE
fix: update quickstart docs to remove python_repl tool

### DIFF
--- a/docs/user-guide/concepts/tools/community-tools-package.md
+++ b/docs/user-guide/concepts/tools/community-tools-package.md
@@ -64,6 +64,7 @@ pip install 'strands-agents-tools[use_computer]'
 
 #### Code Interpretation
 - [`python_repl`]({{ tools_repo }}/src/strands_tools/python_repl.py): Run Python code
+    - Not supported on Windows due to the `fcntl` module not being available on Windows.
 - [`code_interpreter`]({{ tools_repo }}/src/strands_tools/code_interpreter.py): Execute code in isolated sandboxes
 
 #### Web & Network

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -76,7 +76,7 @@ And finally our `agent.py` file where the goodies are:
 
 ```python
 from strands import Agent, tool
-from strands_tools import calculator, current_time, python_repl
+from strands_tools import calculator, current_time
 
 # Define a custom tool as a Python function using the @tool decorator
 @tool
@@ -101,7 +101,7 @@ def letter_counter(word: str, letter: str) -> int:
 
 # Create an agent with tools from the community-driven strands-tools package
 # as well as our custom letter_counter tool
-agent = Agent(tools=[calculator, current_time, python_repl, letter_counter])
+agent = Agent(tools=[calculator, current_time, letter_counter])
 
 # Ask the agent a question that uses the available tools
 message = """
@@ -110,8 +110,6 @@ I have 4 requests:
 1. What is the time right now?
 2. Calculate 3111696 / 74088
 3. Tell me how many letter R's are in the word "strawberry" 🍓
-4. Output a script that does what we just spoke about!
-   Use your python tools to confirm that the script works before outputting it
 """
 agent(message)
 ```


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->
Remove `python_repl` tool from the quickstart agent guide so that users on any OS, especially, Windows can copy/paste the example and continue executing it. This change is needed because currently `python_repl` has a known issue of not being supported on Windows due to `fnctl` module needed for the tool not being available on Windows. 

## Type of Change
<!-- What kind of change are you making -->
- Content update/revision

<Enter type of change here>


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Users have reported not being able to run the example on the quickstart page on their windows machine. This is due to the `python_repl` tool having a known issue. 

## Areas Affected
<!-- List the pages/sections affected by this PR -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->
https://github.com/strands-agents/sdk-python/issues/673

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
