### PR TITLE
Add strands command to docs repo

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -1,0 +1,123 @@
+name: Strands Command Handler
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Issue ID to process (can be issue or PR number)'
+        required: true
+        type: string
+      command:
+        description: 'Strands command to execute'
+        required: false
+        type: string
+        default: ''
+      session_id:
+        description: 'Optional session ID to use'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  authorization-check:
+    if: startsWith(github.event.comment.body, '/strands') || github.event_name == 'workflow_dispatch'
+    permissions: read-all
+    runs-on: ubuntu-latest
+    outputs:
+      approval-env: ${{ steps.collab-check.outputs.result || steps.auto-approve.outputs.result }}
+    steps:
+      - name: Collaborator Check
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v8
+        id: collab-check
+        with:
+          result-encoding: string
+          script: |
+            try {
+              const permissionResponse = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.comment.user.login,
+              });
+              const role_name = permissionResponse.data.role_name;
+              const hasWriteAccess = ['triage', 'write', 'admin'].includes(role_name);
+              if (!hasWriteAccess) {
+                console.log(`User ${context.payload.comment.user.login} does not have write access to the repository (permission: ${permission})`);
+                return "manual-approval"
+              } else {
+                console.log(`Verified ${context.payload.comment.user.login} has write access. Auto Approving strands command.`)
+                return "auto-approve"
+              }
+            } catch (error) {
+              console.log(`${context.payload.comment.user.login} does not have write access. Requiring Manual Approval to run strands command.`)
+              return "manual-approval"
+            }
+
+      - name: Auto-approve for workflow dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: auto-approve
+        uses: actions/github-script@v8
+        with:
+          result-encoding: string
+          script: |
+            return "auto-approve"
+  
+  setup-and-process:
+    needs: [authorization-check]
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
+    permissions:
+      # Needed to create a branch for the Implementer Agent
+      contents: write
+      # These both are needed to add the `strands-running` label to issues and prs
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse input
+        id: parse
+        uses: strands-agents/devtools/strands-command/actions/strands-input-parser@main
+        with:
+          issue_id: ${{ inputs.issue_id }}
+          command: ${{ inputs.command }}
+          session_id: ${{ inputs.session_id }}
+
+  execute-readonly-agent:
+    needs: [setup-and-process]
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      id-token: write # Required for OIDC
+    runs-on: ubuntu-latest 
+    timeout-minutes: 60
+    steps:
+      
+      # Add any steps here to set up the environment for the Agent in your repo
+      # setup node, setup python, or any other dependencies
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run Strands Agent
+        id: agent-runner
+        uses: strands-agents/devtools/strands-command/actions/strands-agent-runner@main
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          sessions_bucket: ${{ secrets.AGENT_SESSIONS_BUCKET }}
+          write_permission: 'false'
+
+  finalize:
+    needs: [setup-and-process, execute-readonly-agent]
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest 
+    timeout-minutes: 30
+    steps:
+      - name: Execute write operations
+        uses: strands-agents/devtools/strands-command/actions/strands-finalize@main


### PR DESCRIPTION
## Description
Adding the strands-command agents to the repo

This change introduces a minor change to the permissions of the strands-command. Before we were using the [github get user permission api](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user) `permission` field, which categorizes users into "admin", "write", "read", or "none". Instead I updated it to use the `role_name` field so we can allow access to users based on their role name, specifically adding access for the `triage` role. This way we can be more permissive on who we give access to the agent to, without necessarily giving them write access to the rep.


Example of this working: https://github.com/Unshure/docs/issues/1

## Related Issues
N/A


## Type of Change
Repo feature update

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
