### PR TITLE
add ES module configuration to TypeScript quickstart

### DIFF
--- a/docs/user-guide/quickstart/typescript.md
+++ b/docs/user-guide/quickstart/typescript.md
@@ -17,6 +17,7 @@ Create a new directory for your project and initialize it:
 mkdir my-agent
 cd my-agent
 npm init -y
+npm pkg set type=module
 ```
 
 Learn more about the [npm init command](https://docs.npmjs.com/cli/v8/commands/npm-init) and its options.


### PR DESCRIPTION
## Description
This pull request updates the TypeScript quickstart guide to ensure compatibility with ES modules by setting the package type to `module` during project initialization.

- Documentation improvements:
  * Added the command `npm pkg set type=module` to the setup instructions in `docs/user-guide/quickstart/typescript.md` to clarify that the project should use ES module syntax.

## Related Issues
Fixes #485


## Type of Change
<!-- What kind of change are you making -->

- Content update/revision
- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
