### PR TITLE
docs(quickstart): add feature availability matrix

### DIFF
--- a/docs/user-guide/quickstart/overview.md
+++ b/docs/user-guide/quickstart/overview.md
@@ -21,63 +21,36 @@ Create your first TypeScript Strands agent!
 
 ---
 
-
-## Language Support
+## Language support
 
 Strands Agents SDK is available in both Python and TypeScript. The Python SDK is mature and production-ready with comprehensive feature coverage. The TypeScript SDK is experimental and focuses on core agent functionality.
 
-### Feature Availability Matrix
+### Feature availability
 
-The table below shows feature availability across both SDKs. Python is the primary SDK with complete feature coverage, while TypeScript provides essential agent capabilities with ongoing development.
+The table below compares feature availability between the Python and TypeScript SDKs.
 
-| Feature Category | Feature | Python | TypeScript | Notes |
-|------------------|---------|--------|------------|-------|
-| **Core Agent** | Basic agent creation | ✅ | ✅ | |
-| | Agent invocation | ✅ | ✅ | |
-| | Streaming responses | ✅ | ✅ | |
-| | Agent state management | ✅ | ✅ | |
-| | Structured output | ✅ | ❌ | TypeScript support planned |
-| **Model Providers** | Amazon Bedrock | ✅ | ✅ | |
-| | OpenAI | ✅ | ✅ | |
-| | Anthropic | ✅ | ❌ | |
-| | Google Gemini | ✅ | ❌ | |
-| | LiteLLM | ✅ | ❌ | |
-| | Ollama | ✅ | ❌ | |
-| | Mistral | ✅ | ❌ | |
-| | Llama API | ✅ | ❌ | |
-| | SageMaker | ✅ | ❌ | |
-| | Writer | ✅ | ❌ | |
-| | Custom providers | ✅ | ❌ | |
-| **Tools & Extensions** | Custom function tools | ✅ | ✅ | |
-| | MCP (Model Context Protocol) | ✅ | ✅ | |
-| | Built-in vended tools | Community package | 4 built-in tools | bash, file_editor, http_request, notebook |
-| | Tool executors (sequential/concurrent) | ✅ | ❌ | |
-| | Hot tool reloading | ✅ | ❌ | |
-| | Automatic tool loading | ✅ | ❌ | |
-| **Conversation Management** | Null conversation manager | ✅ | ✅ | |
-| | Sliding window manager | ✅ | ✅ | |
-| | Summarizing conversation manager | ✅ | ❌ | |
-| **Multi-Agent Patterns** | Agent swarm | ✅ | ❌ | |
-| | Agent workflows | ✅ | ❌ | |
-| | Agent graphs | ✅ | ❌ | |
-| | Agent-to-agent communication | ✅ | ❌ | |
-| | Agents as tools | ✅ | ❌ | |
-| **Session Management** | File session manager | ✅ | ❌ | |
-| | S3 session manager | ✅ | ❌ | |
-| | Repository session manager | ✅ | ❌ | |
-| | Custom session managers | ✅ | ❌ | |
-| **Observability** | OpenTelemetry traces | ✅ | ❌ | |
-| | Metrics collection | ✅ | ❌ | |
-| | Custom telemetry | ✅ | ❌ | |
-| **Hooks & Lifecycle** | Agent lifecycle hooks | ✅ | ✅ | |
-| | Custom hook providers | ✅ | ✅ | |
-| | Multi-agent hooks | ✅ | ❌ | Experimental in Python |
-| **Experimental Features** | Bidirectional streaming | ✅ | ❌ | Real-time voice/audio agents |
-| | Agent steering | ✅ | ❌ | Dynamic behavior modification |
-| | Agent configuration | ✅ | ❌ | Runtime configuration management |
-| **Interrupts & Control** | Agent interrupts | ✅ | ❌ | Graceful stopping and resumption |
-| | Context overflow handling | ✅ | ❌ | |
-| **Development Tools** | Debug logging | ✅ | ✅ | |
-| | Agent builder | ✅ | ❌ | AI-powered agent generation |
-| | Community tools package | ✅ | ❌ | 30+ production-ready tools |
-
+| Category | Feature | Python | TypeScript |
+|----------|---------|:------:|:----------:|
+| **Core** | Agent creation and invocation | ✅ | ✅ |
+| | Streaming responses | ✅ | ✅ |
+| | Structured output | ✅ | ❌ |
+| **Model providers** | Amazon Bedrock | ✅ | ✅ |
+| | OpenAI | ✅ | ✅ |
+| | Anthropic | ✅ | ❌ |
+| | Ollama | ✅ | ❌ |
+| | LiteLLM | ✅ | ❌ |
+| | Custom providers | ✅ | ✅ |
+| **Tools** | Custom function tools | ✅ | ✅ |
+| | MCP (Model Context Protocol) | ✅ | ✅ |
+| | Built-in tools | 30+ via community package | 4 built-in |
+| **Conversation** | Null manager | ✅ | ✅ |
+| | Sliding window manager | ✅ | ✅ |
+| | Summarizing manager | ✅ | ❌ |
+| **Hooks** | Lifecycle hooks | ✅ | ✅ |
+| | Custom hook providers | ✅ | ✅ |
+| **Multi-agent** | Swarms, workflows, graphs | ✅ | ❌ |
+| | Agents as tools | ✅ | ❌ |
+| **Session management** | File, S3, repository managers | ✅ | ❌ |
+| **Observability** | OpenTelemetry integration | ✅ | ❌ |
+| **Experimental** | Bidirectional streaming | ✅ | ❌ |
+| | Agent steering | ✅ | ❌ |


### PR DESCRIPTION
## Description
Adding a feature availability matrix to compare Python vs TypeScript easily.

## Type of Change
- New content addition

## Motivation and Context
We need an overview of features, because right now the availability tags are inside each page. So a developer that wants to compare the two languages would need to traverse everything. 

## Areas Affected
Quickstart


## Screenshots

<img width="974" height="1146" alt="Screenshot 2025-12-11 at 16 46 38" src="https://github.com/user-attachments/assets/1cd1dc24-4683-49cc-8dfe-6d78def2b5f3" />

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
