### PR TITLE
fix(docs): update typescript model provider import path

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
@@ -10,5 +10,5 @@ import { z } from 'zod'
 // --8<-- [end:tool_update_config_imports]
 
 // --8<-- [start:custom_credentials_imports]
-import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
+import { BedrockModel } from '@strands-agents/sdk/bedrock'
 // --8<-- [end:custom_credentials_imports]

--- a/docs/user-guide/concepts/model-providers/index_imports.ts
+++ b/docs/user-guide/concepts/model-providers/index_imports.ts
@@ -2,6 +2,6 @@
 
 // --8<-- [start:basic_usage_imports]
 import { Agent } from '@strands-agents/sdk'
-import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
-import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+import { BedrockModel } from '@strands-agents/sdk/bedrock'
+import { OpenAIModel } from '@strands-agents/sdk/openai'
 // --8<-- [end:basic_usage_imports]

--- a/docs/user-guide/concepts/model-providers/openai.ts
+++ b/docs/user-guide/concepts/model-providers/openai.ts
@@ -6,7 +6,7 @@
 // Imports are in openai_imports.ts
 
 import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+import { OpenAIModel } from '@strands-agents/sdk/openai'
 
 // Basic usage
 async function basicUsage() {

--- a/docs/user-guide/concepts/model-providers/openai_imports.ts
+++ b/docs/user-guide/concepts/model-providers/openai_imports.ts
@@ -2,5 +2,5 @@
 
 // --8<-- [start:basic_usage_imports]
 import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+import { OpenAIModel } from '@strands-agents/sdk/openai'
 // --8<-- [end:basic_usage_imports]


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
When following documentation to use [OpenAI](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/model-providers/openai/) or [Bedrock](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/model-providers/amazon-bedrock/) model providers in Typescript: 
```
Cannot find module '@strands-agents/sdk/models/openai' or its corresponding type declarations.
```

Models are internally nested under `strands-agents/sdk/model` but exported at the top level under `strands-agents/sdk`. See [package.json export](https://github.com/strands-agents/sdk-typescript/blob/main/package.json#L17-L24)

## Type of Change
- Bug fix

## Motivation and Context
- Anyone following the documentation for OpenAI or Bedrock on Typescript will have to debug the model provider import

## Areas Affected
- Docs/Concepts/Model Providers
- Docs/Concepts/Model Providers/OpenAI
- Docs/Concepts/Model Providers/Anthropic

## Screenshots
[OpenAIPage.pdf](https://github.com/user-attachments/files/24299549/OpenAIPage.pdf)
[BedrockPage.pdf](https://github.com/user-attachments/files/24299552/BedrockPage.pdf)
[ModelProvidersPage.pdf](https://github.com/user-attachments/files/24299553/ModelProvidersPage.pdf)

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
