### PR TITLE
fix(quickstart): update typescript examples link to repo

### DIFF
--- a/docs/user-guide/quickstart/typescript.md
+++ b/docs/user-guide/quickstart/typescript.md
@@ -183,7 +183,7 @@ See the [Async Iterators](../concepts/streaming/async-iterators.md) documentatio
 
 Ready to learn more? Check out these resources:
 
-- [Examples](../../examples/README.md) - Examples for many use cases
+- [Examples](https://github.com/strands-agents/sdk-typescript/tree/main/examples) - Examples for many use cases
 - [TypeScript SDK Repository]({{ ts_sdk_repo_home }}) - Explore the TypeScript SDK source code and contribute
 - [Agent Loop](../concepts/agents/agent-loop.md) - Learn how Strands agents work under the hood
 - [State](../concepts/agents/state.md) - Understand how agents maintain context and state across a conversation


### PR DESCRIPTION
## Description
- Updates "examples" link in quickstart to point to typescript examples
- Fix until consensus has been gathered on docs versus repo for long term example habitat

## Related Issues
Fix for https://github.com/strands-agents/sdk-typescript/issues/441


## Type of Change
<!-- What kind of change are you making -->

- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
