### PR TITLE
feat: Add example demonstrating sub-tool/agent event propagating

### DIFF
--- a/docs/user-guide/concepts/streaming/overview.md
+++ b/docs/user-guide/concepts/streaming/overview.md
@@ -60,6 +60,136 @@ agent = Agent(callback_handler=handle_events)
 agent("Calculate 2+2")
 ```
 
+## Event Loop Lifecycle Example
+
+This example demonstrates how to track the complete event loop lifecycle using a shared processing function that works with both streaming approaches:
+
+```python
+from strands import Agent
+from strands_tools import calculator
+
+def process_event(event):
+    """Shared event processor for both async iterators and callback handlers"""
+    # Track event loop lifecycle
+    if event.get("init_event_loop", False):
+        print("🔄 Event loop initialized")
+    elif event.get("start_event_loop", False):
+        print("▶️ Event loop cycle starting")
+    elif "message" in event:
+        print(f"📬 New message created: {event['message']['role']}")
+    elif event.get("complete", False):
+        print("✅ Cycle completed")
+    elif event.get("force_stop", False):
+        print(f"🛑 Event loop force-stopped: {event.get('force_stop_reason', 'unknown reason')}")
+
+    # Track tool usage
+    if "current_tool_use" in event and event["current_tool_use"].get("name"):
+        tool_name = event["current_tool_use"]["name"]
+        print(f"🔧 Using tool: {tool_name}")
+
+    # Show text snippets
+    if "data" in event:
+        data_snippet = event["data"][:20] + ("..." if len(event["data"]) > 20 else "")
+        print(f"📟 Text: {data_snippet}")
+```
+        
+Usage with async-iterators:
+
+```python
+agent = Agent(tools=[calculator], callback_handler=None)
+async for event in agent.stream_async("What is the capital of France and what is 42+7?"):
+    process_event(event)
+
+```
+
+Using with callback handlers:
+    
+```python
+def handle_events(**kwargs):
+    process_event(kwargs)
+
+agent = Agent(tools=[calculator], callback_handler=handle_events)
+agent("What is the capital of France and what is 42+7?")
+```
+
+## Sub-Agent Streaming Example
+
+Utilizing both [agents as a tool](../multi-agent/agents-as-tools.md) and [tool streaming](../tools/python-tools.md#tool-streaming), this example shows how to stream events from sub-agents:
+
+```python
+from typing import AsyncIterator
+from dataclasses import dataclass
+from strands import Agent, tool
+from strands_tools import calculator
+
+@dataclass
+class SubAgentResult:
+    agent: Agent
+    event: dict
+
+@tool
+async def math_agent(query: str) -> AsyncIterator:
+    """Solve math problems using the calculator tool."""
+    agent = Agent(
+        name="Math Expert",
+        system_prompt="You are a math expert. Use the calculator tool for calculations.",
+        callback_handler=None,
+        tools=[calculator]
+    )
+    
+    result = None
+    async for event in agent.stream_async(query):
+        yield SubAgentResult(agent=agent, event=event)
+        if "result" in event:
+            result = event["result"]
+    
+    yield str(result)
+
+def process_sub_agent_events(event):
+    """Shared processor for sub-agent streaming events"""
+    tool_stream = event.get("tool_stream_event", {}).get("data")
+    
+    if isinstance(tool_stream, SubAgentResult):
+        current_tool = tool_stream.event.get("current_tool_use", {})
+        tool_name = current_tool.get("name")
+        
+        if tool_name:
+            print(f"Agent '{tool_stream.agent.name}' using tool '{tool_name}'")
+    
+    # Also show regular text output
+    if "data" in event:
+        print(event["data"], end="")
+
+# Using with async iterators
+orchestrator = Agent(
+    system_prompt="Route math questions to the math_agent tool.",
+    callback_handler=None,
+    tools=[math_agent]
+)
+```
+
+Usage with async-iterators:
+
+```python
+async for event in orchestrator.stream_async("What is 3+3?"):
+    process_sub_agent_events(event)
+```
+
+Using with callback handlers:
+    
+```python
+def handle_events(**kwargs):
+    process_sub_agent_events(kwargs)
+
+orchestrator = Agent(
+    system_prompt="Route math questions to the math_agent tool.",
+    callback_handler=handle_events,
+    tools=[math_agent]
+)
+
+orchestrator("What is 3+3?")
+```
+
 ## Next Steps
 
 - Learn about [Async Iterators](async-iterators.md) for asynchronous streaming


### PR DESCRIPTION


<!-- Thank you for contributing to our documentation! -->

## Description

Add two examples to our streaming overview doc:
  1. Lifecycle tracking
  2. Sub-agent streaming

The async-iterator/callback pages also have life-cycle tracking examples, but a practical example needs to live on the overview page.

We've also been asked about sub-agent streaming, so I've also added that as an example that works with both streaming mechanisms

## Type of Change
<!-- What kind of change are you making -->
- New content addition

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

We've been asked about sub-agent event streaming, so added an example to the docs

## Areas Affected

Streaming overview

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

<img width="858" height="984" alt="image" src="https://github.com/user-attachments/assets/ef3da83a-850e-4c79-a19e-81bfbb25a35f" />

<img width="899" height="980" alt="image" src="https://github.com/user-attachments/assets/c75e1937-3341-4a18-afa7-84f0632dcbe6" />


## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
