### PR TITLE
fix: installation instructions to reflect switchover to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The official documentation is available online at: https://strandsagents.com.
 python -m venv .venv
 source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
 
-pip install -r requirements.txt
+pip install .
 ```
 
 ### Building and Previewing


### PR DESCRIPTION
## Summary
Updates the README installation instructions to use `pip install .` instead of `pip install -r requirements.txt`, aligning with the project's migration to pyproject.toml.

## Background
In commit d7bc993 (PR #225), the project switched from using requirements.txt to pyproject.toml for dependency management. However, the README was never updated to reflect this change, causing confusion for new contributors following the setup instructions.

## Changes
- Updated installation command from `pip install -r requirements.txt` to `pip install .`
- Maintains all other setup instructions unchanged

## Testing
- [X] Verified the installation command works with the current pyproject.toml setup
- [X] Confirmed the documentation builds successfully after installation

Fixes the outdated installation instructions and ensures consistency with the current project structure.
