### PR TITLE
docs(evals): updated import notice of adding session_id into trace_attributes, and quickstart update

### DIFF
--- a/docs/examples/evals-sdk/actor_simulator.py
+++ b/docs/examples/evals-sdk/actor_simulator.py
@@ -17,6 +17,8 @@ def task_function(case: Case) -> dict:
 
     # Create target agent
     agent = Agent(
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
         system_prompt="You are a helpful travel assistant.",
         callback_handler=None,

--- a/docs/examples/evals-sdk/evaluate_async.py
+++ b/docs/examples/evals-sdk/evaluate_async.py
@@ -1,0 +1,66 @@
+import json
+import asyncio
+from strands import Agent
+from strands_tools import calculator, retrieve, file_read, diagram, journal,generate_image, image_reader
+
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import OutputEvaluator
+from strands_evals.telemetry import StrandsEvalsTelemetry
+
+telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
+memory_exporter = telemetry.in_memory_exporter
+
+async def async_example():
+    """
+    Demonstrates evaluating graph-based agent workflows for research tasks.
+
+    This example:
+    1. Defines a task function with a graph of specialized research agents
+    2. Creates test cases for research and report generation scenarios
+    3. Creates TrajectoryEvaluator and InteractionsEvaluator to assess graph execution
+    4. Creates datasets with the test cases and evaluators
+    5. Runs evaluations and analyzes the reports
+
+    Returns:
+        tuple[EvaluationReport, EvaluationReport]: The trajectory and interaction evaluation results
+    """
+
+    ### Step 1: Define task ###
+    def user_task_function(case: Case) -> dict:
+        memory_exporter.clear()
+
+        agent = Agent(
+            # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+            # to prevent spans from different test cases from being mixed together in the memory exporter
+            trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
+            tools=[calculator],
+            callback_handler=None,
+        )
+        agent_response = agent(case.input)
+        finished_spans = memory_exporter.get_finished_spans()
+        mapper = StrandsInMemorySessionMapper()
+        session = mapper.map_to_session(finished_spans, session_id=case.session_id)
+        return {"output": str(agent_response), "trajectory": session}
+
+    ### Step 2: Create test cases ###
+    test_cases = [
+        Case[str, str](name="math-1", input="Calculate the square root of 144", metadata={"category": "math"}),
+        Case[str, str](
+            name="math-2",
+            input="What is 25 * 4? can you use that output and then divide it by 4, then the final output should be squared. Give me the final value.",
+            metadata={"category": "math"},
+        )
+    ]
+
+    evaluators = [ToolSelectionAccuracyEvaluator()]
+    experiment = Experiment[str, str](cases=test_cases, evaluators=evaluators)
+    reports = await experiment.run_evaluations_async(research_graph)
+    return reports
+    
+
+if __name__ == "__main__":
+    # run the file as a module: eg. python -m examples.evaluate_graph
+    reports = asyncio.run(async_graph_example())
+
+    # report.to_file("tool_selection_accuracy_async")
+    reports[0].run_display(include_actual_trajectory=True)

--- a/docs/examples/evals-sdk/faithfulness_evaluator.py
+++ b/docs/examples/evals-sdk/faithfulness_evaluator.py
@@ -13,6 +13,8 @@ memory_exporter = telemetry.in_memory_exporter
 # 1. Define a task function
 def user_task_function(case: Case) -> dict:
     agent = Agent(
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
         callback_handler=None,
     )

--- a/docs/examples/evals-sdk/goal_success_rate_evaluator.py
+++ b/docs/examples/evals-sdk/goal_success_rate_evaluator.py
@@ -12,6 +12,8 @@ memory_exporter = telemetry.in_memory_exporter
 # 1. Define a task function
 def user_task_function(case: Case) -> dict:
     agent = Agent(
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
         callback_handler=None,
     )

--- a/docs/examples/evals-sdk/harmfulness_evaluator.py
+++ b/docs/examples/evals-sdk/harmfulness_evaluator.py
@@ -12,6 +12,8 @@ memory_exporter = telemetry.in_memory_exporter
 # 1. Define a task function
 def user_task_function(case: Case) -> dict:
     agent = Agent(
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
         callback_handler=None,
     )

--- a/docs/examples/evals-sdk/helpfulness_evaluator.py
+++ b/docs/examples/evals-sdk/helpfulness_evaluator.py
@@ -12,6 +12,8 @@ memory_exporter = telemetry.in_memory_exporter
 # 1. Define a task function
 def user_task_function(case: Case) -> dict:
     agent = Agent(
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
         callback_handler=None,
     )

--- a/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py
+++ b/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py
@@ -15,6 +15,8 @@ def user_task_function(case: Case) -> dict:
     """Execute agent with tools and capture trajectory."""
     memory_exporter.clear()
     agent = Agent(
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
         tools=[calculator],
         callback_handler=None,

--- a/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py
+++ b/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py
@@ -15,6 +15,8 @@ def user_task_function(case: Case) -> dict:
     memory_exporter.clear()
 
     agent = Agent(
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={"gen_ai.conversation.id": case.session_id, "session.id": case.session_id},
         tools=[calculator],
         callback_handler=None,

--- a/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.md
+++ b/docs/user-guide/evals-sdk/evaluators/faithfulness_evaluator.md
@@ -54,6 +54,9 @@ A response passes the evaluation if the score is >= 0.5.
 
 ## Basic Usage
 
+!!! warning "Required: Session ID Trace Attributes"
+    When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+
 ```python
 from strands import Agent
 from strands_evals import Case, Experiment

--- a/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.md
+++ b/docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator.md
@@ -51,6 +51,9 @@ A session passes the evaluation only if the score is 1.0 (all goals achieved).
 
 ## Basic Usage
 
+!!! warning "Required: Session ID Trace Attributes"
+    When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+
 ```python
 from strands import Agent
 from strands_evals import Case, Experiment

--- a/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.md
+++ b/docs/user-guide/evals-sdk/evaluators/helpfulness_evaluator.md
@@ -61,6 +61,9 @@ A response passes the evaluation if the score is >= 0.5.
 
 ## Basic Usage
 
+!!! warning "Required: Session ID Trace Attributes"
+    When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+
 ```python
 from strands import Agent
 from strands_evals import Case, Experiment

--- a/docs/user-guide/evals-sdk/evaluators/index.md
+++ b/docs/user-guide/evals-sdk/evaluators/index.md
@@ -130,6 +130,9 @@ Evaluators and simulators complement each other. Use simulators to generate real
 
 Evaluators work seamlessly with simulator-generated conversations:
 
+!!! warning "Required: Session ID Trace Attributes"
+    When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+
 ```python
 from strands import Agent
 from strands_evals import Case, Experiment, ActorSimulator

--- a/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.md
+++ b/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.md
@@ -49,6 +49,9 @@ The evaluator uses a binary scoring system:
 
 ## Basic Usage
 
+!!! warning "Required: Session ID Trace Attributes"
+    When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+
 ```python
 from strands import Agent
 from strands_tools import calculator

--- a/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.md
+++ b/docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator.md
@@ -49,6 +49,9 @@ The evaluator uses a binary scoring system:
 
 ## Basic Usage
 
+!!! warning "Required: Session ID Trace Attributes"
+    When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+
 ```python
 from strands import Agent, tool
 from strands_evals import Case, Experiment

--- a/docs/user-guide/evals-sdk/quickstart.md
+++ b/docs/user-guide/evals-sdk/quickstart.md
@@ -1,8 +1,19 @@
 # Strands Evaluation Quickstart
 
-This quickstart guide shows you how to create your first evaluation experiment, use built-in evaluators to assess agent performance, generate test cases automatically, and analyze results. You'll learn to evaluate output quality, tool usage patterns, and agent helpfulness.
+Strands Evaluation is a framework for evaluating AI agents and LLM applications. From simple output validation to complex multi-agent interaction analysis, trajectory evaluation, and automated experiment generation, Strands Evaluation provides features to measure and improve your AI systems.
 
-After completing this guide you can create custom evaluators, implement trace-based evaluation, build comprehensive test suites, and integrate evaluation into your development workflow.
+## What Strands Evaluation Provides
+
+- **Multiple Evaluation Types**: Output evaluation, trajectory analysis, tool usage assessment, and interaction evaluation
+- **Dynamic Simulators**: Multi-turn conversation simulation with realistic user behavior and goal-oriented interactions
+- **LLM-as-a-Judge**: Built-in evaluators using language models for sophisticated assessment with structured scoring
+- **Trace-based Evaluation**: Analyze agent behavior through OpenTelemetry execution traces
+- **Automated Experiment Generation**: Generate comprehensive test suites from context descriptions
+- **Custom Evaluators**: Extensible framework for domain-specific evaluation logic
+- **Experiment Management**: Save, load, and version your evaluation experiments with JSON serialization
+- **Built-in Scoring Tools**: Helper functions for exact, in-order, and any-order trajectory matching
+
+This quickstart guide shows you how to create your first evaluation experiment, use built-in evaluators to assess agent performance, generate test cases automatically, and analyze results. After completing this guide you can create custom evaluators, implement trace-based evaluation, build comprehensive test suites, and integrate evaluation into your development workflow.
 
 ## Install the SDK
 
@@ -229,6 +240,9 @@ print("\nExperiment saved to ./experiment_files/trajectory_evaluation.json")
 
 For more advanced evaluation, let's assess agent helpfulness using execution traces:
 
+!!! warning "Required: Session ID Trace Attributes"
+    When using `StrandsInMemorySessionMapper`, you **must** include session ID trace attributes in your agent configuration. This prevents spans from different test cases from being mixed together in the memory exporter.
+
 ```python
 from strands import Agent
 from strands_evals import Case, Experiment
@@ -246,6 +260,8 @@ def user_task_function(case: Case) -> dict:
     
     agent = Agent(
         tools=[calculator],
+        # IMPORTANT: trace_attributes with session IDs are required when using StrandsInMemorySessionMapper
+        # to prevent spans from different test cases from being mixed together in the memory exporter
         trace_attributes={
             "gen_ai.conversation.id": case.session_id,
             "session.id": case.session_id


### PR DESCRIPTION
## Description
1. Added what strands-evals features into quickstart
2. Added important notice to solve mixing spans when using the memory exporter

## Related Issues
Customer did not know the trace_attributes are required to prevent mixing spans from the mapper.

## Type of Change
- Content update/revision

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
