### PR TITLE
fix: Don't auto-redirect to GitHub

### DIFF
--- a/docs/assets/auto-redirect.js
+++ b/docs/assets/auto-redirect.js
@@ -6,7 +6,9 @@
 class AutoRedirect extends HTMLElement {
     connectedCallback() {
         const currentUrl = window.location.href;
-        const link = this.parentElement.closest(".md-content")?.querySelector("a[href]")
+        const links = this.parentElement.closest(".md-content")?.querySelectorAll("a[href]") || [];
+        // exclude links to github as those are edit links
+        const link = Array.from(links).find(a => !a.href.includes("github.com"));
 
         if (link) {
             // immediately redirecting makes a flash of content, so do it after a second


### PR DESCRIPTION
## Description

Bug: [This page](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/model-providers/clova-studio/) incorrectly redirects to github instead of our documentation page.

Currently our auto-redirect hack is redirecting to GitHub since the "edit page in github" is now the first link in the content.  Exclude github links from the "first-link" detection to avoid that.

Note: In the new CMS, we'll have a more robust system for redirects and this will go away

## Type of Change
<!-- What kind of change are you making -->

- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
