### PR TITLE
docs(bedrock): add aws login credential option

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -131,10 +131,10 @@ For more details, see the [Amazon Bedrock documentation on modifying model acces
     aws login
     ```
 
-    To use `aws login` with enhanced performance, install Strands with CRT support:
+    To use `aws login` with enhanced performance, install botocore with CRT support:
 
     ```bash
-    pip install strands-agent[crt]
+    pip install botocore[crt]
     ```
 
     See the [Login for AWS local development using console credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html) documentation for more details.


### PR DESCRIPTION
Document aws login as a recommended authentication method for local development. Include instructions for optional CRT installation to enhance performance.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/1486
https://github.com/strands-agents/sdk-python/pull/1487

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
