### PR TITLE
feat: add telemetry.getTracer() example

### DIFF
--- a/src/content/docs/user-guide/observability-evaluation/traces.ts
+++ b/src/content/docs/user-guide/observability-evaluation/traces.ts
@@ -86,6 +86,13 @@ function configuringExporters() {
 
   // Register the provider with Strands
   telemetry.setupTracer({ provider })
+
+  // Get your configured tracer to optionally create your own custom spans
+  const tracer = telemetry.getTracer()
+  const span = tracer.startSpan('my-custom-operation')
+  span.setAttribute('custom.key', 'value')
+  // ... do work ...
+  span.end()
   // --8<-- [end:configuring_exporters]
 }
 


### PR DESCRIPTION
## Description
- Adds Typescript getTracer API example to trace observability documentation to accompany release


## Related Issues

https://github.com/strands-agents/sdk-typescript/pull/604

## Type of Change

- Content update

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
