### PR TITLE
Add Strands MCP server to quickstart

### DIFF
--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -33,6 +33,32 @@ Let's install those development packages too:
 pip install strands-agents-tools strands-agents-builder
 ```
 
+### Strands MCP Server (Optional)
+
+Strands also provides an MCP (Model Context Protocol) server that can assist you during development. This server gives AI coding assistants in your IDE access to Strands documentation, development prompts, and best practices. You can use it with MCP-compatible clients like Q Developer CLI, Cursor, Claude, Cline, and others to help you:
+
+- Develop custom tools and agents with guided prompts
+- Debug and troubleshoot your Strands implementations
+- Get quick answers about Strands concepts and patterns
+- Design multi-agent systems with Graph or Swarm patterns
+
+To use the MCP server, you'll need [uv](https://github.com/astral-sh/uv) installed on your system. You can install it by following the [official installation instructions](https://github.com/astral-sh/uv#installation).
+
+Once uv is installed, configure the MCP server with your preferred client. For example, to use with Q Developer CLI, add to `~/.aws/amazonq/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "strands-agents": {
+      "command": "uvx",
+      "args": ["strands-agents-mcp-server"]
+    }
+  }
+}
+```
+
+See the [MCP server documentation](https://github.com/strands-agents/mcp-server) for setup instructions with other clients.
+
 ## Configuring Credentials
 
 Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with the Claude 4 model.


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description

Add a section for Strands MCP server in quickstart

## Type of Change
- New content addition


## Motivation and Context
We have recently improved the MCP server, and a quick testing showed me that Kiro can answer most of the questions we get with this MCP server. 

Given most of our developers have access to a coding assistant, using our MCP server will improve the DevX, and speed up how fast they can get to prototyping/production.  

## Areas Affected
Quickstart

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
