### PR TITLE
fix(mkdocs): remove invalid TypeScript entry point to fix serve error

### DIFF
--- a/build-ts-docs.py
+++ b/build-ts-docs.py
@@ -1,8 +1,0 @@
-import subprocess
-import os
-
-def on_startup(**kwargs):
-    """Run npm docs:ts before building the site"""
-    subprocess.run(['npm', 'run', 'docs:ts'], check=True, cwd=os.getcwd())
-    print("✓ TypeScript documentation generated successfully")
-

--- a/docs/api-reference/interrupt.md
+++ b/docs/api-reference/interrupt.md
@@ -1,3 +1,3 @@
-::: strands.interrupt
+::: strands_agents.interrupt
     options:
       heading_level: 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -282,9 +282,6 @@ plugins:
           - examples/**/*.md
         API Reference:
           - api-reference/*.md
-
-hooks:
-  - build-ts-docs.py
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
<!-- Provide a clear and concise description of your changes -->
This PR addresses and resolves issue #382

## Type of Change
<!-- What kind of change are you making -->
- New content addition
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

<Enter type of change here>
Bug fix

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The current repository is solely for documentation; sdk-typescript has its own separate repository. The MkDocs configuration was incorrectly attempting to process the invalid sdk-typescript folder, causing the build to fail. It is unclear why this was configured this way. This PR fixes the issue by removing the invalid entry point.

## Areas Affected
<!-- List the pages/sections affected by this PR -->
- `mkdocs serve` command

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
