### PR TITLE
fix: Don't run python and typescript hooks on rebuilds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 node_modules
 uv.lock
 
+temp_python_sdk
 sdk-typescript
 package-lock.json
 

--- a/build-ts-docs.py
+++ b/build-ts-docs.py
@@ -2,7 +2,7 @@ import subprocess
 import os
 
 
-def on_pre_build(config):
+def on_startup(command, dirty):
     """Run npm docs:ts before building the site"""
     subprocess.run(['npm', 'run', 'docs:clone'], check=True, cwd=os.getcwd())
     print("✓ TypeScript clone repository successfully")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "mkdocs-llmstxt~=0.2.0",
     "strands-agents[all,bidi-all]",
     "pymdown-extensions>=10.16.1",
+    "psutil~=7.2.0",
 ]
 
 


### PR DESCRIPTION
## Description

Don't run python and typescript hooks on rebuilds

They're time consuming and generally don't change when iterating on documentation.

Also fixed a bug where pip install was failing when running under uv, and ignored temp_python_sdk which gets created as part of the build process.

### Notes

Per the mkdocs documentation:

 - [`on_startup`](https://www.mkdocs.org/dev-guide/plugins/#on_startup) runs once on startup
 - [`on_pre_build`](https://www.mkdocs.org/dev-guide/plugins/#on_pre_build) is a global plugin and thus re-runs on every build.

TS is easy and just uses `on_startup` now since it didn't need access to the config; Python needed access to work done on startup, so it was split into  `on_startup` and `on_pre_build`

<!-- Thank you for contributing to our documentation! -->

## Type of Change
<!-- What kind of change are you making -->

- Other (please describe): Plugin Refactor

## Motivation and Context

Hot reloads via ` uv run mkdocs serve --dirtyreload` were re-running the TS/Python steps, resulting a 1-3 minute delay when iterating on docs


## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working
- [X] Images/diagrams are properly sized and formatted
- [X] All new and existing tests pass

## Additional Notes
<!-- Any other information that is important to this PR -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
