### PR TITLE
docs: add automatic cache strategy for Bedrock prompt caching

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -525,9 +525,7 @@ Enable automatic cache point management for agent workflows with repeated tool c
     print(f"Cache read tokens: {response2.metrics.accumulated_usage.get('cacheReadInputTokens')}")
     ```
 
-=== "TypeScript"
-
-    {{ ts_not_supported_code("Automatic cache strategy is not yet supported in the TypeScript SDK") }}
+{{ ts_not_supported_code("Automatic cache strategy is not yet supported in the TypeScript SDK") }}
 
 > **Note**: Cache misses occur if you intentionally modify past conversation context (e.g., summarization or editing previous messages).
 


### PR DESCRIPTION
## Summary

Add documentation for the automatic prompt caching feature introduced in [sdk-python PR #1438](https://github.com/strands-agents/sdk-python/pull/1438).

## Changes

- Add automatic cache strategy (Option A) for Messages Caching
- Update Caching section overview with Claude/Nova model support
- Add pricing considerations and link to AWS Bedrock pricing page
- Clarify Claude-only limitation for automatic strategy
- Simplify System Prompt Caching section for consistency

## Related Issue

Closes #484