### PR TITLE
docs: add tool simulator example

### DIFF
--- a/docs/examples/evals-sdk/tool_simulator.py
+++ b/docs/examples/evals-sdk/tool_simulator.py
@@ -1,8 +1,8 @@
-from typing import Dict, Any
+from typing import Any
 from enum import Enum
 from pydantic import BaseModel, Field
 
-from strands import Agent, tool
+from strands import Agent
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import GoalSuccessRateEvaluator
 from strands_evals.simulation.tool_simulator import ToolSimulator
@@ -35,7 +35,7 @@ class HVACControllerResponse(BaseModel):
     initial_state_description="Room environment: temperature 68°F, humidity 45%, HVAC off",
     output_schema=HVACControllerResponse
 )
-def hvac_controller(temperature: float, mode: str) -> Dict[str, Any]:
+def hvac_controller(temperature: float, mode: str) -> dict[str, Any]:
     """Control home heating/cooling system that affects room temperature and humidity."""
     pass
 


### PR DESCRIPTION
## Description
Adds comprehensive documentation and examples for the ToolSimulator framework introduced in strands-agents/evals. Demonstrates realistic multi-turn agent evaluation scenarios with simulated tools.

Key additions:
- Complete smart home example (tool_simulator.py) showcasing all three simulation modes working together with shared state
- Multi-agent workflow demonstration with agent-as-tool pattern using hvac_control_assistant sub-agent
- State inspection utilities showing how to track state changes across tool invocations

## Related Issues
https://github.com/strands-agents/evals/issues/93


## Type of Change
- New content

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
