### PR TITLE
Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,38 +1,30 @@
-<!-- Thank you for contributing to our documentation! -->
-
 ## Description
-<!-- Provide a clear and concise description of your changes -->
+<!-- Provide a detailed description of the changes in this PR -->
+<!-- If applicable, add screenshots to help explain your changes -->
+
+
+## Related Issues
+<!-- Link to related issues using #issue-number format -->
+
 
 ## Type of Change
 <!-- What kind of change are you making -->
-- New content addition
+
+- New content
 - Content update/revision
 - Structure/organization improvement
 - Typo/formatting fix
 - Bug fix
 - Other (please describe):
 
-<Enter type of change here>
-
-## Motivation and Context
-<!-- Why is this change needed? What problem does it solve? -->
-
-## Areas Affected
-<!-- List the pages/sections affected by this PR -->
-
-## Screenshots
-<!-- If applicable, add screenshots to help explain your changes -->
-
 ## Checklist
 <!-- Mark completed items with an [x] -->
+
 - [ ] I have read the CONTRIBUTING document
 - [ ] My changes follow the project's documentation style
 - [ ] I have tested the documentation locally using `mkdocs serve`
 - [ ] Links in the documentation are valid and working
-- [ ] Images/diagrams are properly sized and formatted
-- [ ] All new and existing tests pass
 
-## Additional Notes
-<!-- Any other information that is important to this PR -->
+----
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->

Our PR template had a lot of content that seemed like boilerplate.  Looking through past PRs, the fields in the new template seem to be the most useful.

This PR follows the new format.

## Related Issues
<!-- Link to related issues using #issue-number format -->

N/A

## Type of Change
<!-- What kind of change are you making -->

- Content update/revision

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [-] My changes follow the project's documentation style
- [-] I have tested the documentation locally using `mkdocs serve`
- [-] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.