### PR TITLE
fix: update TypeScript api docs to use MDX by escaping the markdown

### DIFF
--- a/CMS-README.md
+++ b/CMS-README.md
@@ -475,9 +475,11 @@ The generation script performs these transformations after typedoc runs:
    ---
    ```
 
-2. **Fixes relative links** to match the flat slug structure (e.g., `../interfaces/AgentData.md` → `../AgentData.md`)
+2. **Fixes relative links** to match the flat slug structure (e.g., `../interfaces/AgentData.md` → `../AgentData.md`) and updates `.md` extensions to `.mdx`.
 
-3. **Deletes the generated index.md** - We use our own custom index page instead
+3. **Converts to MDX** — runs content through a `unified`/`remark-gfm` pipeline with `mdxToMarkdown()` serialization, which escapes characters that are valid in markdown but invalid in MDX (e.g. `{`, `}` outside code blocks). Content inside code fences is left untouched. Files are written as `.mdx` instead of `.md`. A targeted replacement also handles the literal string `<name>Data` that typedoc emits in prose to describe the naming pattern for data interfaces.
+
+4. **Deletes the generated index.md** - We use our own custom index page instead
 
 ### Flat Slugs with Category Grouping
 
@@ -701,3 +703,9 @@ The `src/util/links.ts` module was extended:
 ```
 
 Type declarations in `src/types/turndown-plugin-gfm.d.ts` (no @types package available).
+
+## Dependency Version Pinning
+
+### `astro-broken-links-checker`
+
+This package is pinned to an exact version (`1.0.6`) rather than using a semver range. It's a low-popularity package, so we avoid automatic updates to prevent potentially pulling in malicious or breaking changes without an explicit review. Before upgrading, manually inspect the changelog and diff on the package's repository.

--- a/CMS-TODO.md
+++ b/CMS-TODO.md
@@ -8,6 +8,7 @@
 - [ ] Look into markdown 
 - [X] Add header links to Python/TypeScript method sections (api/python/strands.agent.agent/)
 - [ ] Migrate all files and remove conversion scripts
+- [ ] Remove `<name>Data` special-case in `scripts/api-generation-typescript.ts` once typedoc fixes the prose or we find a better general solution
 
 ## After Launch
 - [ ] Move asset files to proper location (currently in `docs/assets/`, should be in `src/content/docs/assets/`)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import { loadSidebarFromMkdocs } from "./src/sidebar.ts"
 import AutoImport from './src/plugins/astro-auto-import.ts'
 import astroExpressiveCode from "astro-expressive-code"
 import mdx from '@astrojs/mdx';
+import astroBrokenLinksChecker from 'astro-broken-links-checker';
 
 // Generate sidebar from mkdocs nav (validates against existing content files)
 // Top-level groups will be rendered as tabs by the custom Sidebar component
@@ -78,6 +79,12 @@ export default defineConfig({
         Sidebar: './src/components/overrides/Sidebar.astro',
       },
   }),
