### PR TITLE
mcp - elicitation - use elicit method

### DIFF
--- a/docs/user-guide/concepts/experimental/bidirectional-streaming/events.md
+++ b/docs/user-guide/concepts/experimental/bidirectional-streaming/events.md
@@ -314,8 +314,6 @@ async for event in agent.receive():
 !!! note "BidiInterruptionEvent vs Human-in-the-Loop Interrupts"
     `BidiInterruptionEvent` is different from [human-in-the-loop (HIL) interrupts](../../interrupts.md). BidiInterruptionEvent is emitted when the model detects user speech during audio conversations and automatically stops generating the current response. HIL interrupts pause agent execution to request human approval or input before continuing, typically used for tool execution approval. BidiInterruptionEvent is automatic and audio-specific, while HIL interrupts are programmatic and require explicit handling.
 
-See [Interruptions](agent.md#interruptions) for more details on interruption handling.
-
 ### Tool Events
 
 Events for tool execution during conversations. Bidirectional streaming reuses the standard `ToolUseStreamEvent` from Strands.


### PR DESCRIPTION
## Description
Similar to what was done in https://github.com/strands-agents/sdk-python/pull/1281, I am updating our MCP elicitation example to use the new `elicit` method for actually sending the elicitation request from server to client. The current approach documented is now broken because of a recent update in the MCP python sdk ([commit](https://github.com/modelcontextprotocol/python-sdk/commit/02b78899296ce3631565345501e3d956b83ffe94)).

## Type of Change
- Content update/revision

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
