### PR TITLE
Add usage guidance for structured_output behaviour

### DIFF
--- a/docs/user-guide/concepts/agents/structured-output.md
+++ b/docs/user-guide/concepts/agents/structured-output.md
@@ -52,7 +52,13 @@ class WeatherForecast(BaseModel):
     forecast_days: List[str] = Field(default_factory=list, description="Multi-day forecast")
 ```
 
-Then use the `Agent.structured_output()` method:
+Then use the `Agent.structured_output()` method as shown in the following sections.
+
+> #### Note on Usage
+> Using `structured_ouput` creates a tool with the same name as the Pydantic model you have defined, say - "SomePydanticModel".
+> `agent.structured_output` should be used to re-organize information from the existing conversation (or optional prompt) into the Pydantic model. To do this, `structured_output` expects to invoke only the SomePydanticModel tool. Attempting to use any other tool will result in errors.
+>
+> Note that the prompt attached to the `structured_output` call will not be integrated into the conversation history, therefore `structured_output` should solely be invoked to restructure data from a conversation or from the isolated optional prompt.
 
 ### Basic Usage
 


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
Added usage guidance on a commonly observed misunderstanding about "structured_output". Customers usually expect to be able to use "structured_output" to continue conversations like regular agent prompts, however tool use apart from the Pydantic model tool cause errors 

## Type of Change

- New content addition

## Motivation and Context
Primarily provides more clarity on the intended usage as called out here - 
[309](https://github.com/strands-agents/sdk-python/issues/309#issuecomment-3247471020)

Improves customer expectation for short-term, while changes like https://github.com/strands-agents/sdk-python/issues/891 can potentially solve for long term.

## Areas Affected
Description of structured_output

## Screenshots
<img width="1276" height="390" alt="image" src="https://github.com/user-attachments/assets/1e6c221d-2d57-4443-9640-91dfe6dac136" />



## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
