### PR TITLE
feat: add workflow to manually deploying to GH Pages

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -35,7 +35,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git fetch origin gh-pages || true
           git worktree add gh-pages-deploy origin/gh-pages 2>/dev/null || git worktree add --orphan -b gh-pages gh-pages-deploy
-          rsync -a --delete --exclude='.git' dist/ gh-pages-deploy/
+          rsync -a --delete --exclude='.git' --exclude='CNAME' dist/ gh-pages-deploy/
           cd gh-pages-deploy
           git add -A
           git diff --cached --quiet || git commit -m "Deploy to GitHub Pages from ${{ github.sha }}"


### PR DESCRIPTION
## Description

**Note**: This PR is targeting the `main` branch.

Add a manually triggered workflow for publishing to GitHub pages in the docs repository - this follows the pattern at https://github.com/strands-agents/strandsagents.com/blob/main/.github/workflows/build-deploy.yml

Once we release, we'll use this as part of the release process instead of the workflow in the other repository.

In the meantime (since the domain is not pointing to this repository) I'll be using it for testing purposes.

## Related Issues

#441 

## Type of Change

- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
