### PR TITLE
docs: add section to litellm for proxy server usage

### DIFF
--- a/docs/user-guide/concepts/model-providers/litellm.md
+++ b/docs/user-guide/concepts/model-providers/litellm.md
@@ -36,6 +36,41 @@ response = agent("What is 2+2")
 print(response)
 ```
 
+## Using LiteLLM Proxy
+
+To use a [LiteLLM Proxy Server](https://docs.litellm.ai/docs/simple_proxy), you have two options:
+
+### Option 1: Use `use_litellm_proxy` parameter
+
+```python
+from strands import Agent
+from strands.models.litellm import LiteLLMModel
+
+model = LiteLLMModel(
+    client_args={
+        "api_key": "<PROXY_KEY>",
+        "api_base": "<PROXY_URL>",
+        "use_litellm_proxy": True
+    },
+    model_id="amazon.nova-lite-v1:0"
+)
+
+agent = Agent(model=model)
+response = agent("Tell me a story")
+```
+
+### Option 2: Use `litellm_proxy/` prefix in model ID
+
+```python
+model = LiteLLMModel(
+    client_args={
+        "api_key": "<PROXY_KEY>",
+        "api_base": "<PROXY_URL>"
+    },
+    model_id="litellm_proxy/amazon.nova-lite-v1:0"
+)
+```
+
 ## Configuration
 
 ### Client Configuration


### PR DESCRIPTION
## Description

Doc updated related to https://github.com/strands-agents/sdk-python/pull/808.


> A customer complained that when they ran

> litellm_model = LiteLLMModel(
        client_args={
            "api_key": "sk-1234",
            "api_base": LITELLM_PROXY_URL  # also fails for "base_url": LITELLM_PROXY_URL
        },
        model_id="amazon.nova-lite-v1:0"
    )
> They were seeing httpx.HTTPStatusError: Client error '404 Not Found' for url '{LITELLM_PROXY_URL}/model/amazon.nova-pro-v1%3A0/converse'

> The reason for this is that LiteLLM recognizes the model as a Bedrock model, so it selects the BedrockModel provider. Then it uses api_base in a similar way to how in the Strand BedrockModel we have endpoint_url. So LiteLLM, as a client, is making a request to Bedrock but assuming Bedrock is behind some other endpoint.

> What the customer expected, is that the request would be route to their own [LiteLLM Proxy Server](https://docs.litellm.ai/docs/simple_proxy). As stated above, setting the api_base does NOT indicate that the LiteLLM Proxy Server should be used, it indicates that the selected model provider happens to. have an endpoint different than the default one - for example for bedrock the default is https://bedrock-runtime.{region}.amazonaws.com

> So the primary fix will be to update https://strandsagents.com/latest/documentation/docs/user-guide/concepts/model-providers/litellm/.

> The fix in this PR is to make it easier for customers to use the proxy. There are three methods described in https://github.com/BerriAI/litellm/issues/13454 but according to https://github.com/BerriAI/litellm/issues/13454 passing in as a dynamic param is broken. Meaning without this fix, customers would need to break the abstraction in Strands and directly do os.environ["USE_LITELLM_PROXY"] = "True" or litellm.use_litellm_proxy = True.

## Type of Change


- Content update/revision


<Enter type of change here>

## Motivation and Context

Explicitly instruct users who want to use the LiteLLM proxy

## Areas Affected

https://strandsagents.com/latest/documentation/docs/user-guide/concepts/model-providers/litellm/

## Screenshots


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [n/a] Links in the documentation are valid and working
- [n/a] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
