### PR TITLE
fix: Add Amazon Nova to Community Sidebar

### DIFF
--- a/docs/community/model-providers/amazon-nova.md
+++ b/docs/community/model-providers/amazon-nova.md
@@ -1,5 +1,7 @@
 # Amazon Nova
 
+{{ community_contribution_banner }}
+
 [Amazon Nova](https://nova.amazon.com/) is a new generation of foundation models with frontier intelligence and industry leading price performance. Generate text, code, and images with natural language prompts. The [`strands-amazon-nova`](https://pypi.org/project/strands-amazon-nova/) package ([GitHub](https://github.com/amazon-nova-api/strands-nova)) provides an integration for the Strands Agents SDK, enabling seamless use of Amazon Nova models.
 
 ## Installation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
       - Tools:
         - UTCP: community/tools/utcp.md
       - Model Providers:
+        - Amazon Nova: community/model-providers/amazon-nova.md
         - Cohere: community/model-providers/cohere.md
         - CLOVA Studio: community/model-providers/clova-studio.md
         - Fireworks AI: community/model-providers/fireworksai.md


### PR DESCRIPTION
Quick follow up to #347

Add Amazon Nova to Community Sidebar + add community macro to the top of the page

-----

