### PR TITLE
Document tool streaming

### DIFF
--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -168,7 +168,7 @@ agent("What is the tool use id?")
 
 ### Tool Streaming
 
-Async tools can yield intermediate results to provide real-time progress updates. Each yielded value becomes a streaming event, with the final value serving as the tool's return result.
+Async tools can yield intermediate results to provide real-time progress updates. Each yielded value becomes a streaming event (see [async iterators](../streaming/async-iterators.md) or [callback handlers](../streaming/callback-handlers.md) for more information), with the final value serving as the tool's return result:
 
 ```python
 from datetime import datetime
@@ -192,12 +192,15 @@ async def process_dataset(records: int) -> str:
 Stream events contain a `tool_stream_event` dictionary with `tool_use` (invocation info) and `data` (yielded value) fields:
 
 ```python
-agent = Agent(tools=[process_dataset])
+async def tool_stream_example():
+    agent = Agent(tools=[process_dataset])
 
-async for event in agent.stream_async("Process 50 records"):
-    if tool_stream := event.get("tool_stream_event"):
-        if update := tool_stream.get("data"):
-            print(f"Progress: {update}")
+    async for event in agent.stream_async("Process 50 records"):
+        if tool_stream := event.get("tool_stream_event"):
+            if update := tool_stream.get("data"):
+                print(f"Progress: {update}")
+
+asyncio.run(tool_stream_example())
 ```
 
 ## Class-Based Tools


### PR DESCRIPTION

## Description

Add a section on tools yielding events back up to the caller.  This documents the implementation of strands-agents/sdk-python/issues/543

## Type of Change

- New content addition

## Motivation and Context

Currently tool streaming is un-documented; this fixes that and completes strands-agents/sdk-python/issues/543

## Areas Affected

python-tools

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
