### PR TITLE
interrupts - graph - multiagentbase supported

### DIFF
--- a/docs/user-guide/concepts/interrupts.md
+++ b/docs/user-guide/concepts/interrupts.md
@@ -420,9 +420,6 @@ print(f"MESSAGE: {json.dumps(result.results['cleanup'].result.message, indent=2)
 
 Graphs also support interrupts raised from within the nodes themselves following any of the single-agent interrupt patterns outlined above.
 
-!!! warning
-    Support for raising interrupts from multi-agent nodes is still under development. For status updates, please see [here](https://github.com/strands-agents/sdk-python/issues/204).
-
 #### Components
 
 - `event.interrupt` - Raises an interrupt with a unique name and optional reason


### PR DESCRIPTION
## Description
Interrupts from a multi-agent node is now supported in graphs ([PR](https://github.com/strands-agents/sdk-python/pull/1606)).


## Related Issues
https://github.com/strands-agents/sdk-python/issues/204


## Type of Change
- Content update/revision

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
