### PR TITLE
Remove under construction bidi otel page

### DIFF
--- a/docs/user-guide/concepts/bidirectional-streaming/otel.md
+++ b/docs/user-guide/concepts/bidirectional-streaming/otel.md
@@ -1,6 +1,0 @@
-# OpenTelemetry Integration [Experimental]
-
-{{ experimental_feature_warning() }}
-
-!!! info "Under Construction"
-    OpenTelemetry support for bidirectional streaming is currently under development. Check back soon for information on observability, tracing, and monitoring capabilities.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,7 +149,6 @@ nav:
         - Interruptions: user-guide/concepts/bidirectional-streaming/interruption.md
         - Hooks: user-guide/concepts/bidirectional-streaming/hooks.md
         - Session Management: user-guide/concepts/bidirectional-streaming/session-management.md
-        - Observability: user-guide/concepts/bidirectional-streaming/otel.md
       - Experimental:
         - AgentConfig: user-guide/concepts/experimental/agent-config.md
         - Steering: user-guide/concepts/experimental/steering.md


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->
In this PR, we are removing the under construction page for bidirectional otel. This is done so that bidi otel is not "under construction" forever. This page will be reintroduced as effort is focused towards moving bidirectional streaming out of experimental on the strands roadmap. Till then, it makes sense to remove this page. 


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `mkdocs serve`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
