### PR TITLE
fix: remove 'agentcore in preview' from docs

### DIFF
--- a/docs/user-guide/deploy/deploy_to_bedrock_agentcore.md
+++ b/docs/user-guide/deploy/deploy_to_bedrock_agentcore.md
@@ -3,8 +3,6 @@
 ## What is Amazon Bedrock AgentCore Runtime
 Amazon Bedrock AgentCore Runtime is a secure, serverless runtime purpose-built for deploying and scaling dynamic AI agents and tools using any open-source framework including Strands Agents, LangChain, LangGraph and CrewAI. It supports any protocol such as MCP and A2A, and any model from any provider including Amazon Bedrock, OpenAI, Gemini, etc. Developers can securely and reliably run any type of agent including multi-modal, real-time, or long-running agents. AgentCore Runtime helps protect sensitive data with complete session isolation, providing dedicated microVMs for each user session - critical for AI agents that maintain complex state and perform privileged operations on users' behalf. It is highly reliable with session persistence and it can scale up to thousands of agent sessions in seconds so developers don't have to worry about managing infrastructure and only pay for actual usage. AgentCore Runtime, using AgentCore Identity, also seamlessly integrates with the leading identity providers such as Amazon Cognito, Microsoft Entra ID, and Okta, as well as popular OAuth providers such as Google and GitHub. It supports all authentication methods, from OAuth tokens and API keys to IAM roles, so developers don't have to build custom security infrastructure.
 
-> ⚠️ **Important**: Amazon Bedrock AgentCore is in preview release and is subject to change.
-
 ## Prerequisites
 
 Before you start, you need:
@@ -678,7 +676,6 @@ For more supported headers details, please check [Bedrock AgentCore Runtime Obse
 
 ## Notes
 
-- Amazon Bedrock AgentCore is in preview release and is subject to change.
 - Keep your AgentCore Runtime and Strands packages updated for latest features and security fixes
 
 ## Additional Resources


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
Removed two lines from deploy to agentcore documentation. Agentcore is no longer in preview. 

## Type of Change
<!-- What kind of change are you making -->
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

documentation change

## Motivation and Context
helps users deploy onto agentcore

## Areas Affected
docs/user-guide/deploy/deploy_to_bedrock_agentcore.md
two lines that warned users agentcore are in preview is no longer true


## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
