### PR TITLE
docs(telemetry): add resources and notes for sending traces to CloudWatch

### DIFF
--- a/docs/user-guide/observability-evaluation/traces.md
+++ b/docs/user-guide/observability-evaluation/traces.md
@@ -362,3 +362,9 @@ print(response)
 
 # Each interaction creates a complete trace that can be visualized in your tracing tool
 ```
+
+## Sending traces to CloudWatch X-ray
+There are several ways to send traces, metrics, and logs to CloudWatch. Please visit the following pages for more details and configurations:
+1. [AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter)
+2. [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html)
+  - Please ensure Transaction Search is enabled in CloudWatch.


### PR DESCRIPTION
## Description
Users sometimes face issue with getting traces in CloudWatch X-ray.

Most of the time the issues are fixed after providing the ADOT / CloudWatch documentations. Therefore adding the resources links in the traces section so users can follow the user guide.

## Type of Change
- Content update/revision

## Motivation and Context
Customers sometimes reach out and mention that they are not able to send / view traces in CloudWatch.

## Areas Affected
traces

## Screenshots
N/A

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [ ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
