### PR TITLE
feat: Add "Edit this page" button to doc pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_dir: site
 site_url: https://strandsagents.com
 
 repo_url: https://github.com/strands-agents/sdk-python
+edit_uri: https://github.com/strands-agents/docs/edit/main/docs
 
 theme:
   name: material
@@ -31,6 +32,7 @@ theme:
     admonition:
       code: material/code-json
   features:
+    - content.action.edit
     - content.code.copy
     - content.tabs.link
     - content.code.select


### PR DESCRIPTION


<!-- Thank you for contributing to our documentation! -->

## Description

Add "Edit this page" button to doc pages

I have a parallel PR in the website repo, but with the intention of keeping the docs and website as close as possible, add an edit button that can be used for preview builds.

## Type of Change

- New content addition



## Motivation and Context

So that folks can see what the generated site will look like with an edit button; for local development this is pretty useless

## Screenshots

The link below goes to https://github.com/strands-agents/docs/edit/main/docs/README.md for example

<img width="1555" height="609" alt="image" src="https://github.com/user-attachments/assets/a05d9140-0225-4460-a169-37426be952b6" />


## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
