### PR TITLE
Update link for 'Agent as Tool Pattern' documentation

### DIFF
--- a/docs/examples/python/multi_agent_example/multi_agent_example.md
+++ b/docs/examples/python/multi_agent_example/multi_agent_example.md
@@ -118,7 +118,7 @@ Each specialized agent has a distinct system prompt, and tools in its inventory,
 
 ### 3. Agent as Tool Pattern
 
-This example demonstrates the ["Agent as Tool Pattern"](../../../user-guide/concepts/multi-agent/agent-to-agent.md) where Strands agents are wrapped as tools. These tools are then provided to another agent (the Teacher's Assistant), creating a system where agents can use other agents as tools.
+This example demonstrates the ["Agent as Tool Pattern"](../../../user-guide/concepts/multi-agent/agents-as-tools.md) where Strands agents are wrapped as tools. These tools are then provided to another agent (the Teacher's Assistant), creating a system where agents can use other agents as tools.
 
 
 ### Sample Interactions


### PR DESCRIPTION
## Description
Fix incorrect link for 'Agent as Tool Pattern' (previously linking to Agent-to-Agent (A2A) Protocol)


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change

- Content update/revision

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
