### PR TITLE
add env for strands-command

### DIFF
--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -109,6 +109,10 @@ jobs:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           sessions_bucket: ${{ secrets.AGENT_SESSIONS_BUCKET }}
           write_permission: 'false'
+          langfuse_public_key: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          langfuse_secret_key: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          langfuse_host: ${{ secrets.LANGFUSE_HOST }}
+          evals_sqs_queue_arn: ${{ secrets.EVALS_SQS_QUEUE_ARN }}
 
   finalize:
     needs: [setup-and-process, execute-readonly-agent]


### PR DESCRIPTION
## Description
This pull request updates the GitHub Actions workflow configuration to add new environment variables required for integrations and evaluation processing.

**Workflow configuration updates:**

* Added `langfuse_public_key`, `langfuse_secret_key`, and `langfuse_host` environment variables to support Langfuse integration.
* Added `evals_sqs_queue_arn` environment variable to enable evaluation queue processing.


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content
- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
