### PR TITLE
Match the colorings of strandsagents.com

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,13 +32,25 @@ export default defineConfig({
     remarkPlugins: [remarkMkdocsSnippets],
   },
   integrations: [
-    astroExpressiveCode(),
+    astroExpressiveCode({
+      // Use themes that complement the Strands color scheme
+      themes: ['github-light', 'github-dark'],
+      styleOverrides: {
+        // Match the accent color from the site theme
+        frames: {
+          shadowColor: 'transparent',
+        },
+      },
+    }),
     mdx(),
     starlight({
     title: 'Strands Agents SDK',
     description: 'A model-driven approach to building AI agents in just a few lines of code.',
     sidebar: sidebar,
     routeMiddleware: './src/route-middleware.ts',
+    customCss: [
+      './src/styles/custom.css',
+    ],
     logo: {
       light: './src/assets/logo-light.svg',
       dark: './src/assets/logo-dark.svg',

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,0 +1,57 @@
+/**
+ * Strands Agents Documentation Theme
+ * 
+ * Color scheme from strandsagents.com theme-overrides.css:
+ * - Logo green: #00cc5f
+ * - Bright green: #00FF77
+ * - Dark bg: #0E0E0E
+ */
+
+/* Dark mode colors. */
+:root {
+	--sl-color-accent-low: #0a2e12;
+	--sl-color-accent: #00cc5f;
+	--sl-color-accent-high: #00FF77;
+	--sl-color-white: #ffffff;
+	--sl-color-gray-1: #E0E0E0;
+	--sl-color-gray-2: #c8d0d8;
+	--sl-color-gray-3: #a0a8b0;
+	--sl-color-gray-4: #777777;
+	--sl-color-gray-5: #333333;
+	--sl-color-gray-6: #1F1F1F;
+	--sl-color-black: #0E0E0E;
+	/* Link hover color - same in light & dark mode */
+	--sl-color-link-hover: #00cc5f;
+}
+
+/* Light mode colors. */
+:root[data-theme='light'] {
+	--sl-color-accent-low: #d4f5e0;
+	--sl-color-accent: #00cc5f;
+	--sl-color-accent-high: #00B353;
+	--sl-color-white: #0E0E0E;
+	--sl-color-gray-1: #1F1F1F;
+	--sl-color-gray-2: #3d4349;
+	--sl-color-gray-3: #555555;
+	--sl-color-gray-4: #777777;
+	--sl-color-gray-5: #d0d7de;
+	--sl-color-gray-6: #E0E0E0;
+	--sl-color-gray-7: #F9F9F9;
+	--sl-color-black: #ffffff;
+}
+
+/* Link hover - green text color (uses same color in light & dark mode) */
+a:hover {
+	color: var(--sl-color-link-hover);
+}
+
+/* Don't change color on hover for selected sidebar items (has green background) */
+a[aria-current="page"]:hover {
+	color: var(--sl-color-text-invert);
+}
+
+
+/* Layout */
+:root {
+	--sl-content-width: 50rem;
+}


### PR DESCRIPTION
Note: This is targeting the workstream/cms-migration branch.

----

Migrate to a custom color scheme that better matches strandsagents.com

## Related Issues

#441

- Other (please describe): CMS Migration

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
