### PR TITLE
fix: Update community contributions messaging

### DIFF
--- a/docs/community/community-packages.md
+++ b/docs/community/community-packages.md
@@ -1,6 +1,6 @@
 # Community Packages
 
-The Strands Agents ecosystem is built on community contributions that extend agent capabilities through custom tools and integrations. If you've built a useful extension for Strands Agents that solves a common problem or integrates with popular services, packaging it for distribution allows other developers to benefit from your work.
+The Strands Agents SDK is built on community contributions that extend agent capabilities through custom tools and integrations. If you've built a useful extension for Strands Agents that solves a common problem or integrates with popular services, packaging it for distribution allows other developers to benefit from your work.
 
 ## Creating A Package
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -231,7 +231,10 @@ extra:
   link_strands_builder: "[`strands-agents-builder`](https://github.com/strands-agents/agent-builder)"
   community_contribution_banner: |
     !!! info "Community Contribution"
-        This is a community contribution. Have your own integration? [We'd love to add it here too!](https://github.com/strands-agents/docs/issues/new?assignees=&labels=enhancement&projects=&template=content_addition.yml&title=%5BContent+Addition%5D%3A+)
+        This is a community-maintained package that is not owned or supported by the Strands team. Validate and review 
+        the package before using it in your project.
+        
+        Have your own integration? [We'd love to add it here too!](https://github.com/strands-agents/docs/issues/new?assignees=&labels=enhancement&projects=&template=content_addition.yml&title=%5BContent+Addition%5D%3A+)
 
 validation:
   nav:


### PR DESCRIPTION
## Description

Updating the community contributions messages based on  internal feedback.

 - Remove "ecosystem"
 - Add indicator that integrations should vet the package themselves

## Type of Change
<!-- What kind of change are you making -->

- Content update/revision
<Enter type of change here>

## Screenshots

<img width="868" height="177" alt="image" src="https://github.com/user-attachments/assets/8e00e48f-03c1-436e-a3d1-8dc778d12725" />

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
