### PR TITLE
fix: replace deprecated complete event with result key check

### DIFF
--- a/docs/user-guide/concepts/streaming/async-iterators.md
+++ b/docs/user-guide/concepts/streaming/async-iterators.md
@@ -119,8 +119,8 @@ This async stream processor illustrates the event loop lifecycle events and how 
             print("▶️ Event loop cycle starting")
         elif "message" in event:
             print(f"📬 New message created: {event['message']['role']}")
-        elif event.get("complete", False):
-            print("✅ Cycle completed")
+        elif "result" in event:
+            print("✅ Agent completed with result")
         elif event.get("force_stop", False):
             print(f"🛑 Event loop force-stopped: {event.get('force_stop_reason', 'unknown reason')}")
 
@@ -142,7 +142,7 @@ This async stream processor illustrates the event loop lifecycle events and how 
     2. Then the cycle begins (`start_event_loop`)
     3. New cycles may start multiple times during execution (`start_event_loop`)
     4. Text generation and tool usage events occur during the cycle
-    5. Finally, the cycle completes (`complete`) or may be force-stopped (`force_stop`)
+    5. Finally, the agent completes with a `result` event or may be force-stopped (`force_stop`)
 
 === "TypeScript"
 

--- a/docs/user-guide/concepts/streaming/callback-handlers.md
+++ b/docs/user-guide/concepts/streaming/callback-handlers.md
@@ -120,8 +120,8 @@ def event_loop_tracker(**kwargs):
         print("▶️ Event loop cycle starting")
     elif "message" in kwargs:
         print(f"📬 New message created: {kwargs['message']['role']}")
-    elif kwargs.get("complete", False):
-        print("✅ Cycle completed")
+    elif "result" in kwargs:
+        print("✅ Agent completed with result")
     elif kwargs.get("force_stop", False):
         print(f"🛑 Event loop force-stopped: {kwargs.get('force_stop_reason', 'unknown reason')}")
         
@@ -152,7 +152,7 @@ The output will show the sequence of events:
 2. Then the cycle begins (`start_event_loop`)
 3. New cycles may start multiple times during execution (`start`)
 4. Text generation and tool usage events occur during the cycle
-5. Finally, the cycle completes (`complete`) or may be force-stopped
+5. Finally, the agent completes with a `result` event or may be force-stopped
 
 ## Best Practices
 

--- a/docs/user-guide/concepts/streaming/index.md
+++ b/docs/user-guide/concepts/streaming/index.md
@@ -159,8 +159,8 @@ This example demonstrates how to identify event emitted from an agent:
             print("▶️ Event loop cycle starting")
         elif "message" in event:
             print(f"📬 New message created: {event['message']['role']}")
-        elif event.get("complete", False):
-            print("✅ Cycle completed")
+        elif "result" in event:
+            print("✅ Agent completed with result")
         elif event.get("force_stop", False):
             print(f"🛑 Event loop force-stopped: {event.get('force_stop_reason', 'unknown reason')}")
 


### PR DESCRIPTION
Fixes strands-agents/docs#433

The `complete` event flag was removed from the SDK (sdk-python#276) but code examples in the streaming documentation still referenced it. PR #152 partially addressed this by updating the event types list, but missed updating the code examples and explanatory text.

Changes:
- async-iterators.md: Update code example and sequence description
- callback-handlers.md: Update code example and sequence description
- index.md: Update code example

The `result` key is now the correct way to detect agent completion, as it contains the final AgentResult when the agent finishes.

## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
