### PR TITLE
fix: update steering docs to reference it as a plugin

### DIFF
--- a/docs/user-guide/concepts/experimental/steering.md
+++ b/docs/user-guide/concepts/experimental/steering.md
@@ -105,7 +105,7 @@ handler = LLMSteeringHandler(
 
 agent = Agent(
     tools=[send_email],
-    hooks=[handler]  # Steering handler integrates as a hook
+    plugins=[handler]  # Steering handler integrates as a plugin
 )
 
 # Agent receives guidance about email tone


### PR DESCRIPTION
## Description
Update steering to say its a plugin and not a hook

## Related Issues
https://github.com/strands-agents/sdk-python/pull/1738


## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
