### PR TITLE
docs: Remove redundant section from user guide

### DIFF
--- a/docs/user-guide/concepts/tools/index.md
+++ b/docs/user-guide/concepts/tools/index.md
@@ -177,28 +177,6 @@ When models return multiple tool requests, you can control whether they execute 
 
 {{ ts_not_supported_code() }}
 
-## Tool Executors
-
-When models return multiple tool requests, you can control whether they execute concurrently or sequentially. Agents use concurrent execution by default, but you can specify sequential execution for cases where order matters:
-
-```python
-from strands import Agent
-from strands.tools.executors import SequentialToolExecutor
-
-# Concurrent execution (default)
-agent = Agent(tools=[weather_tool, time_tool])
-agent("What is the weather and time in New York?")
-
-# Sequential execution
-agent = Agent(
-    tool_executor=SequentialToolExecutor(),
-    tools=[screenshot_tool, email_tool]
-)
-agent("Take a screenshot and email it to my friend")
-```
-
-For more details, see [Tool Executors](executors.md).
-
 ## Building & Loading Tools
 
 ### 1. Custom Tools


### PR DESCRIPTION
Removed redundant section on Tool Executors.

## Description
There are two "Tool Executors" section in the user guide redundantly; this change removes one of them.  

## Type of Change
- Typo/formatting fix

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
