### PR TITLE
docs: add shared responsibility model and tool security guidance

### DIFF
--- a/docs/user-guide/concepts/tools/index.md
+++ b/docs/user-guide/concepts/tools/index.md
@@ -5,7 +5,7 @@ Tools are the primary mechanism for extending agent capabilities, enabling them 
 Strands Agents Tools is a community-driven project that provides a powerful set of tools for your agents to use. For more information, see [Strands Agents Tools](community-tools-package.md).
 
 !!! warning "Tool Security"
-    All tools, whether custom, community-provided, or included in the Strands tools package, execute code on behalf of your agent with the permissions of the host process. Under the shared responsibility model, you should audit each tool's behavior (file access patterns, network calls, shell execution) and ensure it is appropriate for your deployment environment and threat model. See [Responsible AI](../../safety-security/responsible-ai.md#shared-responsibility-model) for more details.
+    All tools, whether custom, community-provided, or included in the Strands tools package, execute code on behalf of your agent with the permissions of the host process. Under the shared responsibility model, you should audit each tool's behavior (file access patterns, network calls, shell execution) and ensure it is appropriate for your deployment environment and threat model. See [Responsible AI](../../safety-security/responsible-ai.md) for more details.
 
 ## Adding Tools to Agents
 

--- a/docs/user-guide/safety-security/responsible-ai.md
+++ b/docs/user-guide/safety-security/responsible-ai.md
@@ -4,25 +4,6 @@ Strands Agents SDK provides powerful capabilities for building AI agents with ac
 
 You can learn more about the core dimensions of responsible AI on the [AWS Responsible AI](https://aws.amazon.com/ai/responsible-ai/) site. 
 
-## Shared Responsibility Model
-
-Strands Agents SDK provides building blocks for constructing AI agent systems. Security of the overall system is a shared responsibility between the SDK and you, the developer.
-
-**What the SDK provides:**
-
-- Input validation against common injection patterns (e.g., path traversal)
-- Secure defaults where possible
-- Extensible interfaces for adding custom validation
-
-**What you are responsible for:**
-
-- Securing the runtime environment your agents operate in, including filesystem permissions, network access, and container/host isolation
-- Auditing all tools used by your agents, including tools provided by Strands and the community, for their specific behavior and assumptions, and ensuring they are appropriate for your workload, threat model, and deployment environment
-- Protecting any directories the SDK reads from or writes to (e.g., session storage, tool loading directories) from unauthorized access, as the SDK trusts the contents of these locations
-- Implementing additional validation or hardening layers (e.g., symlink checks, integrity verification) when operating in shared, multi-tenant, or adversarial environments
-
-No SDK can anticipate every deployment topology or threat model. You should review how each component interacts with your infrastructure and apply appropriate security controls at the environment level.
-
 ### Tool Design
 
 When designing tools with Strands, follow these principles:


### PR DESCRIPTION
## Description

Add a Shared Responsibility Model section to the Responsible AI page
clarifying the security boundary between the SDK and the developer.
Add a Tool Security admonition to the Tools Overview page advising
users to audit all tools for their deployment environment.


## Type of Change

- Content update/revision


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