+   astroBrokenLinksChecker({
+      checkExternalLinks: false,       // Optional: check external links (default: false)
+      cacheExternalLinks: false,       // Optional: cache verified external links to disk (default: true)
+      throwError: false,               // Optional: fail the build if broken links are found (default: false)
+      linkCheckerDir: '.link-checker' // Optional: directory for cache and log files (default: '.link-checker')
+    }),
    AutoImport({
       imports: [
         {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@strands-agents/sdk": "github:strands-agents/sdk-typescript",
     "@types/express": "^5.0.5",
     "@types/turndown": "^5.0.6",
+    "astro-broken-links-checker": "1.0.6",
     "express": "^5.1.0",
     "prettier": "^3.6.2",
     "turndown": "^7.2.2",

--- a/scripts/api-generation-typescript.ts
+++ b/scripts/api-generation-typescript.ts
@@ -11,6 +11,11 @@
 import { execSync } from 'child_process'
 import { existsSync, readdirSync, readFileSync, writeFileSync, rmSync, statSync } from 'fs'
 import { join, basename, relative } from 'path'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkStringify from 'remark-stringify'
+import { mdxToMarkdown } from 'mdast-util-mdx'
 
 const OUTPUT_DIR = '.build/api-docs/typescript'
 
@@ -81,9 +86,22 @@ function generateTitle(category: string, name: string): string {
 }
 
 /**
- * Process a single file to add frontmatter
+ * Escape MDX-unsafe characters in markdown content using the unified pipeline.
+ * Parses as GFM markdown, then serializes with mdxToMarkdown() which escapes
+ * characters like { } that are valid in markdown but invalid in MDX outside code blocks.
+ * Content inside code fences is left untouched.
  */
-function processFile(file: FileInfo): void {
+async function escapeMdxChars(content: string): Promise<string> {
+  const processor = unified().use(remarkParse).use(remarkGfm).use(remarkStringify)
+  processor.data('toMarkdownExtensions', [mdxToMarkdown()])
+  const result = await processor.process(content)
+  return String(result)
+}
+
+/**
+ * Process a single file: add frontmatter, escape MDX-unsafe chars, write as .mdx
+ */
+async function processFile(file: FileInfo): Promise<void> {
   const content = readFileSync(file.path, 'utf-8')
 
   // Check if frontmatter already exists
@@ -102,11 +120,17 @@ function processFile(file: FileInfo): void {
   }
 
   // Fix relative links to remove category folders (e.g., ../interfaces/AgentData.md -> ../AgentData.md)
-  // This matches the flat slug structure we use
-  const processedContent = content.replace(
-    /\]\(\.\.\/(classes|interfaces|type-aliases|functions)\/([^)]+)\)/g,
-    '](../$2)'
-  )
+  // Also update .md extensions to .mdx in relative links since we output .mdx files
+  const linkedFixed = content
+    .replace(/\]\(\.\.\/(classes|interfaces|type-aliases|functions)\/([^)]+)\)/g, '](../$2)')
+    .replace(/\]\((\.\.[^)]+)\.md((?:#[^)]+)?)\)/g, ']($1.mdx$2)')
+
+  // Special-case: escape the literal string "<name>Data" which typedoc emits in prose
+  // to describe the naming pattern for data interfaces (e.g. "the <name>Data pattern")
+  const specialCased = linkedFixed.replace(/<name>Data/g, '\\<name>Data')
+
+  // Escape MDX-unsafe characters (e.g. { } outside code blocks)
+  const mdxSafe = await escapeMdxChars(specialCased)
 
   // Add frontmatter with category for sidebar grouping
   const frontmatter = `---
@@ -118,16 +142,20 @@ editUrl: false
 
 `
 
-  const finalContent = frontmatter + processedContent
+  const finalContent = frontmatter + mdxSafe
 
-  writeFileSync(file.path, finalContent, 'utf-8')
-  console.log(`Processed: ${file.path}`)
+  // Write as .mdx instead of .md
+  const mdxPath = file.path.replace(/\.md$/, '.mdx')
+  writeFileSync(mdxPath, finalContent, 'utf-8')
+  // Remove the original .md file
+  rmSync(file.path)
+  console.log(`Processed: ${file.path} → ${basename(mdxPath)}`)
 }
 
 /**
  * Main function
  */
-function main(): void {
+async function main(): Promise<void> {
   console.log('🔧 TypeScript API Documentation Generator\n')
 
   // Step 1: Clean output directory
@@ -159,10 +187,10 @@ function main(): void {
       console.log(`Deleted: ${file.path} (using custom index)`)
       continue
     }
-    processFile(file)
+    await processFile(file)
   }
 
   console.log(`\n✅ Done! Generated ${files.length - 1} API doc files.`)
 }
 
-main()
+main().catch(console.error)


### PR DESCRIPTION

## Description

Update TypeScript api docs to use MDX by escaping the markdown

Previously the links being generated from TS were incorrect as they weren't getting our mdx enhancements which allow for linking to files instead of using slugs.  So now instead of writing markdown files, we do a safe conversion from md -> mdx which picks up all of our fixes.

Follow-ups:

 - We should also port the python api docs to use this instead of our regex fixes that we're currently do; I will catch that in a follow-up.
 - The index page for TS is currently mis-generated because of the "telemetry" namespace that the TS SDK now generates; that's a known issue that I'll grab in a follow-up


----

As part of this PR I've also added link verification that runs as part of the build; previous to this we got a bunch of warnings about TS; now it's only showing a couple that are due to the recent telemetry changes.

```
16:43:31 [astro-broken-links-checker] Broken link: /api/interfaces/TracerConfig/
  Found in:
    - /api/typescript/
Broken link: /api/functions/setupTracer/
  Found in:
    - /api/typescript/
16:43:31 [astro-broken-links-checker] Time to check links: 2040 ms
```

Once I fix these, I'll change to this be errors

## Related Issues

#441 

## Type of Change

- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
