### PR TITLE
Default model id warn

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,16 +30,11 @@ That's it!
 
 > **Note**: To run this example hello world agent you will need to set up credentials for our model provider and enable model access. The default model provider is [Amazon Bedrock](user-guide/concepts/model-providers/amazon-bedrock.md) and the default model is Claude 4 Sonnet inference model from the region of your credentials. For example, if you set the region to `us-east-1` then the default model id will be: `us.anthropic.claude-sonnet-4-20250514-v1:0`. 
 
-!!! warning ""
-
-    If you are getting an error (`ValidationException`), then check if you are using a region that does not [support inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). If so, pass in a valid model id instead of using the default for the Agent, like so:
-    ```python
-    agent = Agent(model="anthropic.claude-3-5-sonnet-20241022-v2:0")
-    ```
-
 > For the default Amazon Bedrock model provider, see the [Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) for setting up AWS credentials. Typically for development, AWS credentials are defined in `AWS_` prefixed environment variables or configured with `aws configure`. You will also need to enable Claude 4 Sonnet model access in Amazon Bedrock, following the [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to enable access.
 
 > Different model providers can be configured for agents by following the [quickstart guide](user-guide/quickstart.md#model-providers).
+
+> See [Bedrock troubleshooting](user-guide/concepts/model-providers/amazon-bedrock.md#troubleshooting) if you encounter any issues.
 
 ## Features
 

--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -119,6 +119,10 @@ agent = Agent()
 response = agent("Tell me about Amazon Bedrock.")
 ```
 
+> **Note:** See [Bedrock troubleshooting](amazon-bedrock.md#troubleshooting) if you encounter any issues.
+
+
+
 You can specify which Bedrock model to use by passing in the model ID string directly to the Agent constructor:
 
 ```python
@@ -563,6 +567,24 @@ Use:
 ```
 us.anthropic.claude-sonnet-4-20250514-v1:0
 ```
+
+
+### Model identifier is invalid
+If you encounter the error:
+
+> ValidationException: An error occurred (ValidationException) when calling the ConverseStream operation: The provided model identifier is invalid
+
+This is very likely due to calling Bedrock with an inference model id, such as: `us.anthropic.claude-sonnet-4-20250514-v1:0` from a region that does not [support inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html). If so, pass in a valid model id, as follows:
+```python
+agent = Agent(model="anthropic.claude-3-5-sonnet-20241022-v2:0")
+```
+
+
+!!! note ""
+
+    Strands uses a default Claude 4 Sonnet inference model from the region of your credentials when no model is provided. So if you did not pass in any model id and are getting the above error, it's very likely due to the `region` from the credentials not supporting inference profiles.
+
+
 
 ## Related Resources
 


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
This pull request updates the documentation to clarify how the default model selection works for Amazon Bedrock and provides guidance for troubleshooting region-specific errors. The changes help users understand which model ID will be used based on their AWS region and what to do if their region does not support inference profiles.

## Type of Change
<!-- What kind of change are you making -->
- Content update/revision


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
help with errors

## Areas Affected
<!-- List the pages/sections affected by this PR -->
Home page

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
<img width="3698" height="1838" alt="image" src="https://github.com/user-attachments/assets/ad71609d-75b5-4f8e-af9c-659514644d99" />
<img width="3698" height="1838" alt="image" src="https://github.com/user-attachments/assets/ba4bbee6-4dd8-461f-9dd2-8736e8f9f5a0" />

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
