### PR TITLE
feat(bedrock): add docs for SystemContentBlock caching approach

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -349,10 +349,7 @@ system_content = [
              "This is a long system prompt with detailed instructions..."
              "..." * 1600  # needs to be at least 1,024 tokens
     ),
-    SystemContentBlock(cachePoint={"type": "default"}),
-    SystemContentBlock(
-        text="Additional instructions that will be cached together."
-    )
+    SystemContentBlock(cachePoint={"type": "default"})
 ]
 
 # Create an agent with SystemContentBlock array


### PR DESCRIPTION

## Description

This is the followup to feat(models): add SystemContentBlock support for provider-agnostic caching https://github.com/strands-agents/sdk-python/pull/1112. It includes documentation to describe the new approach.

After https://github.com/strands-agents/sdk-python/pull/1141 is merged, we will update the LiteLLM section. Then after that as we begin progressing on `[FEATURE] Prompt caching support for all models` https://github.com/strands-agents/sdk-python/issues/1140 we will update docs to provide a general caching section


## Type of Change
- Content update/revision



## Motivation and Context

https://github.com/strands-agents/sdk-python/pull/1112

## Areas Affected
http://127.0.0.1:8000/user-guide/concepts/model-providers/amazon-bedrock/#caching

## Screenshots
<img width="780" height="1158" alt="image" src="https://github.com/user-attachments/assets/d7f94451-1a3c-49b1-87bf-99e3eaf1aaa3" />

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
