### PR TITLE
fix(llmstxt): include TypeScript API docs in llms.txt

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -279,7 +279,7 @@ plugins:
         Python API:
           - docs/api-reference/python/**/*.md
         TypeScript API:
-          - docs/api-reference/typescript/*.html
+          - docs/api-reference/typescript/**/*.html
 
 
 hooks:


### PR DESCRIPTION
## Description

Fixes the empty TypeScript API section in `llms.txt` by using a recursive glob pattern to include all TypeScript API documentation files.

### Problem
The current llms.txt configuration uses `docs/api-reference/typescript/*.html` which only matches files in the root directory. However, typedoc generates documentation into subdirectories:
- `classes/` - Agent, Tool, Message classes
- `types/` - TypeScript type definitions
- `interfaces/` - Interface definitions
- `functions/` - Exported functions

This results in an empty TypeScript API section in llms.txt, blocking AI coding assistants (Claude Code, Cursor, Windsurf) from helping users write TypeScript code.

### Solution
Change the glob pattern from `*.html` to `**/*.html` to recursively match all HTML files generated by typedoc.

### Before
```yaml
TypeScript API:
  - docs/api-reference/typescript/*.html  # Only matches 2 files in root
```

### After
```yaml
TypeScript API:
  - docs/api-reference/typescript/**/*.html  # Matches all 123 HTML files
```

## Related Issues

Fixes #426

## Type of Change

Bug fix

## Testing

Verified locally:
1. Generated TypeScript docs with `npm run docs:ts`
2. Confirmed 123 HTML files exist across subdirectories
3. Verified the glob pattern change matches all files

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
- [x] This is a one-line configuration fix