### PR TITLE
docs(decisions): add high/low level api guidance

### DIFF
--- a/team/DECISIONS.md
+++ b/team/DECISIONS.md
@@ -141,4 +141,4 @@ The `run` method builds on these to abstract the complexity. Users provide IO ca
 await agent.run(inputs=[audio_input], outputs=[audio_output, text_output])
 ```
 
-This pattern aligns with **progressive disclosure** from UX design: show users what they need for common tasks while making advanced capabilities discoverable when needed.
+This pattern aligns with progressive disclosure from UX design: show users what they need for common tasks while making advanced capabilities discoverable when needed.


### PR DESCRIPTION
## Description

Adds a new decision record documenting our approach to API design: providing both low-level and high-level APIs for new features.

This decision formalizes the pattern we've been following (e.g., in `BidiAgent` with `send`/`receive` vs `run`) and provides rationale grounded in our tenets. It references the **progressive disclosure** principle from UX design and the **pit of success** concept.

This pattern is well-established in SDK design — AWS CDK uses similar "construct levels" (L1/L2/L3) where lower levels map directly to underlying resources while higher levels provide opinionated abstractions.

## Related Issues

N/A

## Type of Change

- [x] New content
- [ ] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
