### PR TITLE
feat: Enable the ability to prefix llms.txt with absolute links

### DIFF
--- a/CMS-README.md
+++ b/CMS-README.md
@@ -713,6 +713,17 @@ The `src/util/links.ts` module was extended:
 - `toRawMarkdownUrl()` - Converts paths to index.md URLs, skips files with extensions
 - `isLocalLink()` - Identifies links that should be converted (excludes .txt, external, anchors)
 - `resolveHref()` - Special-cases `llms.txt` and `llms-full.txt` for proper resolution
+- `getSiteOrigin()` - Returns the value of the `SITE_DOMAIN` environment variable (trailing slash stripped), or an empty string if unset. Used by `llms.txt` and `llms-full.txt` to produce absolute URLs when a domain is known.
+
+### Absolute URLs via `SITE_DOMAIN`
+
+By default, links in `llms.txt` and `llms-full.txt` are relative (path-only). Set the `SITE_DOMAIN` environment variable at build time to prefix all links with the full domain:
+
+```bash
+SITE_DOMAIN=https://strandsagents.com npm run build
+```
+
+Without `SITE_DOMAIN`, links remain relative (e.g. `/user-guide/quickstart/`). With it set, they become absolute (e.g. `https://strandsagents.com/user-guide/quickstart/`).
 
 ### Dependencies Added
 

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,13 +1,13 @@
 import type { APIRoute } from 'astro'
 import { getCollection, getEntry } from 'astro:content'
 import { renderEntryToMarkdown } from '@util/render-to-markdown'
-import { getBase } from '@util/links'
+import { getBase, getSiteOrigin } from '@util/links'
 
 export const GET: APIRoute = async () => {
   const allDocs = await getCollection('docs')
   // Exclude API documentation and the llms page itself from full content
   const docs = allDocs.filter((doc) => !doc.id.startsWith('api/') && doc.id !== 'llms')
-  const base = getBase()
+  const base = getSiteOrigin() + getBase()
   const lines: string[] = []
 
   // Render the llms.mdx page as the header

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro'
 import type { CollectionEntry } from 'astro:content'
 import { getCollection, getEntry } from 'astro:content'
-import { getBase } from '@util/links'
+import { getBase, getSiteOrigin } from '@util/links'
 import { loadSidebarFromMkdocs, type StarlightSidebarItem } from '../sidebar'
 import { renderEntryToMarkdown } from '@util/render-to-markdown'
 import path from 'node:path'
@@ -42,7 +42,7 @@ function extractLinks(
 }
 
 function buildLlmsTxt(docs: CollectionEntry<'docs'>[], sidebar: StarlightSidebarItem[], header: string): string {
-  const base = getBase()
+  const base = getSiteOrigin() + getBase()
   const lines: string[] = []
 
   // Header from rendered llms.mdx

--- a/src/util/links.ts
+++ b/src/util/links.ts
@@ -46,6 +46,19 @@ export function getBase(): string {
 }
 
 /**
+ * Get the full site origin (scheme + host) from the SITE_URL environment variable.
+ * Returns an empty string if SITE_URL is not set, so URLs remain relative.
+ *
+ * Set SITE_DOMAIN=https://strandsagents.com when building for production to get
+ * absolute URLs in llms.txt / llms-full.txt.
+ */
+export function getSiteOrigin(): string {
+  const siteUrl = import.meta.env.SITE_DOMAIN
+  if (!siteUrl) return ''
+  return siteUrl.replace(/\/$/, '')
+}
+
+/**
  * Build a URL path with the site's base path prefix.
  * Ensures the path works correctly when deployed at a subpath (e.g., example.com/docs/).
  *


### PR DESCRIPTION
## Description

Enable the ability to prefix llms.txt with absolute links.  Official builds/workflows will specify strandsagents.com as the prefix so that all links continue to work

## Related Issues

#441 

## Type of Change
<!-- What kind of change are you making -->

- New content


## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
