### PR TITLE
feat: Account for namespaces in TS generation

### DIFF
--- a/CMS-README.md
+++ b/CMS-README.md
@@ -450,7 +450,7 @@ npx tsx scripts/api-generation-typescript.ts
 ```
 
 **Input:** `.build/sdk-typescript/src` (cloned SDK repository)
-**Output:** `.build/api-docs/typescript/{classes,interfaces,type-aliases,functions}/*.md`
+**Output:** `.build/api-docs/typescript/{classes,interfaces,type-aliases,functions,namespaces}/*.md`
 
 ### TypeDoc Configuration (`typedoc.json`)
 
@@ -474,8 +474,17 @@ The generation script performs these transformations after typedoc runs:
    editUrl: false
    ---
    ```
+   For namespace members, the slug includes the namespace as a prefix separated by a colon:
+   ```yaml
+   ---
+   title: "setupTracer"
+   slug: api/typescript/telemetry:setupTracer
+   category: functions
+   editUrl: false
+   ---
+   ```
 
-2. **Fixes relative links** to match the flat slug structure (e.g., `../interfaces/AgentData.md` → `../AgentData.md`) and updates `.md` extensions to `.mdx`.
+2. **Fixes relative links** to match the flat slug structure (e.g., `../interfaces/AgentData.md` → `../AgentData.md`) and updates `.md` extensions to `.mdx`. For namespace members and namespace index pages, cross-member links are rewritten to absolute slug paths (e.g., `[TracerConfig](../interfaces/TracerConfig.md)` → `[TracerConfig](/api/typescript/telemetry:TracerConfig)`) to ensure correct resolution regardless of the page's own URL.
 
 3. **Converts to MDX** — runs content through a `unified`/`remark-gfm` pipeline with `mdxToMarkdown()` serialization, which escapes characters that are valid in markdown but invalid in MDX (e.g. `{`, `}` outside code blocks). Content inside code fences is left untouched. Files are written as `.mdx` instead of `.md`. A targeted replacement also handles the literal string `<name>Data` that typedoc emits in prose to describe the naming pattern for data interfaces.
 
@@ -488,6 +497,14 @@ Unlike Python API docs which use hierarchical slugs based on module paths, TypeS
 - The `category` frontmatter field is used for sidebar grouping
 
 This keeps URLs clean while still organizing the sidebar by type (Classes, Interfaces, Type Aliases, Functions).
+
+### Namespace Exports
+
+When the SDK exports a namespace (e.g., `export * as telemetry from './telemetry/index.js'`), typedoc generates a nested directory structure under `namespaces/<ns>/`. The generation script handles this specially:
+
+- The namespace index page (`namespaces/<ns>/index.md`) is kept and written as `namespaces/<ns>.mdx` with slug `api/typescript/<ns>` and category `namespaces`.
+- Members of the namespace (classes, interfaces, functions, etc.) are flattened into the same top-level category directories as regular exports, but their slugs are prefixed with the namespace name using a colon separator: `api/typescript/<ns>:<MemberName>`.
+- All cross-member links within a namespace are rewritten to absolute slug paths to avoid broken relative links after flattening.
 
 ### Symlink Setup
 
@@ -510,18 +527,22 @@ The index page (`src/content/docs/api/typescript/index.mdx`) is a permanent file
 
 **Example structure:**
 ```
+Namespaces
+  └── telemetry
 Classes
   ├── Agent
   ├── BedrockModel
   └── Tool
 Interfaces
   ├── AgentConfig
+  ├── TracerConfig       ← namespace member, slug: api/typescript/telemetry:TracerConfig
   └── ToolSpec
 Type Aliases
   ├── ContentBlock
   └── ToolChoice
 Functions
   ├── configureLogging
+  ├── setupTracer        ← namespace member, slug: api/typescript/telemetry:setupTracer
   └── tool
 ```
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -80,9 +80,9 @@ export default defineConfig({
       },
   }),
    astroBrokenLinksChecker({
-      checkExternalLinks: false,       // Optional: check external links (default: false)
-      cacheExternalLinks: false,       // Optional: cache verified external links to disk (default: true)
-      throwError: false,               // Optional: fail the build if broken links are found (default: false)
+      checkExternalLinks: false,      // Optional: check external links (default: false)
+      cacheExternalLinks: false,      // Optional: cache verified external links to disk (default: true)
+      throwError: true,               // Optional: fail the build if broken links are found (default: false)
       linkCheckerDir: '.link-checker' // Optional: directory for cache and log files (default: '.link-checker')
     }),
    AutoImport({

--- a/scripts/api-generation-typescript.ts
+++ b/scripts/api-generation-typescript.ts
@@ -9,7 +9,7 @@
  */
 
 import { execSync } from 'child_process'
