### PR TITLE
fix: fix github workflow error

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,4 +41,4 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--base . --cache --max-cache-age 1d ."
+          args: "--base ${{ github.workspace }} --cache --max-cache-age 1d ."


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->

In our doc workflow, we have this error:
```
Run /home/runner/work/_actions/lycheeverse/lychee-action/v2/entrypoint.sh
error: invalid value '.' for '--base <BASE>': Error with base dir `.` : Base must either be a URL (with scheme) or an absolute local path. See `--help` for more information. If you want to resolve root-relative links in local files, also see `--root-dir`.
```

Update to use an absolute path ${{ github.workspace }} variable to provide the absolute path the repository in the GitHub runner environment.

## Type of Change
<!-- What kind of change are you making -->
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Areas Affected
<!-- List the pages/sections affected by this PR -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working
- [ ] Images/diagrams are properly sized and formatted
- [ ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
