### PR TITLE
add note in session managment directing users to third-party session …

### DIFF
--- a/docs/user-guide/concepts/agents/session-management.md
+++ b/docs/user-guide/concepts/agents/session-management.md
@@ -12,6 +12,8 @@ A session represents all of the stateful information that is needed by an agent 
 
 Strands provides built-in session persistence capabilities that automatically capture and restore this information, allowing agents to seamlessly continue conversations where they left off.
 
+Beyond the built-in options, [third-party session managers](./#third-party-session-managers) provide additional storage and memory capabilities.
+
 ## Basic Usage
 
 Simply create an agent with a session manager and use it:


### PR DESCRIPTION
…managers


## Description
adding a line in session manager overview to let users know about third party session managers

## Type of Change
<!-- What kind of change are you making -->
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

Documentation

## Motivation and Context
Third party session managers are below but the overview does not let users know it is there. 

## Areas Affected
Session management overview

## Screenshots
<img width="2988" height="1798" alt="image" src="https://github.com/user-attachments/assets/3fded0d0-6012-4381-944d-5cfd4bd628f6" />

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [ ] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