-import { existsSync, readdirSync, readFileSync, writeFileSync, rmSync, statSync } from 'fs'
+import { existsSync, readdirSync, readFileSync, writeFileSync, rmSync, statSync, mkdirSync } from 'fs'
 import { join, basename, relative } from 'path'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
@@ -23,6 +23,7 @@ interface FileInfo {
   path: string
   category: string // 'classes', 'interfaces', 'type-aliases', 'functions', or 'index'
   name: string
+  namespace?: string // set for members under namespaces/<ns>/
 }
 
 /**
@@ -48,17 +49,34 @@ function getAllMdFiles(dir: string, baseDir: string = dir): FileInfo[] {
       let category: string
       let name: string
 
+      // Find 'namespaces' segment anywhere in the path (typedoc may nest under a project-name dir)
+      const nsIdx = parts.indexOf('namespaces')
+
       if (parts.length === 1) {
         // Root level file (index.md)
         category = 'index'
         name = basename(entry, '.md')
+        files.push({ path: fullPath, category, name })
+      } else if (nsIdx !== -1 && parts.length > nsIdx + 2) {
+        // Namespace file: [.../namespaces/<ns>/index.md] or [.../namespaces/<ns>/<category>/<Name>.md]
+        const ns = parts[nsIdx + 1]!
+        const afterNs = parts.slice(nsIdx + 2)
+        if (afterNs.length === 1 && basename(entry, '.md') === 'index') {
+          // namespaces/<ns>/index.md — keep as a dedicated namespace page
+          files.push({ path: fullPath, category: 'namespaces', name: ns, namespace: ns })
+        } else if (afterNs.length === 2) {
+          // namespaces/<ns>/<category>/<Name>.md
+          category = afterNs[0]!
+          name = basename(entry, '.md')
+          files.push({ path: fullPath, category, name, namespace: ns })
+        }
+        // deeper nesting not expected; ignore
       } else {
         // Nested file (classes/Agent.md)
         category = parts[0]!
         name = basename(entry, '.md')
+        files.push({ path: fullPath, category, name })
       }
-
-      files.push({ path: fullPath, category, name })
     }
   }
 
@@ -68,9 +86,16 @@ function getAllMdFiles(dir: string, baseDir: string = dir): FileInfo[] {
 /**
  * Generate a slug for a file (flat, without category)
  */
-function generateSlug(category: string, name: string): string {
+function generateSlug(category: string, name: string, namespace?: string): string {
   if (category === 'index') {
     return 'api/typescript'
+  }
+  if (category === 'namespaces') {
+    // Namespace index page: slug is just the namespace name
+    return `api/typescript/${name}`
+  }
+  if (namespace) {
+    return `api/typescript/${namespace}:${name}`
   }
   return `api/typescript/${name}`
 }
@@ -110,7 +135,7 @@ async function processFile(file: FileInfo): Promise<void> {
     return
   }
 
-  const slug = generateSlug(file.category, file.name)
+  const slug = generateSlug(file.category, file.name, file.namespace)
   const title = generateTitle(file.category, file.name)
 
   // For the index file, we'll create a custom one later
@@ -121,9 +146,29 @@ async function processFile(file: FileInfo): Promise<void> {
 
   // Fix relative links to remove category folders (e.g., ../interfaces/AgentData.md -> ../AgentData.md)
   // Also update .md extensions to .mdx in relative links since we output .mdx files
-  const linkedFixed = content
+  // For namespace members, also strip the extra ../ that points up from the category subfolder
+  // For namespace index pages, rewrite category-prefixed links to absolute slug paths
+  //   e.g. interfaces/TracerConfig.md -> /api/typescript/telemetry:TracerConfig
+  let linkedFixed = content
     .replace(/\]\(\.\.\/(classes|interfaces|type-aliases|functions)\/([^)]+)\)/g, '](../$2)')
