### PR TITLE
mcp-tools.md: Add missing backticks

### DIFF
--- a/docs/user-guide/concepts/tools/mcp-tools.md
+++ b/docs/user-guide/concepts/tools/mcp-tools.md
@@ -153,6 +153,7 @@ For HTTP-based MCP servers that use Streamable HTTP transport:
     streamable_http_mcp_client = MCPClient(
         lambda: streamablehttp_client("http://localhost:8000/mcp")
     )
+    ```
 
 #### AWS IAM
 


### PR DESCRIPTION
Python code block is missing backticks, leading to improper rendering. This fixes it.

## Description
Python code block is missing backticks, leading to improper rendering. This fixes it.

## Type of Change
- Typo/formatting fix

## Motivation and Context
Improves display of Python code block

## Areas Affected
https://strandsagents.com/latest/documentation/docs/user-guide/concepts/tools/mcp-tools/#streamable-http

## Screenshots
Before:
<img width="759" height="332" alt="image" src="https://github.com/user-attachments/assets/d00187e5-721e-43aa-9874-82e79095d6cc" />

After:

<img width="782" height="301" alt="image" src="https://github.com/user-attachments/assets/a5ba564e-0129-4fa8-9f68-aceb910757ad" />


## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
