### PR TITLE
fix: add xAI to model providers navigation and index

### DIFF
--- a/docs/user-guide/concepts/model-providers/index.md
+++ b/docs/user-guide/concepts/model-providers/index.md
@@ -26,6 +26,7 @@ The following table shows all model providers supported by Strands Agents SDK an
 | [Cohere](cohere.md)                          | ✅ | ❌ |
 | [CLOVA Studio](clova-studio.md)              | ✅ | ❌ |
 | [FireworksAI](fireworksai.md)                | ✅ | ❌ |
+| [xAI](xai.md)                                | ✅ | ❌ |
 
 ## Getting Started
 

--- a/docs/user-guide/concepts/model-providers/xai.md
+++ b/docs/user-guide/concepts/model-providers/xai.md
@@ -1,0 +1,3 @@
+<auto-redirect />
+
+This guide has moved to [community/model-providers/xai](../../../community/model-providers/xai.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
         - CLOVA Studio<sup> community</sup>: user-guide/concepts/model-providers/clova-studio.md
         - FireworksAI<sup> community</sup>: user-guide/concepts/model-providers/fireworksai.md
         - Nebius Token Factory<sup> community</sup>: user-guide/concepts/model-providers/nebius-token-factory.md
+        - xAI<sup> community</sup>: user-guide/concepts/model-providers/xai.md
       - Streaming:
         - Overview: user-guide/concepts/streaming/index.md
         - Async Iterators: user-guide/concepts/streaming/async-iterators.md


### PR DESCRIPTION
## Summary

Adds missing xAI model provider references to the main model providers section. PR #504 added xAI documentation to the
community section but missed adding it to:

- Model providers navigation in mkdocs.yml
- Model providers index table
- Redirect stub file

## Changes

- Add xai.md redirect stub in docs/user-guide/concepts/model-providers/
- Add xAI entry to the providers table in index.md
- Add xAI to mkdocs.yml nav under model-providers (with community badge)

## Related

- Follows up on #504