### PR TITLE
docs: clarify short-term memory behavior in the memory example

### DIFF
--- a/docs/examples/python/memory_agent.md
+++ b/docs/examples/python/memory_agent.md
@@ -18,7 +18,7 @@ The memory agent utilizes two primary tools:
 
 1. **memory**: Enables storing and retrieving information with capabilities for:
 
-    - Storing user-specific information persistently
+    - Storing user-specific information, either persistently or temporarily
     - Retrieving memories based on semantic relevance
     - Listing all stored memories for a user
     - Setting relevance thresholds and result limits
@@ -30,7 +30,10 @@ The memory agent utilizes two primary tools:
 
 ## Memory-Enhanced Response Generation Workflow
 
-This example demonstrates a workflow where memories are used to generate contextually relevant responses:
+> [!NOTE]
+> The memory used in this workflow is short-term and scoped to the current session. See [memory types](https://docs.mem0.ai/core-concepts/memory-types) for more details. Update the [configuration](https://docs.mem0.ai/components/vectordbs/config) to enable persistent storage across sessions.
+
+This example demonstrates a workflow where memories are used to generate contextually relevant responses.
 
 ```mermaid
 flowchart TD

--- a/docs/examples/python/memory_agent.md
+++ b/docs/examples/python/memory_agent.md
@@ -18,7 +18,7 @@ The memory agent utilizes two primary tools:
 
 1. **memory**: Enables storing and retrieving information with capabilities for:
 
-    - Storing user-specific information, either persistently or temporarily
+    - Storing user-specific information persistently
     - Retrieving memories based on semantic relevance
     - Listing all stored memories for a user
     - Setting relevance thresholds and result limits
@@ -31,7 +31,7 @@ The memory agent utilizes two primary tools:
 ## Memory-Enhanced Response Generation Workflow
 
 > [!NOTE]
-> The memory used in this workflow is short-term and scoped to the current session. See [memory types](https://docs.mem0.ai/core-concepts/memory-types) for more details. Update the [configuration](https://docs.mem0.ai/components/vectordbs/config) to enable persistent storage across sessions.
+> By default, mem0 persists memories to local storage at `~/.mem0/`. See [mem0 vector store configuration](https://docs.mem0.ai/components/vectordbs/config) for options on using a different backend for production use.
 
 This example demonstrates a workflow where memories are used to generate contextually relevant responses.
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->

**What changed:**  
This change clarifies that the memory used in the memory agent workflow is short-term, using the same terminology as the mem0 documentation, and is scoped to the current session by default. It also directs users to the relevant configuration and documentation for enabling persistence across sessions. Links to the appropriate mem0 documentation are added to improve discoverability and navigation.

**Why this change is needed:**  
The current documentation is largely silent and somewhat misleading regarding memory persistence. This ambiguity is compounded by the fact that mem0’s own documentation is vague on this topic. I had to spend time verifying the actual behavior, and this change aims to save that effort for future readers. The updated text aligns expectations with the default behavior and provides clear pointers to configuration options for enabling persistence.

## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
