### PR TITLE
refactor: Update hook docs with cookbook section + adding example for tool count limiter

### DIFF
--- a/docs/user-guide/concepts/agents/hooks.md
+++ b/docs/user-guide/concepts/agents/hooks.md
@@ -307,6 +307,7 @@ Useful for preventing runaway tool usage, implementing rate limiting, or enforci
 ```python
 from strands import tool
 from strands.hooks import HookRegistry, HookProvider, BeforeToolCallEvent, BeforeInvocationEvent
+from threading import Lock
 
 class LimitToolCounts(HookProvider):
     """Limits the number of times tools can be called per agent invocation"""
@@ -322,30 +323,28 @@ class LimitToolCounts(HookProvider):
         """
         self.max_tool_counts = max_tool_counts
         self.tool_counts = {}
+        self._lock = Lock()
 
     def register_hooks(self, registry: HookRegistry) -> None:
         registry.add_callback(BeforeInvocationEvent, self.reset_counts)
         registry.add_callback(BeforeToolCallEvent, self.intercept_tool)
 
     def reset_counts(self, event: BeforeInvocationEvent) -> None:
-        self.tool_counts = {}
+        with self._lock:
+            self.tool_counts = {}
 
     def intercept_tool(self, event: BeforeToolCallEvent) -> None:
         tool_name = event.tool_use["name"]
-        tool_count = self.tool_counts.setdefault(tool_name, 0) + 1
-        self.tool_counts[tool_name] = tool_count
+        with self._lock:
+            max_tool_count = self.max_tool_counts.get(tool_name)
+            tool_count = self.tool_counts.get(tool_name, 0) + 1
+            self.tool_counts[tool_name] = tool_count
 
-        if tool_name in self.max_tool_counts and tool_count > self.max_tool_counts[tool_name]:
-            @tool
-            def report_max_tool_use(**kwargs) -> dict:
-                error_message = (
-                    f"Tool '{tool_name}' has been invoked too many and is now being throttled. "
-                    f"DO NOT CALL THIS TOOL ANYMORE "
-                )
-
-                raise SystemError(error_message)
-
-            event.selected_tool = report_max_tool_use
+        if max_tool_count and tool_count > max_tool_count:
+            event.cancel_tool = (
+                f"Tool '{tool_name}' has been invoked too many and is now being throttled. "
+                f"DO NOT CALL THIS TOOL ANYMORE "
+            )
 ```
 
 For example, to limit the `sleep` tool to 3 invocations per invocation:


### PR DESCRIPTION
## Description

Add a cookbook section with useful hook examples including:
  1. Fixed tool arguments
  2. Limiting the # of times a tool can be called

The first example already existed but the second example is new but also requested by users

## Notes

I'm not entirely convinced the Cookbook makes sense, but I don't want to bloat out the main content of the page with a bunch of examples - open to ideas/revision though.

 When we have the site-revamp, I'd like to have a dedicated CookBook/Recipes top level section where all of the examples would be instead. 

## Type of Change
<!-- What kind of change are you making -->

- Content update/revision

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

People have asked for examples of this + a cookbook section makes more sense than bloating out the entire page.

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
