### PR TITLE
docs(evals): updated simulator code and added run_evaluations_async examples

### DIFF
--- a/docs/user-guide/evals-sdk/simulators/index.md
+++ b/docs/user-guide/evals-sdk/simulators/index.md
@@ -128,6 +128,18 @@ evaluators = [
     GoalSuccessRateEvaluator()
 ]
 
+# Setup test cases
+test_cases = [
+    Case(
+        input="I need to book a flight to Paris",
+        metadata={"task_description": "Flight booking confirmed"}
+    ),
+    Case(
+        input="Help me write a Python function to sort a list",
+        metadata={"task_description": "Programming assistance"}
+    )
+]
+
 experiment = Experiment(cases=test_cases, evaluators=evaluators)
 reports = experiment.run_evaluations(task_function)
 ```


### PR DESCRIPTION
## Description
1. Fixed the inline code example as it's missing the `test_cases`
2. Added example for `run_evaluations_async` capability

## Type of Change
- New content addition
- Content update/revision

## Motivation and Context
- https://github.com/strands-agents/docs/issues/385
- Customer asked whether we support async since they cannot see examples from the doc.

## Areas Affected
strands-agents-evals

## Screenshots
N/A

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
