### PR TITLE
Document the Console Output default behavior

### DIFF
--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -311,6 +311,20 @@ Traces provide detailed insight into the agent's reasoning process. You can acce
 
 This observability data helps you debug agent behavior, optimize performance, and understand the agent's reasoning process. For detailed information, see [Observability](observability-evaluation/observability.md), [Traces](observability-evaluation/traces.md), and [Metrics](observability-evaluation/metrics.md).
 
+
+## Console Output
+
+Agents display their reasoning and responses in real-time to the console by default. You can disable this output by setting `callback_handler=None` when creating your agent:
+
+```python
+agent = Agent(
+    tools=[calculator, current_time, letter_counter],
+    callback_handler=None,
+)
+```
+
+Learn more in the [Callback Handlers](concepts/streaming/callback-handlers.md) documentation.
+
 ## Debug Logs
 
 To enable debug logs in our agent, configure the `strands` logger:


### PR DESCRIPTION

## Description

We receive a lot of questions about the default output behavior, so putting this up front in the QuickStart

## Type of Change

Content update/revision

## Motivation and Context

We receive a lot of questions about the default output behavior, so putting this up front in the QuickStart.  Semi related to discoverability and strands-agents/sdk-python/issues/506

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
