### PR TITLE
feat: Add docs about conversation-managers being HookProviders

### DIFF
--- a/docs/user-guide/concepts/agents/conversation-management.md
+++ b/docs/user-guide/concepts/agents/conversation-management.md
@@ -256,7 +256,7 @@ Key features of the `SummarizingConversationManager`:
 
     2. [`reduce_context`](../../../api-reference/python/agent/conversation_manager/conversation_manager.md#strands.agent.conversation_manager.conversation_manager.ConversationManager.reduce_context): This method is called when the model's context window is exceeded (typically due to token limits). It implements the specific strategy for reducing the window size when necessary. The agent calls this method when it encounters a context window overflow exception, giving your implementation a chance to trim the conversation history before retrying.
 
-    3. `removed_messages_count`: This attribute is tracked by conversation managers, and utilized by [Session Management](./session-management.md) to efficiently load messages from the session storage. The count represents messages provided by the user or LLM that have been removed from the agent's messages, but not messages included by the conversation manager through something like summarization.
+    3. `removed_message_count`: This attribute is tracked by conversation managers, and utilized by [Session Management](./session-management.md) to efficiently load messages from the session storage. The count represents messages provided by the user or LLM that have been removed from the agent's messages, but not messages included by the conversation manager through something like summarization.
 
     4. `register_hooks` (optional): Override this method to integrate with [hooks](./hooks.md). This enables proactive context management patterns, such as trimming context before model calls. Always call `super().register_hooks` when overriding.
    


### PR DESCRIPTION
<!-- Thank you for contributing to our documentation! -->

## Description

Per strands-agents/sdk-python/pull/1374 update docs with the latest information on being conversation-managers.

I also updated the heading levels to be more consistent; for some reason we jumped from 2 -> 4

## Type of Change
<!-- What kind of change are you making -->
- New content addition

<Enter type of change here>

## Motivation and Context

strands-agents/sdk-python/pull/1374 is updating conversation-managers to be HookProviders; this documents that

## Areas Affected

 - conversation-management.md

## Screenshots

<img width="1432" height="1035" alt="image" src="https://github.com/user-attachments/assets/40d72b54-3f89-4e85-a98c-e5c205770fb3" />


## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
