### PR TITLE
Add documentation to use Nebius Token Factory on strands

### DIFF
--- a/docs/community/model-providers/nebius-token-factory.md
+++ b/docs/community/model-providers/nebius-token-factory.md
@@ -1,0 +1,84 @@
+# Nebius Token Factory
+
+{{ community_contribution_banner }}
+
+!!! info "Language Support"
+    This provider is only supported in Python.
+
+[Nebius Token Factory](https://tokenfactory.nebius.com) provides fast inference for open-source language models. Nebius Token Factory is accessible through OpenAI's SDK via full API compatibility, allowing easy and portable integration with the Strands Agents SDK using the familiar OpenAI interface.
+
+## Installation
+
+The Strands Agents SDK provides access to Nebius Token Factory models through the OpenAI compatibility layer, configured as an optional dependency. To install, run:
+
+```bash
+pip install 'strands-agents[openai]' strands-agents-tools
+```
+
+## Usage
+
+After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Nebius Token Factory models as follows:
+
+```python
+from strands import Agent
+from strands.models.openai import OpenAIModel
+from strands_tools import calculator
+
+model = OpenAIModel(
+    client_args={
+        "api_key": "<NEBIUS_API_KEY>",
+        "base_url": "https://api.tokenfactory.nebius.com/v1/",
+    },
+    model_id="deepseek-ai/DeepSeek-R1-0528",  # or see https://docs.tokenfactory.nebius.com/ai-models-inference/overview
+    params={
+        "max_tokens": 5000,
+        "temperature": 0.1
+    }
+)
+
+agent = Agent(model=model, tools=[calculator])
+agent("What is 2+2?")
+```
+
+## Configuration
+
+### Client Configuration
+
+The `client_args` configure the underlying OpenAI-compatible client. When using Nebius Token Factory, you must set:
+
+* `api_key`: Your Nebius Token Factory API key. Get one from the [Nebius Token Factory Console](https://tokenfactory.nebius.com/).
+* `base_url`: `https://api.tokenfactory.nebius.com/v1/`
+
+Refer to [OpenAI Python SDK GitHub](https://github.com/openai/openai-python) for full client options.
+
+### Model Configuration
+
+The `model_config` specifies which Nebius Token Factory model to use and any additional parameters.
+
+| Parameter  | Description               | Example                                                           | Options                                                            |
+| ---------- | ------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `model_id` | Model name                | `deepseek-ai/DeepSeek-R1-0528`                                   | See [Nebius Token Factory Models](https://nebius.com/services/token-factory) |
+| `params`   | Model-specific parameters | `{"max_tokens": 5000, "temperature": 0.7, "top_p": 0.9}`         | [API reference](https://docs.tokenfactory.nebius.com/api-reference)          |
+
+## Troubleshooting
+
+### `ModuleNotFoundError: No module named 'openai'`
+
+You must install the `openai` dependency to use this provider:
+
+```bash
+pip install 'strands-agents[openai]'
+```
+
+### Unexpected model behavior?
+
+Ensure you're using a model ID compatible with Nebius Token Factory (e.g., `deepseek-ai/DeepSeek-R1-0528`, `meta-llama/Meta-Llama-3.1-70B-Instruct`), and your `base_url` is set to `https://api.tokenfactory.nebius.com/v1/`.
+
+## References
+
+* [Nebius Token Factory Documentation](https://docs.tokenfactory.nebius.com/)
+* [Nebius Token Factory API Reference](https://docs.tokenfactory.nebius.com/api-reference)
+* [Nebius Token Factory Models](https://docs.tokenfactory.nebius.com/ai-models-inference/overview)
+* [OpenAI Python SDK](https://github.com/openai/openai-python)
+* [Strands Agents API](../../api-reference/models.md)
+

--- a/docs/user-guide/concepts/model-providers/nebius-token-factory.md
+++ b/docs/user-guide/concepts/model-providers/nebius-token-factory.md
@@ -1,0 +1,5 @@
+
+<auto-redirect />
+
+This guide has moved to [community/model-providers/nebius-token-factory](../../../community/model-providers/nebius-token-factory.md).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
         - Cohere<sup> community</sup>: user-guide/concepts/model-providers/cohere.md
         - CLOVA Studio<sup> community</sup>: user-guide/concepts/model-providers/clova-studio.md
         - FireworksAI<sup> community</sup>: user-guide/concepts/model-providers/fireworksai.md
+        - Nebius Token Factory<sup> community</sup>: user-guide/concepts/model-providers/nebius-token-factory.md
       - Streaming:
         - Overview: user-guide/concepts/streaming/index.md
         - Async Iterators: user-guide/concepts/streaming/async-iterators.md
@@ -220,6 +221,7 @@ nav:
         - Cohere: community/model-providers/cohere.md
         - CLOVA Studio: community/model-providers/clova-studio.md
         - Fireworks AI: community/model-providers/fireworksai.md
+        - Nebius Token Factory: community/model-providers/nebius-token-factory.md
       - Session Managers:
         - Amazon AgentCore Memory: community/session-managers/agentcore-memory.md
       - Tool Protocols:


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description
This PR adds comprehensive documentation for Nebius Token Factory as a community-maintained model provider. The documentation follows the same structure and patterns as the existing Fireworks AI provider documentation, providing users with clear instructions on how to integrate Nebius Token Factory models with the Strands Agents SDK using the OpenAI compatibility layer.

Fixes: #395 

## Type of Change
- New content addition

## Motivation and Context
Nebius Token Factory is a fast inference service for open-source language models that provides OpenAI-compatible API access. Adding this documentation enables users to easily discover and integrate Nebius Token Factory models into their Strands Agents applications. This addition expands the available community model provider options and follows the established pattern for documenting OpenAI-compatible providers.

## Areas Affected
- **New file**: `docs/community/model-providers/nebius-token-factory.md` - Main documentation page with installation, usage, configuration, troubleshooting, and references
- **New file**: `docs/user-guide/concepts/model-providers/nebius-token-factory.md` - Redirect file that routes users from the user guide to the community documentation
- **Updated**: `mkdocs.yml` - Added navigation entries in two locations:
  - User Guide > Concepts > Model Providers (with community superscript)
  - Community > Model Providers

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working
- [x] Images/diagrams are properly sized and formatted
- [x] All new and existing tests pass

## Additional Notes
- Documentation follows the same structure as Fireworks AI provider documentation for consistency
- Uses OpenAI compatibility layer (same as Fireworks AI), requiring `strands-agents[openai]` dependency
- Includes example model IDs: `deepseek-ai/DeepSeek-R1-0528` and `meta-llama/Meta-Llama-3.1-70B-Instruct`
- Base URL: `https://api.tokenfactory.nebius.com/v1/`
- All external links point to official Nebius Token Factory documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.