### PR TITLE
Replace hardcoded model IDs with Agent() defaults

### DIFF
--- a/docs/user-guide/concepts/agents/conversation-management.md
+++ b/docs/user-guide/concepts/agents/conversation-management.md
@@ -153,7 +153,7 @@ summarization_model = AnthropicModel(
     max_tokens=1000,
     params={"temperature": 0.1}  # Low temperature for consistent summaries
 )
-custom_summarization_agent = Agent(model=summarization_model)
+custom_summarization_agent = Agent()
 
 conversation_manager = SummarizingConversationManager(
     summary_ratio=0.4,

--- a/docs/user-guide/observability-evaluation/evaluation.md
+++ b/docs/user-guide/observability-evaluation/evaluation.md
@@ -68,7 +68,6 @@ from strands_tools import calculator
 
 # Create agent with specific configuration
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
     system_prompt="You are a helpful assistant specialized in data analysis.",
     tools=[calculator]
 )
@@ -94,7 +93,7 @@ with open("test_cases.json", "r") as f:
     test_cases = json.load(f)
 
 # Create agent
-agent = Agent(model="us.anthropic.claude-sonnet-4-20250514-v1:0")
+agent = Agent()
 
 # Run tests and collect results
 results = []
@@ -134,11 +133,10 @@ from strands import Agent
 import json
 
 # Create the agent to evaluate
-agent = Agent(model="anthropic.claude-3-5-sonnet-20241022-v2:0")
+agent = Agent()
 
 # Create an evaluator agent with a stronger model
 evaluator = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
     system_prompt="""
     You are an expert AI evaluator. Your job is to assess the quality of AI responses based on:
     1. Accuracy - factual correctness of the response
@@ -199,7 +197,6 @@ from strands import Agent
 from strands_tools import calculator, file_read, current_time
 # Create agent with multiple tools
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
     tools=[calculator, file_read, current_time],
     record_direct_tool_call = True
 )
@@ -322,12 +319,10 @@ class AgentEvaluator:
 if __name__ == "__main__":
     # Create agents with different configurations
     agent1 = Agent(
-        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
         system_prompt="You are a helpful assistant."
     )
 
     agent2 = Agent(
-        model="anthropic.claude-3-5-haiku-20241022-v1:0",
         system_prompt="You are a helpful assistant."
     )
 

--- a/docs/user-guide/observability-evaluation/logs.md
+++ b/docs/user-guide/observability-evaluation/logs.md
@@ -159,7 +159,6 @@ The callback system is configured through the `callback_handler` parameter when 
 from strands.handlers.callback_handler import PrintingCallbackHandler
 
 agent = Agent(
-    model="anthropic.claude-3-sonnet-20240229-v1:0",
     callback_handler=PrintingCallbackHandler()
 )
 ```

--- a/docs/user-guide/observability-evaluation/traces.md
+++ b/docs/user-guide/observability-evaluation/traces.md
@@ -110,7 +110,6 @@ from strands import Agent
 # Option 1: Skip StrandsTelemetry if global tracer provider and/or meter provider are already configured
 # (your existing OpenTelemetry setup will be used automatically)
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
     system_prompt="You are a helpful AI assistant"
 )
 
@@ -135,7 +134,6 @@ strands_telemetry.setup_otlp_exporter().setup_console_exporter()  # Chaining sup
 
 # Create agent (tracing will be enabled automatically)
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
     system_prompt="You are a helpful AI assistant"
 )
 
@@ -374,7 +372,6 @@ strands_telemetry.setup_console_exporter()   # Print traces to console
 
 # Create agent
 agent = Agent(
-    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
     system_prompt="You are a helpful AI assistant"
 )
 


### PR DESCRIPTION
Remove specific model IDs from basic examples in evaluation, traces, logs, and conversation-management docs
- Use Agent() with no model parameter to leverage Strands built-in defaults
- Reduces maintenance burden when model IDs change
- Keeps model-specific examples only where demonstrating model configuration

Fixes issue strands-agents/sdk-python#2573 
Files changed 
  evaluation.md: 6 instances → Agent()
  • traces.md: 3 instances → Agent()  
  • logs.md: 1 instance → Agent()
  • conversation-management.md: 1 instance → Agent()
 and removed model id parameters 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.