### PR TITLE
docs: add installation sections to bidi model providers

### DIFF
--- a/docs/user-guide/concepts/experimental/bidirectional-streaming/models/gemini_live.md
+++ b/docs/user-guide/concepts/experimental/bidirectional-streaming/models/gemini_live.md
@@ -11,7 +11,25 @@ The [Gemini Live API](https://ai.google.dev/gemini-api/docs/live) lets developer
 - **Session Management**: Supports managing long conversations through sessions, providing context and continuity.
 - **Secure Authentication**: Uses tokens for secure client-side authentication. 
 
+## Installation
+
+Gemini Live is configured as an optional dependency in Strands Agents. 
+
+To install it, run:
+
+```bash
+pip install 'strands-agents[bidi-gemini]'
+```
+
+Or to install all bidirectional streaming providers at once:
+
+```bash
+pip install 'strands-agents[bidi-all]'
+```
+
 ## Usage
+
+After installing `strands-agents[bidi-gemini]`, you can import and initialize the Strands Agents' Gemini Live provider as follows:
 
 ```Python
 import asyncio
@@ -64,6 +82,16 @@ For the list of supported voices and languages, see [here](https://docs.cloud.go
 ## Session Management
 
 Currently, `BidiGeminiLiveModel` does not produce a message history and so has limited compatability with the Strands [session manager](../session-management.md). However, the provider does utilize Gemini's [Session Resumption](https://ai.google.dev/gemini-api/docs/live-session) as part of the [connection restart](../agent.md#connection-restart) workflow. This allows Gemini Live connections to persist up to 24 hours. After this time limit, a new `BidiGeminiLiveModel` instance must be created to continue conversations.
+
+## Troubleshooting
+
+### Module Not Found
+
+If you encounter the error `ModuleNotFoundError: No module named 'google.genai'`, this means the `google-genai` dependency hasn't been properly installed in your environment. To fix this, run `pip install 'strands-agents[bidi-gemini]'`.
+
+### API Key Issues
+
+Make sure your Google AI API key is properly set in `client_config` or as the `GOOGLE_API_KEY` environment variable. You can obtain an API key from the [Google AI Studio](https://aistudio.google.com/app/apikey).
 
 ## References
 

--- a/docs/user-guide/concepts/experimental/bidirectional-streaming/models/nova_sonic.md
+++ b/docs/user-guide/concepts/experimental/bidirectional-streaming/models/nova_sonic.md
@@ -11,7 +11,25 @@
 - Multilingual support with expressive voices and speaking styles. Expressive voices are offered, including both masculine-sounding and feminine sounding, in five languages: English (US, UK), French, Italian, German, and Spanish.
 - Recognition of varied speaking styles across all supported languages.
 
+## Installation
+
+Nova Sonic is included in the base bidirectional streaming dependencies for Strands Agents.
+
+To install it, run:
+
+```bash
+pip install 'strands-agents[bidi]'
+```
+
+Or to install all bidirectional streaming providers at once:
+
+```bash
+pip install 'strands-agents[bidi-all]'
+```
+
 ## Usage
+
+After installing `strands-agents[bidi]`, you can import and initialize the Strands Agents' Nova Sonic provider as follows:
 
 ```Python
 import asyncio
@@ -97,6 +115,13 @@ For more details on this approach, please refer to the [boto3 session docs](http
 | `inference` | Session start `inferenceConfiguration`'s (as snake_case). | `{"top_p": 0.9}` | [reference](https://docs.aws.amazon.com/nova/latest/userguide/input-events.html)
 
 ## Troubleshooting
+
+### Module Not Found
+
+If you encounter the error `ModuleNotFoundError: No module named 'aws_sdk_bedrock_runtime'`, this means the experimental Bedrock runtime dependency hasn't been properly installed in your environment. To fix this, run `pip install 'strands-agents[bidi]'`.
+
+!!! note "Python Version Requirement"
+    Nova Sonic requires Python 3.12+ due to the experimental AWS SDK dependency. If you're using an older Python version, you'll need to upgrade.
 
 ### Hanging
 

--- a/docs/user-guide/concepts/experimental/bidirectional-streaming/models/openai_realtime.md
+++ b/docs/user-guide/concepts/experimental/bidirectional-streaming/models/openai_realtime.md
@@ -10,7 +10,25 @@ The [OpenAI Realtime API](https://platform.openai.com/docs/guides/realtime) is a
 - **Tool Use and Function Calling**: Can use external tools to perform actions and get context while maintaining a real-time connection.
 - **Secure Authentication**: Uses tokens for secure client-side authentication. 
 
+## Installation
+
+OpenAI Realtime is configured as an optional dependency in Strands Agents.
+
+To install it, run:
+
+```bash
+pip install 'strands-agents[bidi-openai]'
+```
+
+Or to install all bidirectional streaming providers at once:
+
+```bash
+pip install 'strands-agents[bidi-all]'
+```
+
 ## Usage
+
+After installing `strands-agents[bidi-openai]`, you can import and initialize the Strands Agents' OpenAI Realtime provider as follows:
 
 ```Python
 import asyncio
@@ -64,6 +82,16 @@ if __name__ == "__main__":
 | `inference` | Dict of inference fields supported in the OpenAI `session.update` event. | `{"max_output_tokens": 4096}` | [reference](https://platform.openai.com/docs/api-reference/realtime-client-events/session/update)
 
 For the list of supported voices, see [here](https://platform.openai.com/docs/guides/realtime-conversations#voice-options).
+
+## Troubleshooting
+
+### Module Not Found
+
+If you encounter the error `ModuleNotFoundError: No module named 'websockets'`, this means the WebSocket dependency hasn't been properly installed in your environment. To fix this, run `pip install 'strands-agents[bidi-openai]'`.
+
+### Authentication Errors
+
+Ensure your OpenAI API key is properly configured. Set the `OPENAI_API_KEY` environment variable or pass it via the `api_key` parameter in the `client_config`.
 
 ## References
 


### PR DESCRIPTION
Updates documentation for bidirectional streaming model providers to follow the same format as regular model providers.

- Add installation sections to Gemini Live, Nova Sonic, and OpenAI Realtime pages
- Include proper package installation instructions with bidi-specific extras
- Add troubleshooting sections with module not found errors
- Update usage sections to reference installation prerequisites
- Follow same format as regular model providers (like Gemini)

<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
- New content addition

## Motivation and Context
Missing content

## Areas Affected
Bidirectional

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
