### PR TITLE
docs: app state alias agent state

### DIFF
--- a/docs/user-guide/concepts/agents/state.md
+++ b/docs/user-guide/concepts/agents/state.md
@@ -131,7 +131,7 @@ See [Conversation Management](conversation-management.md) for more information a
 
 ## Agent State
 
-Agent state (also called user state) provides key-value storage for stateful information that exists outside of the conversation context. Unlike conversation history, agent state is not passed to the model during inference but can be accessed and modified by tools and application logic.
+Agent state (also called app state) provides key-value storage for stateful information that exists outside of the conversation context. Unlike conversation history, agent state is not passed to the model during inference but can be accessed and modified by tools and application logic.
 
 ### Basic Usage
 


### PR DESCRIPTION
## Description

The TypeScript SDK is renaming `AgentState` to `AppState` (strands-agents/sdk-typescript#433). This adds an inline "(also called app state)" note to the Agent State section in the state management docs so TypeScript users can connect the concept to the `AppState` class name.

Note, any references to AgentState in the TypeScript API docs will automatically update after https://github.com/strands-agents/sdk-typescript/pull/591 is merged.

## Related Issues

strands-agents/sdk-typescript#433
strands-agents/sdk-typescript#591

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.