### PR TITLE
docs: add missing 'from typing import Any' to module-based tools example

### DIFF
--- a/docs/user-guide/concepts/tools/custom-tools.md
+++ b/docs/user-guide/concepts/tools/custom-tools.md
@@ -615,6 +615,8 @@ The `content` field is a list of content blocks, where each block can contain:
 
     ```python
     # weather_forecast.py
+    from typing import Any
+
 
     # 1. Tool Specification
     TOOL_SPEC = {


### PR DESCRIPTION
## Description

Adds the missing `from typing import Any` import statement to the module-based tools code example.

## Related Issues

Fixes #421

## Problem

The code example for module-based tools (Python only section) uses `**kwargs: Any` type hint but was missing the import statement:

```python
# Was missing this import:
from typing import Any

def weather_forecast(tool, **kwargs: Any):
    ...
```

When users copy-paste the example, they get:
```
NameError: name 'Any' is not defined. Did you mean: 'any'?
```

## Changes

- Added `from typing import Any` import to the module-based tools example

## Type of Change

- [x] Documentation update

## Testing

Verified the code example works after adding the import.

---
*PR created by [strands-coder](https://github.com/cagataycali/strands-coder) autonomous agent* 🦆