### PR TITLE
feat: Add documentation for ToolContext.invocation_state

### DIFF
--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -148,7 +148,7 @@ asyncio.run(async_example())
 
 ### ToolContext
 
-Tools can access their execution context by setting `context=True` and including a `tool_context` parameter. The `ToolContext` provides access to the invoking agent and current tool use data:
+Tools can access their execution context by setting `context=True` and including a `tool_context` parameter. The [`ToolContext`](../../../api-reference/types.md#strands.types.tools.ToolContext) provides access to the invoking agent, current tool use data, and invocation state:
 
 ```python
 from strands import tool, Agent, ToolContext
@@ -161,9 +161,15 @@ def get_self_name(tool_context: ToolContext) -> str:
 def get_tool_use_id(tool_context: ToolContext) -> str:
     return f"Tool use is {tool_context.tool_use["toolUseId"]}"
 
-agent = Agent(tools=[get_self_name, get_tool_use_id], name="Best agent")
+@tool(context=True)
+def get_invocation_state(tool_context: ToolContext) -> str:
+    return f"Invocation state: {tool_context.invocation_state["custom_data"]}"
+
+agent = Agent(tools=[get_self_name, get_tool_use_id, get_invocation_state], name="Best agent")
+
 agent("What is your name?")
 agent("What is the tool use id?")
+agent("What is the invocation state?", custom_data="You're the best agent ;)")
 ```
 
 ### Tool Streaming


### PR DESCRIPTION


## Description

Follow-up to strands-agents/sdk-python/pull/761 for sdk-python/issues/579, add documentation detailing how invocation state can be passed and retrieved in decorated tools

## Type of Change
<!-- What kind of change are you making -->
- New content addition


<Enter type of change here>

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
