### PR TITLE
Fix incorrect examples for to_file() and memory_exporter usage

### DIFF
--- a/docs/user-guide/evals-sdk/quickstart.md
+++ b/docs/user-guide/evals-sdk/quickstart.md
@@ -239,11 +239,10 @@ from strands_tools import calculator
 
 # Setup telemetry for trace capture
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
-memory_exporter = telemetry.in_memory_exporter
 
 def user_task_function(case: Case) -> dict:
     # Clear previous traces
-    memory_exporter.clear()
+    telemetry.in_memory_exporter.clear()
     
     agent = Agent(
         tools=[calculator],
@@ -256,7 +255,7 @@ def user_task_function(case: Case) -> dict:
     response = agent(case.input)
     
     # Map spans to session for evaluation
-    finished_spans = memory_exporter.get_finished_spans()
+    finished_spans = telemetry.in_memory_exporter.get_finished_spans()
     mapper = StrandsInMemorySessionMapper()
     session = mapper.map_to_session(finished_spans, session_id=case.session_id)
     


### PR DESCRIPTION
## Description
There are two corrections:

In the usage example for **Trace-based Helpfulness Evaluation**, the following code appears:

```python
# Setup telemetry for trace capture
telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()

def user_task_function(case: Case) -> dict:
    # Clear previous traces
    telemetry.memory_exporter.clear()
```
However, the correct property name is `in_memory_exporter`, not `memory_exporter`.

Fixed the usage of `to_file()`in the sections **Basic Output Evaluation**, **Tool Usage Evaluation**, and **Automated Experiment Generation** to match the correct method signature.



## Related Issues


## Type of Change
Typo/formatting fix

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
