### PR TITLE
fix: Switch `Python` code blocks to be `python`

### DIFF
--- a/docs/user-guide/concepts/bidirectional-streaming/io.md
+++ b/docs/user-guide/concepts/bidirectional-streaming/io.md
@@ -25,7 +25,7 @@ Both protocols include optional lifecycle methods (`start` and `stop`) for resou
 
 Implementation of these protocols will look as follows:
 
-```Python
+```python
 from strands.experimental.bidi import BidiAgent
 from strands.experimental.bidi.tools import stop_conversation
 from strands.experimental.bidi.types.events import BidiOutputEvent
@@ -62,7 +62,7 @@ class MyBidiOutput(BidiOutput):
 
 To connect your I/O channels into the agent loop, you can pass them as arguments into the agent `run()` method.
 
-```Python
+```python
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
@@ -167,7 +167,7 @@ Note, the agent provides a preview of what it is about to say before producing t
 
 WebSockets are a common I/O channel for bidi-agents. To learn how to setup WebSockets with `run()`, consider the following server example:
 
-```Python
+```python
 # server.py
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
@@ -191,7 +191,7 @@ async def text_chat(websocket: WebSocket) -> None:
 
 To start this server, you can run `unvicorn server:app --reload`. To interact, open a separate terminal window and run the following client script:
 
-```Python
+```python
 # client.py
 import asyncio
 import json

--- a/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.md
+++ b/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.md
@@ -31,7 +31,7 @@ pip install 'strands-agents[bidi-all]'
 
 After installing `strands-agents[bidi-gemini]`, you can import and initialize the Strands Agents' Gemini Live provider as follows:
 
-```Python
+```python
 import asyncio
 
 from strands.experimental.bidi import BidiAgent

--- a/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.md
+++ b/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.md
@@ -34,7 +34,7 @@ pip install 'strands-agents[bidi-all]'
 
 After installing `strands-agents[bidi]`, you can import and initialize the Strands Agents' Nova Sonic provider as follows:
 
-```Python
+```python
 import asyncio
 
 from strands.experimental.bidi import BidiAgent

--- a/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.md
+++ b/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.md
@@ -30,7 +30,7 @@ pip install 'strands-agents[bidi-all]'
 
 After installing `strands-agents[bidi-openai]`, you can import and initialize the Strands Agents' OpenAI Realtime provider as follows:
 
-```Python
+```python
 import asyncio
 
 from strands.experimental.bidi import BidiAgent

--- a/docs/user-guide/concepts/interrupts.md
+++ b/docs/user-guide/concepts/interrupts.md
@@ -180,7 +180,7 @@ Strands enforces the following rules for tool interrupts:
 
 Users can session manage their interrupts and respond back at a later time under a new agent session. Additionally, users can session manage the responses to avoid repeated interrupts on subsequent tool calls.
 
-```Python
+```python
 ##### server.py #####
 
 import json

--- a/docs/user-guide/concepts/tools/custom-tools.md
+++ b/docs/user-guide/concepts/tools/custom-tools.md
@@ -200,7 +200,7 @@ Function tools may also be defined async. Strands will invoke all async tools co
 
 === "Python"
 
-    ```Python
+    ```python
     import asyncio
     from strands import Agent, tool
 
@@ -696,7 +696,7 @@ The `content` field is a list of content blocks, where each block can contain:
 
     Similar to decorated tools, users may define their module tools async.
 
-    ```Python
+    ```python
     TOOL_SPEC = {
         "name": "call_api",
         "description": "Call my API asynchronously.",


### PR DESCRIPTION
## Description

This is technically more correct and is needed for the CMS migration

