### PR TITLE
community - session managers - valkey

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -230,6 +230,7 @@ nav:
         - MLX: community/model-providers/mlx.md
       - Session Managers:
         - Amazon AgentCore Memory: community/session-managers/agentcore-memory.md
+        - Valkey/Redis: community/session-managers/strands-valkey-session-manager.md
       - Tool Protocols:
         - UTCP: community/tools/utcp.md
       - Tools:


### PR DESCRIPTION
## Description
Adding reference to community session manager into docs menu. Was approved before [here](https://github.com/strands-agents/docs/pull/334/changes) but at some point was unintentionally removed.


## Related Issues
https://github.com/strands-agents/docs/issues/290


## Type of Change
- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
