### PR TITLE
fix: correct broken TypeScript vended tools links

### DIFF
--- a/docs/user-guide/concepts/tools/community-tools-package.md
+++ b/docs/user-guide/concepts/tools/community-tools-package.md
@@ -2,7 +2,7 @@
 
 !!! info "Python-Only Package"
     The Community Tools Package (`strands-agents-tools`) is currently Python-only. 
-    TypeScript users should use [vended tools]({{ ts_sdk_repo_home }}/vended_tools) 
+    TypeScript users should use [vended tools]({{ ts_sdk_repo_home }}/src/vended-tools)
     included in the TypeScript SDK or create custom tools using the `tool()` function.
 
 Strands offers an optional, community-supported tools package [`strands-agents-tools`]({{ tools_pypi }}) which includes pre-built tools to get started quickly experimenting with agents and tools during development. The package is also open source and available on [GitHub]({{ tools_repo_home }}).

--- a/docs/user-guide/concepts/tools/index.md
+++ b/docs/user-guide/concepts/tools/index.md
@@ -378,7 +378,7 @@ Pre-built tools are available in both Python and TypeScript to help you get star
 
     **Vended Tools**
 
-    TypeScript vended tools are included in the SDK at [`vended_tools/`]({{ ts_sdk_repo_home }}/vended_tools). 
+    TypeScript vended tools are included in the SDK at [`vended-tools/`]({{ ts_sdk_repo_home }}/src/vended-tools).
     The Community Tools Package (`strands-agents-tools`) is Python-only.
 
     ```typescript


### PR DESCRIPTION
## Description
Fix broken links to TypeScript vended tools. Changed path from /vended_tools to /src/vended-tools.

## Related Issues
N/A

## Type of Change
- Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
