### PR TITLE
fix(docs): correct spelling in structured output example and update p…

### DIFF
--- a/docs/user-guide/concepts/agents/structured-output.md
+++ b/docs/user-guide/concepts/agents/structured-output.md
@@ -221,7 +221,7 @@ Stream structured output progressively while maintaining type safety and validat
         if "data" in event:
             print(event["data"], end="", flush=True)
         elif "result" in event:
-            print(f'The forcast for today is: {event["result"].structured_output}')
+            print(f'The forecast for today is: {event["result"].structured_output}')
     ```
 
 {{ ts_not_supported_code() }}

--- a/docs/user-guide/deploy/deploy_to_bedrock_agentcore/python.md
+++ b/docs/user-guide/deploy/deploy_to_bedrock_agentcore/python.md
@@ -277,7 +277,7 @@ Create Project
 ```bash
 mkdir my-custom-agent && cd my-custom-agent
 uv init --python 3.11
-uv add fastapi uvicorn[standard] pydantic httpx strands-agents
+uv add fastapi 'uvicorn[standard]' pydantic httpx strands-agents
 ```
 
 Project Structure example


### PR DESCRIPTION
…ackage installation command format

- Fixed the spelling of "forecast" in the structured output example.
- Updated the installation command in the Bedrock AgentCore Python deployment guide to use quotes for the 'uvicorn[standard]' package.

<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- What kind of change are you making -->
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

<Enter type of change here>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Areas Affected
<!-- List the pages/sections affected by this PR -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
