### PR TITLE
feat: Add new CMS documentation preview

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,168 @@
+name: Deploy Docs Preview
+
+on:
+  pull_request_target:
+    branches:
+      # TODO once we merge the new CMS to main, adjust this
+      - 'workstream/cms-migration'
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: preview-cms-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  authorization-check:
+    name: Authorization Check
+    permissions: read-all
+    runs-on: ubuntu-latest
+    outputs:
+      approval-env: ${{ steps.auth.outputs.result }}
+    steps:
+      - name: Check Authorization
+        id: auth
+        uses: strands-agents/devtools/authorization-check@main
+        with:
+          username: ${{ github.event.pull_request.user.login }}
+          allowed-roles: 'write,maintain,admin'
+
+  build-and-deploy:
+    name: Build and Deploy Preview
+    runs-on: ubuntu-latest
+    needs: authorization-check
+    environment: ${{ needs.authorization-check.outputs.approval-env }}
+
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write # For OIDC authentication
+
+    env:
+      # PR metadata
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      RUN_ID: ${{ github.run_id }}
+      # Secrets
+      AWS_DEPLOY_ROLE: ${{ secrets.STRANDS_DOCS_DEPLOY_ROLE }}
+      S3_BUCKET: ${{ secrets.STRANDS_DOCS_BUCKET }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      CLOUDFRONT_DOMAIN: ${{ secrets.CLOUDFRONT_DOMAIN }}
+      # Derived paths (defined once, used everywhere)
+      BUILD_OUTPUT_DIR: dist
+      S3_PATH: pr-cms-${{ github.event.pull_request.number }}
+      # TODO - update subpath to point at root instead of subfolder
+      PREVIEW_URL: https://${{ secrets.CLOUDFRONT_DOMAIN }}/pr-cms-${{ github.event.pull_request.number }}/user-guide/quickstart/overview/
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Checkout head commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.PR_HEAD_SHA }}
+          persist-credentials: false # Don't persist credentials for subsequent actions
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build CMS
+        env:
+          ASTRO_BASE_PATH: /${{ env.S3_PATH }}/
+        run: npm run cms:build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE }}
+          role-session-name: GitHubActions-Docs-${{ env.RUN_ID }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
+
+      - name: Deploy to S3
+        run: |
+          aws s3 sync ${{ env.BUILD_OUTPUT_DIR }}/ s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/ \
+            --cache-control "public, max-age=3600"
+
+      - name: Invalidate CloudFront cache for PR preview
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --invalidation-batch '{"Paths":{"Quantity":1,"Items":["/${{ env.S3_PATH }}/*"]},"CallerReference":"'$(date +%s)'"}'
+
+      - name: Output deployment info
+        run: |
+          echo "Deployment complete!"
+          echo "Deployed to: ${{ env.PREVIEW_URL }}"
+          echo "This is a preview deployment for PR #${{ env.PR_NUMBER }}"
+
+      - name: Comment on PR (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = '${{ env.PREVIEW_URL }}';
+
+            // Find existing bot comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Documentation Preview')
+            );
+
+            const body = [
+              '## Documentation Preview Ready',
+              '',
+              'Your documentation preview has been successfully deployed!',
+              '',
+              `**Preview URL**: ${previewUrl}`,
+              '',
+              `_Updated at: ${new Date().toISOString()}_`
+            ].join('\n');
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }
+
+      - name: Comment on PR (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const runUrl = '${{ env.RUN_URL }}';
+
+            const body = [
+              '## Documentation Preview Failed',
+              '',
+              `The documentation deployment encountered an error. Please check the [deployment logs](${runUrl}) for more details.`
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body
+            });


### PR DESCRIPTION
## Description

Add a new workflow which creates previews of the documentation using a workflow in this repository instead of the site repository.  This is the flow that the new CMS will be using going forward.

This is a revamp of #536 - the original workflow was flawed because workflows running against pull_request target don't have access to secrets, and thus it cannot deploy to S3.  Instead we need to use pull_request_target which then means we need to use environments and the workflow needs to work on the main branch.

The workflow is a port of the one in #536 but now following the same flow we use for integ tests:

 - Determine which environment to deploy to (github org members get auto deployed) using the shared action
 - Subsequent steps build & deploy to S3

An example of this flow exists at https://github.com/zastrowm/docs/pull/11

A follow up change will remove the old workflow from the `workstream/cms-migration` branch, which is no longer needed (since it doesn't work).

## Related Issues

https://github.com/strands-agents/docs/issues/441

## Type of Change
<!-- What kind of change are you making -->

- Other (please describe): Workflow

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
