### PR TITLE
update Eval SOP direct agent example to support multi-turn interaction

### DIFF
--- a/docs/user-guide/evals-sdk/eval-sop.md
+++ b/docs/user-guide/evals-sdk/eval-sop.md
@@ -155,14 +155,32 @@ The workflow proceeds through four phases:
 ```python
 from strands import Agent
 from strands_tools import editor, shell
-from strands_agents_sops import eval
+from strands_agents_sops import eval 
 
 agent = Agent(
     system_prompt=eval,
     tools=[editor, shell],
 )
 
+# Initial message to start the evaluation
 agent("Start Eval sop for evaluating my QA agent")
+
+# Multi-turn conversation loop
+while True:
+    user_input = input("\nYou: ")
+    if user_input.lower() in ("exit", "quit", "done"):
+        print("Evaluation session ended.")
+        break
+
+    agent(user_input)
+```
+
+You can bypass tool consent when running Eval SOP by setting the following environment variable:
+
+```python
+import os 
+
+os.environ["BYPASS_TOOL_CONSENT"] = "true"
 ```
 
 ### Option 3: Anthropic Skills


### PR DESCRIPTION
The Eval SOP is designed to run as a multi-turn interaction, but the current Direct Strands Agent Integration example only invokes the agent once, causing execution to block when follow-up input is required.

This update adds a conversation loop so the example can be run end-to-end and clarifies how to bypass repeated tool consent prompts during evaluation runs.

Fixes #379

<!-- Thank you for contributing to our documentation! -->

## Description
Updates the Eval SOP “Direct Strands Agent Integration” documentation to reflect the required multi-turn interaction model. The example now includes a conversation loop so the Eval SOP can run end-to-end instead of blocking after the first follow-up prompt. The update also documents how to bypass repeated tool consent prompts during evaluation runs.

## Type of Change
- Content update/revision

## Motivation and Context
The Eval SOP is inherently multi-turn and may ask follow-up questions, request clarification, or iterate over evaluation steps. The current documentation example only invokes the agent once, which causes execution to stall when the SOP requests additional input. This makes the example appear broken when copied and run. The updated example aligns the documentation with the actual interaction pattern required by the Eval SOP and reduces friction during evaluation workflows.

## Areas Affected
[<!-- List the pages/sections affected by this PR -->
](https://strandsagents.com/latest/documentation/docs/user-guide/evals-sdk/eval-sop/#option-2-direct-strands-agent-integration)

https://strandsagents.com/latest/documentation/docs/user-guide/evals-sdk/eval-sop/#option-2-direct-strands-agent-integration

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x ] I have read the CONTRIBUTING document
- [x ] My changes follow the project's documentation style
- [x ] I have tested the documentation locally using `mkdocs serve`
- [x ] Links in the documentation are valid and working
- [x ] Images/diagrams are properly sized and formatted
- [x ] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
