### PR TITLE
feat: Add documentation about ToolContext

### DIFF
--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -115,6 +115,26 @@ async def async_example():
 asyncio.run(async_example())
 ```
 
+### ToolContext
+
+Tools can access their execution context by setting `context=True` and including a `tool_context` parameter. The `ToolContext` provides access to the invoking agent and current tool use data:
+
+```python
+from strands import tool, Agent, ToolContext
+
+@tool(context=True)
+def get_self_name(tool_context: ToolContext) -> str:
+    return f"The agent name is {tool_context.agent.name}"
+
+@tool(context=True)
+def get_tool_use_id(tool_context: ToolContext) -> str:
+    return f"Tool use is {tool_context.tool_use["toolUseId"]}"
+
+agent = Agent(tools=[get_self_name, get_tool_use_id], name="Best agent")
+agent("What is your name?")
+agent("What is the tool use id?")
+```
+
 ## Class-Based Tools
 
 Class-based tools allow you to create tools that maintain state and leverage object-oriented programming patterns. This approach is useful when your tools need to share resources, maintain context between invocations, follow object-oriented design principles, customize tools before passing them to an agent, or create different tool configurations for different agents.


### PR DESCRIPTION
## Description

Adding barebones docs as a follow-up to strands-agents/sdk-python/pull/557

## Type of Change
<!-- What kind of change are you making -->
- New content addition


<Enter type of change here>

## Motivation and Context

People have asked about this; follow-up to strands-agents/sdk-python/pull/557


## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
