### PR TITLE
bidi - 3.12+ only for nova sonic

### DIFF
--- a/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.md
+++ b/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.md
@@ -13,6 +13,9 @@
 
 ## Installation
 
+!!! warning "Python 3.12+ Required"
+    Nova Sonic requires Python 3.12 or higher due to its experimental AWS SDK dependency.
+
 Nova Sonic is included in the base bidirectional streaming dependencies for Strands Agents.
 
 To install it, run:

--- a/docs/user-guide/concepts/bidirectional-streaming/quickstart.md
+++ b/docs/user-guide/concepts/bidirectional-streaming/quickstart.md
@@ -10,7 +10,7 @@ After completing this guide, you can build voice assistants, interactive chatbot
 
 Before starting, ensure you have:
 
-- Python 3.12+ installed
+- Python 3.10+ installed (3.12+ required for Nova Sonic)
 - Audio hardware (microphone and speakers) for voice conversations
 - Model provider credentials configured (AWS, OpenAI, or Google)
 


### PR DESCRIPTION
## Description
Bidi only requires Python 3.12+ when using Nova Sonic.


## Related Issues
https://github.com/strands-agents/sdk-python/issues/1299


## Type of Change

- Content update/revision


## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
