### PR TITLE
Update docs to account for private VPC endpoint for Bedrock.

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -534,6 +534,21 @@ print(f"Features: {result.features}")
 print(f"Rating: {result.rating}")
 ```
 
+### Use private interface VPC endpoint (AWS Private Link) for Bedrock
+
+You can use AWS PrivateLink to create a private connection between your VPC and Amazon Bedrock. You can access Amazon Bedrock as if it were in your VPC, without the use of an internet gateway, NAT device, VPN connection, or AWS Direct Connect connection.
+
+Configure the `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` environment variable to use your private VPC endpoint for Amazon Bedrock:
+
+```bash
+# Your private VPC endpoint for Amazon Bedrock
+export AWS_ENDPOINT_URL_BEDROCK_RUNTIME="https://vpce-xx.bedrock-runtime.region.vpce.amazonaws.com"
+```
+
+This provides secure, low‑latency access to Bedrock while keeping traffic off the public internet. 
+
+For complete details on private interface VPC endpoint configuration and resolution, see the [bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/vpc-interface-endpoints.html).
+
 ## Troubleshooting
 
 ### Model access issue


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->
Update docs to account for private VPC endpoint for Bedrock.

## Type of Change
<!-- What kind of change are you making -->
- Content update

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The environment variable is supported by the boto3 but there are no documentation mentioned about it. See https://docs.aws.amazon.com/sdkref/latest/guide/ss-endpoints-table.html

Resolve this issue: https://github.com/strands-agents/sdk-python/pull/502

## Areas Affected
<!-- List the pages/sections affected by this PR -->
 - [amazon-bedrock.md](docs/user-guide/concepts/model-providers/amazon-bedrock.md)


## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
 
<img width="1468" height="528" alt="image" src="https://github.com/user-attachments/assets/95aa2ae6-a7b8-48ce-abaa-37e9df5e31c5" />

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
