### PR TITLE
ci: switch preview github action to use approval envs

### DIFF
--- a/.github/workflows/trigger-preview-docs.yml
+++ b/.github/workflows/trigger-preview-docs.yml
@@ -6,9 +6,10 @@ on:
 
 jobs:
   authorization-check:
+    permissions: read-all
     runs-on: ubuntu-latest
     outputs:
-      should-deploy: ${{ steps.collab-check.outputs.result }}
+      approval-env: ${{ steps.collab-check.outputs.result }}
     steps:
       - name: Collaborator Check
         uses: actions/github-script@v8
@@ -24,23 +25,23 @@ jobs:
               });
               const permission = permissionResponse.data.permission;
               const hasWriteAccess = ['write', 'admin'].includes(permission);
-              
+
               if (!hasWriteAccess) {
                 console.log(`User ${context.payload.pull_request.user.login} does not have write access to the repository (permission: ${permission})`);
-                return "false"
+                return "manual-approval"
               } else {
-                console.log(`Verified ${context.payload.pull_request.user.login} has write access. Approving documentation deployment.`)
-                return "true"
+                console.log(`Verified ${context.payload.pull_request.user.login} has write access. Auto approving documentation deployment.`)
+                return "auto-approve"
               }
             } catch (error) {
-              console.log(`${context.payload.pull_request.user.login} does not have write access. Denying documentation deployment.`)
-              return "false"
+              console.log(`${context.payload.pull_request.user.login} does not have write access. Requiring manual approval to deploy documentation.`)
+              return "manual-approval"
             }
 
   trigger-docs-deploy:
     runs-on: ubuntu-latest
     needs: [authorization-check]
-    if: needs.authorization-check.outputs.should-deploy == 'true'
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
     
     steps:
       - name: Trigger documentation deployment


### PR DESCRIPTION
## Summary

Updates the preview deployment workflow to use GitHub environment-based approval instead of the boolean skip pattern.

## Changes

- Replace `should-deploy` output (true/false) with `approval-env` output (auto-approve/manual-approval)
- Replace `if:` condition with `environment:` directive on the trigger job
- Add `permissions: read-all` to authorization-check job

## Why

The previous approach would silently skip preview deployments for external contributors. The new approach allows maintainers to manually approve preview deployments from external contributors through GitHub's environment protection rules.

## Setup Required

Two GitHub environments need to be configured in repository settings:
- **`auto-approve`** - No required reviewers (for collaborators with write access)
- **`manual-approval`** - Configure required reviewers (for external contributors)

This pattern matches the approach used in [strands-agents/sdk-python](https://github.com/strands-agents/sdk-python/blob/main/.github/workflows/integration-test.yml).