### PR TITLE
fix: clarify `tool_context` parameter name.

### DIFF
--- a/docs/user-guide/concepts/agents/state.md
+++ b/docs/user-guide/concepts/agents/state.md
@@ -157,7 +157,8 @@ except ValueError as e:
 
 !!! note
 
-    To use `ToolContext` in your tool function, the parameter must exactly be named `tool_context`.
+    To use `ToolContext` in your tool function, the parameter must be named `tool_context`. See [ToolContext documentation](../tools/python-tools.md#toolcontext) for more information.
+
 
 Agent state is particularly useful for maintaining information across tool executions:
 

--- a/docs/user-guide/concepts/tools/python-tools.md
+++ b/docs/user-guide/concepts/tools/python-tools.md
@@ -172,6 +172,20 @@ agent("What is the tool use id?")
 agent("What is the invocation state?", custom_data="You're the best agent ;)")
 ```
 
+To use a different parameter name for ToolContext, specify the desired name as the value of the `@tool.context` argument:
+
+```python
+from strands import tool, Agent, ToolContext
+
+@tool(context="context")
+def get_self_name(context: ToolContext) -> str:
+    return f"The agent name is {context.agent.name}"
+
+agent = Agent(tools=[get_self_name], name="Best agent")
+
+agent("What is your name?")
+```
+
 #### Accessing Invocation State in Tools
 
 The `invocation_state` attribute in `ToolContext` provides access to data passed through the agent invocation. This is particularly useful for:


### PR DESCRIPTION
Provides a clarifying note for [my own issue](https://github.com/strands-agents/sdk-python/issues/1020)