+    .replace(/\]\(\.\.\/([^./][^)]+\.md(?:#[^)]*)?)\)/g, ']($1)')
+
+  if (file.namespace) {
+    // Rewrite category-prefixed links in namespace pages/members to relative paths
+    linkedFixed = linkedFixed.replace(
+      /\]\((classes|interfaces|type-aliases|functions|namespaces)\/([^)]+?)\.md((?:#[^)]*)?)\)/g,
+      (_match, _cat, name, hash) => `](../${file.namespace}:${name}/${hash})`,
+    )
+    // Also rewrite bare Name.md links (after ../category/ was already stripped) to relative paths
+    linkedFixed = linkedFixed.replace(
+      /\]\(([A-Z][^)/]+?)\.md((?:#[^)]*)?)\)/g,
+      (_match, name, hash) => `](../${file.namespace}:${name}/${hash})`,
+    )
+  }
+
+  linkedFixed = linkedFixed
     .replace(/\]\((\.\.[^)]+)\.md((?:#[^)]+)?)\)/g, ']($1.mdx$2)')
+    .replace(/\]\(([^)]+)\.md((?:#[^)]+)?)\)/g, ']($1.mdx$2)')
 
   // Special-case: escape the literal string "<name>Data" which typedoc emits in prose
   // to describe the naming pattern for data interfaces (e.g. "the <name>Data pattern")
@@ -144,12 +189,16 @@ editUrl: false
 
   const finalContent = frontmatter + mdxSafe
 
-  // Write as .mdx instead of .md
-  const mdxPath = file.path.replace(/\.md$/, '.mdx')
+  // Write as .mdx into the flat category folder at OUTPUT_DIR root (not in-place)
+  const flatDir = join(OUTPUT_DIR, file.category)
+  const mdxPath = join(flatDir, `${file.name}.mdx`)
+  if (!existsSync(flatDir)) {
+    mkdirSync(flatDir, { recursive: true })
+  }
   writeFileSync(mdxPath, finalContent, 'utf-8')
   // Remove the original .md file
   rmSync(file.path)
-  console.log(`Processed: ${file.path} → ${basename(mdxPath)}`)
+  console.log(`Processed: ${file.path} → ${file.category}/${file.name}.mdx`)
 }
 
 /**

--- a/src/dynamic-sidebar.ts
+++ b/src/dynamic-sidebar.ts
@@ -26,6 +26,7 @@ function getCategoryDisplayName(category: string): string {
     interfaces: 'Interfaces',
     'type-aliases': 'Type Aliases',
     functions: 'Functions',
+    namespaces: 'Namespaces',
   }
   return mapping[category] || category
 }
@@ -175,6 +176,7 @@ export function buildTypeScriptApiSidebar(docs: DocInfo[], currentSlug: string):
     interfaces: [],
     'type-aliases': [],
     functions: [],
+    namespaces: [],
   }
 
   for (const doc of tsApiDocs) {
@@ -188,7 +190,7 @@ export function buildTypeScriptApiSidebar(docs: DocInfo[], currentSlug: string):
   const entries: SidebarEntry[] = []
 
   // Define category order
-  const categoryOrder = ['classes', 'interfaces', 'type-aliases', 'functions']
+  const categoryOrder = ['namespaces', 'classes', 'interfaces', 'type-aliases', 'functions']
 
   for (const category of categoryOrder) {
     const categoryDocs = categories[category]


### PR DESCRIPTION
## Description

Update API generation to account for TS namespaces.

The new convention is that we'll now expose namespaces as a new top-level concept, and in slugs, we'll prefix the members with the namespace; so `setupTracer` has a slug of `api/typescript/telemetry:setupTracer`.

There's some plumbing needed to account for this, but after these changes all links/pages should now generate correctly for typescript.

Now that all links are valid, I also changes our link-detection to be an error instead of a warning.

## Related Issues

#441 

## Type of Change

- Structure/organization improvement

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
