### PR TITLE
docs: add S3 location support documentation for Bedrock multimodal content

### DIFF
--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -382,7 +382,8 @@ As an alternative to providing media content as bytes, Amazon Bedrock supports r
                     "format": "pdf",
                     "name": "report.pdf",
                     "source": {
-                        "s3Location": {
+                        "location": {
+                            "type": "s3",
                             "uri": "s3://my-bucket/documents/report.pdf",
                             "bucketOwner": "123456789012"  # Optional: for cross-account access
                         }

--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -359,6 +359,56 @@ Some Bedrock models support multimodal inputs (Documents, Images, etc.). Here's 
 
 For a complete list of input types, please refer to the [API Reference](../../../api-reference/python/types/content.md).
 
+#### S3 Location Support
+
+As an alternative to providing media content as bytes, Amazon Bedrock supports referencing documents, images, and videos stored in Amazon S3 directly. This is useful when working with large files or when your content is already stored in S3.
+
+!!! note "IAM Permissions Required"
+
+    To use S3 locations, the IAM role or user making the Bedrock API call must have `s3:GetObject` permission on the S3 bucket and objects being referenced.
+
+=== "Python"
+
+    ```python
+    from strands import Agent
+    from strands.models import BedrockModel
+
+    agent = Agent(model=BedrockModel())
+
+    response = agent(
+        [
+            {
+                "document": {
+                    "format": "pdf",
+                    "name": "report.pdf",
+                    "source": {
+                        "s3Location": {
+                            "uri": "s3://my-bucket/documents/report.pdf",
+                            "bucketOwner": "123456789012"  # Optional: for cross-account access
+                        }
+                    }
+                }
+            },
+            {
+                "text": "Summarize this document."
+            }
+        ]
+    )
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    --8<-- "user-guide/concepts/model-providers/amazon-bedrock.ts:s3_location"
+    ```
+
+!!! tip "Supported Media Types"
+
+    The same `s3Location` pattern works for images and videos:
+
+    - **Images**: Use the `image` block with `s3Location` source
+    - **Videos**: Use the `video` block with `s3Location` source (supports files up to 1GB)
+
 ### Guardrails
 
 === "Python"

--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.md
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.md
@@ -404,10 +404,7 @@ As an alternative to providing media content as bytes, Amazon Bedrock supports r
 
 !!! tip "Supported Media Types"
 
-    The same `s3Location` pattern works for images and videos:
-
-    - **Images**: Use the `image` block with `s3Location` source
-    - **Videos**: Use the `video` block with `s3Location` source (supports files up to 1GB)
+    The same `s3Location` pattern also works for images and videos.
 
 ### Guardrails
 

--- a/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -194,6 +194,27 @@ async function multimodalSupport() {
   // --8<-- [end:multimodal_full]
 }
 
+// S3 location support for multimodal content
+async function s3LocationSupport() {
+  // --8<-- [start:s3_location]
+  const agent = new Agent({ model: new BedrockModel() })
+
+  const response = await agent.invoke([
+    new DocumentBlock({
+      format: 'pdf',
+      name: 'report.pdf',
+      source: {
+        s3Location: {
+          uri: 's3://my-bucket/documents/report.pdf',
+          bucketOwner: '123456789012', // Optional: for cross-account access
+        },
+      },
+    }),
+    'Summarize this document.',
+  ])
+  // --8<-- [end:s3_location]
+}
+
 // System prompt caching
 async function systemPromptCachingFull() {
   // --8<-- [start:system_prompt_caching_full]
@@ -209,7 +230,7 @@ async function systemPromptCachingFull() {
   // First request will cache the system prompt
   let cacheWriteTokens = 0
   let cacheReadTokens = 0
-  
+
   for await (const event of agent.stream('Tell me about Python')) {
     if (event.type === 'modelMetadataEvent' && event.usage) {
       cacheWriteTokens = event.usage.cacheWriteInputTokens || 0


### PR DESCRIPTION
## Description

Adds documentation for S3 location support in multimodal content (documents, images, videos) to the Amazon Bedrock model provider documentation. This feature allows users to reference media files stored in S3 directly rather than requiring base64 encoding.

## Changes

### Documentation Updates (`amazon-bedrock.md`)
- Added "S3 Location Support" subsection under "Multimodal Support"
- Included Python example showing `s3Location` usage with document block
- Included TypeScript example using `DocumentBlock` with `s3Location` source
- Added IAM permissions note explaining `s3:GetObject` requirement
- Added tip about support for images and videos with S3 locations

### TypeScript Example (`amazon-bedrock.ts`)
- Added `s3LocationSupport()` function with snippet markers for documentation inclusion

## Implementation Details

The S3 location source provides an alternative to `bytes` for media content:
- `uri`: S3 URI in format `s3://bucket-name/key-name`
- `bucketOwner`: Optional AWS account ID for cross-account access

## Testing

- ✅ TypeScript compiles without errors (`npm run test`)
- ✅ All existing tests pass

## References

- [SDK Python PR #1572](https://github.com/strands-agents/sdk-python/pull/1572) - Feature implementation
- [TypeScript SDK media.ts](https://github.com/strands-agents/sdk-typescript/blob/main/src/types/media.ts) - TypeScript S3Location type

Resolves #506