### PR TITLE
Temporarily remove reference for tools executor from docs

### DIFF
--- a/docs/api-reference/tools.md
+++ b/docs/api-reference/tools.md
@@ -8,9 +8,6 @@
 ::: strands.tools.decorator
     options:
       heading_level: 2
-::: strands.tools.executor
-    options:
-      heading_level: 2
 ::: strands.tools.loader
     options:
       heading_level: 2


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- What kind of change are you making -->
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Areas Affected
<!-- List the pages/sections affected by this PR -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [ ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
