### PR TITLE
Don't include the version in the API Docs

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -11,7 +11,7 @@
   "hideGenerator": true,
   "sort": ["source-order"],
   "excludePrivate": true,
-  "includeVersion": true,
+  "includeVersion": false,
   "navigation": true,
   "navigationLinks": {
     "Docs Home": "/",


### PR DESCRIPTION
And isn't valid in source code, so don't include it in the build

Notice that the current version is incorrect: https://strandsagents.com/latest/documentation/docs/api-reference/typescript/