### PR TITLE
Add OVHcloud AI Endpoints documentation

### DIFF
--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -29,6 +29,9 @@
 ::: strands.models.openai
     options:
       heading_level: 2
+::: strands.models.ovhcloud
+    options:
+      heading_level: 2
 ::: strands.models.writer
     options:
       heading_level: 2

--- a/docs/user-guide/concepts/model-providers/ovhcloud.md
+++ b/docs/user-guide/concepts/model-providers/ovhcloud.md
@@ -1,0 +1,97 @@
+# OVHcloud AI Endpoints
+
+[OVHcloud AI Endpoints](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/) provides access to a variety of AI models through OpenAI-compatible API endpoints. 
+
+OVHcloud is a French Cloud Provider, leading in Europe. Our key values are data sovereignty and privacy, while being GDPR compliant. Your data will never be used to train or improve our AI models; this is one of our many security guarantees.
+
+## Installation
+
+The Strands Agents SDK provides access to OVHcloud AI Endpoints models through our custom model. To install, run:
+
+```bash
+pip install 'strands-agents[ovhcloud]' strands-agents-tools
+```
+
+## Usage
+
+After installing the `ovhcloud` package, you can import and initialize OVHcloud AI Endpoints provider as follows:
+
+```python
+from strands import Agent
+from strands.models.ovhcloud import OpenAIModel
+from strands_tools import calculator
+
+model = OVHcloudModel(
+    client_args={
+        "api_key": "<OVHCLOUD_API_KEY>",  # Optional: can be empty string or omitted for free tier
+    },
+    model_id="<MODEL_ID>",  # See https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/
+    params={
+        "max_tokens": 1000,
+        "temperature": 0.7,
+    }
+)
+
+agent = Agent(model=model, tools=[calculator])
+agent("What is 2+2?")
+```
+
+### Free Tier Usage
+
+OVHcloud AI Endpoints can be used for free with rate limits if you don't provide an API key or provide an empty string:
+
+```python
+model = OpenAIModel(
+    client_args={
+        "api_key": "",  # Empty string for free tier
+    },
+    model_id="<MODEL_ID>",
+)
+```
+
+## Configuration
+
+### Client Configuration
+
+The `client_args` configure the underlying client. When using OVHcloud AI Endpoints, you must set:
+
+* `api_key`: Your OVHcloud AI Endpoints API key (optional for free tier). To generate an API key:
+  1. Go to [OVHcloud Manager](https://ovh.com/manager)
+  2. Navigate to **Public Cloud** section
+  3. Select **AI & Machine Learning** → **AI Endpoints and API keys**
+  4. Create a new API key
+
+### Model Configuration
+
+The `model_config` specifies which OVHcloud AI Endpoints model to use and any additional parameters.
+
+| Parameter  | Description               | Example                                                           | Options                                                            |
+| ---------- | ------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `model_id` | Model name                | Varies by model                                                   | See [OVHcloud AI Endpoints Catalog](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/) |
+| `params`   | Model-specific parameters | `{"max_tokens": 1000, "temperature": 0.7, "top_p": 0.9}`         | Standard OpenAI API parameters                                     |
+
+## Troubleshooting
+
+### `ModuleNotFoundError: No module named 'ovhcloud'`
+
+You must install the `ovhcloud` dependency to use this provider:
+
+```bash
+pip install 'strands-agents[ovhcloud]'
+```
+
+### Unexpected model behavior?
+
+Ensure you're using a valid model ID from the [OVHcloud AI Endpoints Catalog](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/). We are available on [Discord](https://discord.gg/ovhcloud) in the `#ai-endpoints` channel to help you with any issues!
+
+### Rate limiting on free tier
+
+If you're using the free tier (no API key or empty string), you may encounter rate limits. To remove rate limits, generate an API key from the OVHcloud Manager and use it in the `client_args`.
+
+## References
+
+* [OVHcloud AI Endpoints](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/)
+* [OVHcloud AI Endpoints Catalog](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/catalog/)
+* [OVHcloud Manager](https://ovh.com/manager)
+* [Strands Agents API](../../../api-reference/models.md)
+

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -441,6 +441,7 @@ Strands Agents supports several other model providers beyond Amazon Bedrock:
 - **[Mistral](concepts/model-providers/mistral.md)** - Access to Mistral models
 - **[Ollama](concepts/model-providers/ollama.md)** - Run models locally for privacy or offline use
 - **[OpenAI](concepts/model-providers/openai.md)** - Access to OpenAI or OpenAI-compatible models
+- **[OVHcloud AI Endpoints](concepts/model-providers/ovhcloud.md)** - European Cloud provider with sovereignty, data privacy and GDPR compliant
 - **[Writer](concepts/model-providers/writer.md)** - Access to Palmyra models
 - **[Cohere <sup> community</sup>](../community/model-providers/cohere.md)** - Use Cohere models through an OpenAI compatible interface
 - **[CLOVA Studio<sup> community</sup>](../community/model-providers/clova-studio.md)** - Korean-optimized AI models from Naver Cloud Platform

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
         - LlamaAPI: user-guide/concepts/model-providers/llamaapi.md
         - MistralAI: user-guide/concepts/model-providers/mistral.md
         - Ollama: user-guide/concepts/model-providers/ollama.md
+        - OVHcloud AI Endpoints: user-guide/concepts/model-providers/ovhcloud.md
         - OpenAI: user-guide/concepts/model-providers/openai.md
         - SageMaker: user-guide/concepts/model-providers/sagemaker.md
         - Writer: user-guide/concepts/model-providers/writer.md


### PR DESCRIPTION

## Description
This PR introduces the documentation for the integration of OVHcloud AI Endpoints inference provider. It follows the PR done in the python-sdk repository: https://github.com/strands-agents/sdk-python/pull/1172

## Type of Change
- New content addition
- Content update

## Motivation and Context
This PR is needed for the introduction of the new model OVHcloud AI Endpoints, to guide user on how to use it.

## Areas Affected

- user-guide/concepts/model-providers/ovhcloud
- api-reference/models/#strands.models.ovhcloud
- user-guide/quickstart/#model-providers

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
