### PR TITLE
security(tool_loader): add note about shared responsiblity in auto tool loading

### DIFF
--- a/docs/user-guide/concepts/tools/tools_overview.md
+++ b/docs/user-guide/concepts/tools/tools_overview.md
@@ -52,6 +52,9 @@ from strands import Agent
 agent = Agent(load_tools_from_directory=True)
 ```
 
+!!! note "Tool Loading Implications"
+    When enabling automatic tool loading, any Python file placed in the `./tools/` directory will be executed by the agent. Under the shared responsibility model, it is your responsibility to ensure that only safe, trusted code is written to the tool loading directory, as the agent will automatically pick up and execute any tools found there.
+
 ## Using Tools
 
 Tools can be invoked in two primary ways.


### PR DESCRIPTION
## Description

This PR adds a note to the Auto tool loading section to explicitly comment on the auto loading shared responsibility model.

## Type of Change
- Content update/revision

## Areas Affected

user-guide/concepts/tools/tools_overview/#auto-loading-and-reloading-tools

## Screenshots

<img width="848" height="465" alt="image" src="https://github.com/user-attachments/assets/06734dfc-f6c9-4b19-a405-34aa84286594" />


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
