### PR TITLE
Ia redesign

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,50 +84,33 @@ extra_javascript:
   - assets/auto-redirect.js
 
 nav:
-  - User Guide:
+  - Docs:
     - Welcome: README.md
-    - Quickstart:
-      - Getting Started: user-guide/quickstart/overview.md
-      - Python: user-guide/quickstart/python.md
-      - TypeScript: user-guide/quickstart/typescript.md
+    - Get Started:
+      - "Quickstart: Python": user-guide/quickstart/python.md
+      - "Quickstart: TypeScript": user-guide/quickstart/typescript.md
+      - Why Strands?: user-guide/why-strands.md
+    - Build:
+      - Adding Tools: user-guide/concepts/tools/index.md
+      - Creating Custom Tools: user-guide/concepts/tools/custom-tools.md
+      - Using MCP Tools: user-guide/concepts/tools/mcp-tools.md
+      - Multi-Agent Systems: user-guide/concepts/multi-agent/multi-agent-patterns.md
+      - Structured Output: user-guide/concepts/agents/structured-output.md
+      - Streaming Responses: user-guide/concepts/streaming/index.md
+      - Voice & Realtime: user-guide/concepts/bidirectional-streaming/quickstart.md
     - Concepts:
-      - Agents:
-        - Agent Loop: user-guide/concepts/agents/agent-loop.md
-        - State: user-guide/concepts/agents/state.md
-        - Session Management: user-guide/concepts/agents/session-management.md
-        - Prompts: user-guide/concepts/agents/prompts.md
-        - Retry Strategies: user-guide/concepts/agents/retry-strategies.md
-        - Hooks: user-guide/concepts/agents/hooks.md
-        - Structured Output: user-guide/concepts/agents/structured-output.md
-        - Conversation Management: user-guide/concepts/agents/conversation-management.md
+      - Agent Loop: user-guide/concepts/agents/agent-loop.md
+      - State: user-guide/concepts/agents/state.md
+      - Session Management: user-guide/concepts/agents/session-management.md
+      - Prompts: user-guide/concepts/agents/prompts.md
+      - Hooks: user-guide/concepts/agents/hooks.md
+      - Conversation Management: user-guide/concepts/agents/conversation-management.md
+      - Retry Strategies: user-guide/concepts/agents/retry-strategies.md
+      - Interrupts: user-guide/concepts/interrupts.md
       - Tools:
-        - Overview: user-guide/concepts/tools/index.md
-        - Creating Custom Tools: user-guide/concepts/tools/custom-tools.md
-        - Model Context Protocol (MCP): user-guide/concepts/tools/mcp-tools.md
         - Executors: user-guide/concepts/tools/executors.md
         - Community Tools Package: user-guide/concepts/tools/community-tools-package.md
-      - Model Providers:
-        - Overview: user-guide/concepts/model-providers/index.md
-        - Amazon Bedrock: user-guide/concepts/model-providers/amazon-bedrock.md
-        - Amazon Nova: user-guide/concepts/model-providers/amazon-nova.md
-        - Anthropic: user-guide/concepts/model-providers/anthropic.md
-        - Gemini: user-guide/concepts/model-providers/gemini.md
-        - LiteLLM: user-guide/concepts/model-providers/litellm.md
-        - llama.cpp: user-guide/concepts/model-providers/llamacpp.md
-        - LlamaAPI: user-guide/concepts/model-providers/llamaapi.md
-        - MistralAI: user-guide/concepts/model-providers/mistral.md
-        - Ollama: user-guide/concepts/model-providers/ollama.md
-        - OpenAI: user-guide/concepts/model-providers/openai.md
-        - SageMaker: user-guide/concepts/model-providers/sagemaker.md
-        - Writer: user-guide/concepts/model-providers/writer.md
-        - Custom Providers: user-guide/concepts/model-providers/custom_model_provider.md
-        - Cohere<sup> community</sup>: user-guide/concepts/model-providers/cohere.md
-        - CLOVA Studio<sup> community</sup>: user-guide/concepts/model-providers/clova-studio.md
-        - FireworksAI<sup> community</sup>: user-guide/concepts/model-providers/fireworksai.md
-        - Nebius Token Factory<sup> community</sup>: user-guide/concepts/model-providers/nebius-token-factory.md
-        - xAI<sup> community</sup>: user-guide/concepts/model-providers/xai.md
       - Streaming:
-        - Overview: user-guide/concepts/streaming/index.md
         - Async Iterators: user-guide/concepts/streaming/async-iterators.md
         - Callback Handlers: user-guide/concepts/streaming/callback-handlers.md
       - Multi-agent:
@@ -136,10 +119,7 @@ nav:
         - Swarm: user-guide/concepts/multi-agent/swarm.md
         - Graph: user-guide/concepts/multi-agent/graph.md
         - Workflow: user-guide/concepts/multi-agent/workflow.md
-        - Multi-agent Patterns: user-guide/concepts/multi-agent/multi-agent-patterns.md
-      - Interrupts: user-guide/concepts/interrupts.md
       - Bidirectional Streaming:
-        - Quickstart: user-guide/concepts/bidirectional-streaming/quickstart.md
         - BidiAgent: user-guide/concepts/bidirectional-streaming/agent.md
         - Models:
           - Nova Sonic: user-guide/concepts/bidirectional-streaming/models/nova_sonic.md
@@ -153,6 +133,43 @@ nav:
       - Experimental:
         - AgentConfig: user-guide/concepts/experimental/agent-config.md
         - Steering: user-guide/concepts/experimental/steering.md
+    - Model Providers:
+      - Overview: user-guide/concepts/model-providers/index.md
+      - Amazon Bedrock: user-guide/concepts/model-providers/amazon-bedrock.md
+      - Amazon Nova: user-guide/concepts/model-providers/amazon-nova.md
+      - Anthropic: user-guide/concepts/model-providers/anthropic.md
+      - Gemini: user-guide/concepts/model-providers/gemini.md
+      - LiteLLM: user-guide/concepts/model-providers/litellm.md
+      - llama.cpp: user-guide/concepts/model-providers/llamacpp.md
+      - LlamaAPI: user-guide/concepts/model-providers/llamaapi.md
+      - MistralAI: user-guide/concepts/model-providers/mistral.md
+      - Ollama: user-guide/concepts/model-providers/ollama.md
+      - OpenAI: user-guide/concepts/model-providers/openai.md
+      - SageMaker: user-guide/concepts/model-providers/sagemaker.md
+      - Writer: user-guide/concepts/model-providers/writer.md
+      - Custom Providers: user-guide/concepts/model-providers/custom_model_provider.md
+      - Cohere<sup> community</sup>: user-guide/concepts/model-providers/cohere.md
+      - CLOVA Studio<sup> community</sup>: user-guide/concepts/model-providers/clova-studio.md
+      - FireworksAI<sup> community</sup>: user-guide/concepts/model-providers/fireworksai.md
+      - Nebius Token Factory<sup> community</sup>: user-guide/concepts/model-providers/nebius-token-factory.md
+      - xAI<sup> community</sup>: user-guide/concepts/model-providers/xai.md
+    - Deploy:
+      - Operating Agents in Production: user-guide/deploy/operating-agents-in-production.md
+      - Amazon Bedrock AgentCore:
+          - Overview: user-guide/deploy/deploy_to_bedrock_agentcore/index.md
+          - Python: user-guide/deploy/deploy_to_bedrock_agentcore/python.md
+          - TypeScript: user-guide/deploy/deploy_to_bedrock_agentcore/typescript.md
+      - AWS Lambda<sup> new</sup>: user-guide/deploy/deploy_to_aws_lambda.md
+      - AWS Fargate: user-guide/deploy/deploy_to_aws_fargate.md
+      - AWS App Runner: user-guide/deploy/deploy_to_aws_apprunner.md
+      - Amazon EKS: user-guide/deploy/deploy_to_amazon_eks.md
+      - Amazon EC2: user-guide/deploy/deploy_to_amazon_ec2.md
+      - Docker:
+        - Overview: user-guide/deploy/deploy_to_docker/index.md
+        - Python: user-guide/deploy/deploy_to_docker/python.md
+        - TypeScript: user-guide/deploy/deploy_to_docker/typescript.md
+      - Kubernetes: user-guide/deploy/deploy_to_kubernetes.md
+      - Terraform: user-guide/deploy/deploy_to_terraform.md
     - Safety & Security:
       - Responsible AI: user-guide/safety-security/responsible-ai.md
       - Guardrails: user-guide/safety-security/guardrails.md
@@ -184,23 +201,6 @@ nav:
       - How-To Guides:
         - Experiment Management: user-guide/evals-sdk/how-to/experiment_management.md
         - Serialization: user-guide/evals-sdk/how-to/serialization.md
-    - Deploy:
-      - Operating Agents in Production: user-guide/deploy/operating-agents-in-production.md
-      - Amazon Bedrock AgentCore:
-          - Overview: user-guide/deploy/deploy_to_bedrock_agentcore/index.md
-          - Python: user-guide/deploy/deploy_to_bedrock_agentcore/python.md
-          - TypeScript: user-guide/deploy/deploy_to_bedrock_agentcore/typescript.md
-      - AWS Lambda<sup> new</sup>: user-guide/deploy/deploy_to_aws_lambda.md
-      - AWS Fargate: user-guide/deploy/deploy_to_aws_fargate.md
-      - AWS App Runner: user-guide/deploy/deploy_to_aws_apprunner.md
-      - Amazon EKS: user-guide/deploy/deploy_to_amazon_eks.md
-      - Amazon EC2: user-guide/deploy/deploy_to_amazon_ec2.md
-      - Docker:
-        - Overview: user-guide/deploy/deploy_to_docker/index.md
-        - Python: user-guide/deploy/deploy_to_docker/python.md
-        - TypeScript: user-guide/deploy/deploy_to_docker/typescript.md
-      - Kubernetes: user-guide/deploy/deploy_to_kubernetes.md
-      - Terraform: user-guide/deploy/deploy_to_terraform.md
     - Versioning & Support: user-guide/versioning-and-support.md
 
   - Examples:
@@ -244,23 +244,19 @@ nav:
         - teams: community/tools/strands-teams.md
         - telegram: community/tools/strands-telegram.md
         - telegram-listener: community/tools/strands-telegram-listener.md
-
-  - Labs:
-      - Overview: labs/index.md
-      - Projects:
+      - Labs:
+        - Overview: labs/index.md
         - Robots: labs/robots.md
         - Robots Sim: labs/robots-sim.md
         - AI Functions: labs/ai-functions.md
-
-  - Contribute ❤️:
-      - Overview: contribute/index.md
-      - Contribution Types:
+      - Contribute:
+        - Overview: contribute/index.md
         - SDK: contribute/contributing/core-sdk.md
         - Documentation: contribute/contributing/documentation.md
         - Feature Proposals: contribute/contributing/feature-proposals.md
         - Extensions: contribute/contributing/extensions.md
-  - Python API: []
-  - TypeScript API: api-reference/typescript/index.html
+
+  - API Reference: []
 
 exclude_docs: |
   node_modules
@@ -286,16 +282,17 @@ plugins:
   - llmstxt:
       full_output: llms-full.txt
       sections:
-        User Guide:
+        Docs:
           - README.md
           - user-guide/**/*.md
         Community:
           - community/**/*.md
+          - labs/**/*.md
+          - contribute/**/*.md
         Examples:
           - examples/**/*.md
-        Python API:
+        API Reference:
           - docs/api-reference/python/**/*.md
-        TypeScript API:
           - docs/api-reference/typescript/*.html
 
 

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -5,14 +5,65 @@
 import MobileMenuFooter from 'virtual:starlight/components/MobileMenuFooter';
 import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
 import SidebarSublist from './SidebarSublist.astro';
+import { pathWithBase } from '../../util/links';
 
 const { sidebar } = Astro.locals.starlightRoute;
+const currentSlug = Astro.locals.starlightRoute.id;
+const isApiPage = currentSlug.startsWith('docs/api/');
+const isOnPython = currentSlug.startsWith('docs/api/python');
 ---
 
 <SidebarPersister>
+  {isApiPage && (
+    <nav class="api-lang-switcher" aria-label="API language">
+      <a
+        href={pathWithBase('/docs/api/python/')}
+        class:list={['api-lang-tab', { active: isOnPython }]}
+        aria-current={isOnPython ? 'true' : undefined}
+      >Python</a>
+      <a
+        href={pathWithBase('/docs/api/typescript/')}
+        class:list={['api-lang-tab', { active: !isOnPython }]}
+        aria-current={!isOnPython ? 'true' : undefined}
+      >TypeScript</a>
+    </nav>
+  )}
   <SidebarSublist sublist={sidebar} />
 </SidebarPersister>
 
 <div class="md:sl-hidden">
   <MobileMenuFooter />
 </div>
+
+<style>
+  .api-lang-switcher {
+    display: flex;
+    gap: 0;
+    margin-bottom: 0.75rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+
+  .api-lang-tab {
+    flex: 1;
+    padding: 0.4rem 0.75rem;
+    font-size: var(--sl-text-sm);
+    font-weight: 500;
+    text-align: center;
+    text-decoration: none;
+    color: var(--sl-color-gray-2);
+    background: transparent;
+    transition: background-color 0.15s, color 0.15s;
+  }
+
+  .api-lang-tab:hover {
+    background-color: var(--sl-color-gray-6);
+    color: var(--sl-color-white);
+  }
+
+  .api-lang-tab.active {
+    background-color: var(--sl-color-accent);
+    color: var(--sl-color-text-invert);
+  }
+</style>

--- a/src/config/navbar.ts
+++ b/src/config/navbar.ts
@@ -17,6 +17,12 @@ export interface NavLink {
    * Example: href="/user-guide/quickstart/" but basePath="/user-guide/"
    */
   basePath?: string
+  /**
+   * Additional base paths that should also resolve to this nav section.
+   * Useful when a tab absorbs content from other URL prefixes
+   * (e.g., Community tab also owns /docs/labs/ and /docs/contribute/ pages).
+   */
+  additionalBasePaths?: string[]
   /** Set to true for external links (opens in new tab) */
   external?: boolean
 }
@@ -51,6 +57,9 @@ function transformNavLinks(links: NavLink[]): NavLink[] {
       ...link,
       href: withBase(link.href),
       ...(link.basePath ? { basePath: withBase(link.basePath) } : {}),
+      ...(link.additionalBasePaths
+        ? { additionalBasePaths: link.additionalBasePaths.map(withBase) }
+        : {}),
     }
   })
 }
@@ -65,8 +74,8 @@ const rawNavLinks: NavLink[] = [
     href: '/',
   },
   {
-    label: 'User Guide',
-    href: '/docs/user-guide/quickstart/overview/',
+    label: 'Docs',
+    href: '/docs/user-guide/quickstart/python/',
     basePath: '/docs/user-guide/',
   },
   {
@@ -78,26 +87,12 @@ const rawNavLinks: NavLink[] = [
     label: 'Community',
     href: '/docs/community/community-packages/',
     basePath: '/docs/community/',
+    additionalBasePaths: ['/docs/labs/', '/docs/contribute/'],
   },
   {
-    label: 'Labs',
-    href: '/docs/labs/',
-    basePath: '/docs/labs/',
-  },
-  {
-    label: 'Contribute ❤️',
-    href: '/docs/contribute/',
-    basePath: '/docs/contribute/',
-  },
-  {
-    label: 'Python API',
+    label: 'API Reference',
     href: '/docs/api/python/',
-    basePath: '/docs/api/python/',
-  },
-  {
-    label: 'TypeScript API',
-    href: '/docs/api/typescript/',
-    basePath: '/docs/api/typescript/',
+    basePath: '/docs/api/',
   },
 ]
 

--- a/src/content/docs/user-guide/why-strands.mdx
+++ b/src/content/docs/user-guide/why-strands.mdx
@@ -1,0 +1,123 @@
+---
+title: Why Strands?
+---
+
+Most AI agent frameworks ask you to define every step your agent should take. Strands takes a different approach: **let the model decide**.
+
+## Model-Driven vs. Workflow-Driven
+
+In a **workflow-driven** framework, you build a graph of steps — nodes, edges, conditional branches — and the model fills in each step. You control the flow; the model provides the text.
+
+In a **model-driven** framework like Strands, you give the model a goal and a set of tools. The model decides which tools to call, in what order, and when it's done. The [agent loop](concepts/agents/agent-loop.md) handles the orchestration automatically.
+
+Here's the difference in code:
+
+<Tabs>
+<Tab label="Strands (model-driven)">
+```python
+from strands import Agent
+from strands_tools import calculator, web_search
+
+agent = Agent(tools=[calculator, web_search])
+agent("What is the population of Tokyo divided by the area of France?")
+```
+
+Three lines. The model figures out that it needs to search for two facts, then do the math.
+</Tab>
+<Tab label="Workflow-driven (pseudocode)">
+```python
+# Define the graph
+graph = StateGraph()
+graph.add_node("search_population", search_population)
+graph.add_node("search_area", search_area)
+graph.add_node("calculate", calculate)
+graph.add_edge("search_population", "calculate")
+graph.add_edge("search_area", "calculate")
+
+# Define each node function
+def search_population(state):
+    result = web_search("population of Tokyo")
+    state["population"] = parse_number(result)
+    return state
+
+def search_area(state):
+    result = web_search("area of France in km2")
+    state["area"] = parse_number(result)
+    return state
+
+def calculate(state):
+    state["answer"] = state["population"] / state["area"]
+    return state
+
+# Compile and run
+app = graph.compile()
+app.invoke({"question": "..."})
+```
+
+You had to anticipate the steps, wire the graph, and handle the state yourself.
+</Tab>
+</Tabs>
+
+## When to Use Each Approach
+
+Model-driven development works best when:
+
+- **The steps aren't predictable.** If you don't know in advance what tools the agent needs to call or in what order, let the model figure it out.
+- **You want to iterate quickly.** Changing behavior means changing the prompt or the tool set — not rewiring a graph.
+- **You need flexibility.** The same agent can handle variations of a task without code changes.
+
+Workflow-driven frameworks can be a better fit when:
+
+- You need **deterministic, auditable** execution paths (e.g., compliance workflows).
+- You want **fine-grained control** over every decision point.
+- The task is **always the same sequence** of steps.
+
+Strands supports both styles. You can use the model-driven agent loop for flexible tasks and [graph workflows](concepts/multi-agent/graph.md) or [structured workflows](concepts/multi-agent/workflow.md) when you need explicit control.
+
+## What You Get
+
+- **Any model, any provider.** Amazon Bedrock, Anthropic, OpenAI, Gemini, Ollama, and [more](concepts/model-providers/index.md). Switch providers without changing your agent code.
+- **Tools as plain functions.** Write a Python function with a docstring and it becomes a [tool](concepts/tools/custom-tools.md). No schemas, no boilerplate.
+- **Multi-agent out of the box.** [Agents as tools](concepts/multi-agent/agents-as-tools.md), [swarms](concepts/multi-agent/swarm.md), [A2A protocol](concepts/multi-agent/agent-to-agent.md) — simple primitives that compose.
+- **Production-ready deployment.** Deploy to [AWS Lambda](deploy/deploy_to_aws_lambda.md), [Fargate](deploy/deploy_to_aws_fargate.md), [EKS](deploy/deploy_to_amazon_eks.md), [Bedrock AgentCore](deploy/deploy_to_bedrock_agentcore/index.md), and more.
+- **Built-in observability.** [Traces](../observability-evaluation/traces.md), [metrics](../observability-evaluation/metrics.md), and [logs](../observability-evaluation/logs.md) with OpenTelemetry integration.
+
+## Python & TypeScript
+
+Strands is available in both Python and TypeScript. The Python SDK is mature and production-ready. The TypeScript SDK is experimental with focus on core agent functionality.
+
+<details>
+<summary>Feature comparison</summary>
+
+| Category | Feature | Python | TypeScript |
+|----------|---------|:------:|:----------:|
+| **Core** | Agent creation and invocation | ✅ | ✅ |
+| | Streaming responses | ✅ | ✅ |
+| | Structured output | ✅ | ❌ |
+| **Model providers** | Amazon Bedrock | ✅ | ✅ |
+| | OpenAI | ✅ | ✅ |
+| | Anthropic | ✅ | ❌ |
+| | Ollama | ✅ | ❌ |
+| | LiteLLM | ✅ | ❌ |
+| | Custom providers | ✅ | ✅ |
+| **Tools** | Custom function tools | ✅ | ✅ |
+| | MCP (Model Context Protocol) | ✅ | ✅ |
+| | Built-in tools | 30+ via community package | 4 built-in |
+| **Conversation** | Null manager | ✅ | ✅ |
+| | Sliding window manager | ✅ | ✅ |
+| | Summarizing manager | ✅ | ❌ |
+| **Hooks** | Lifecycle hooks | ✅ | ✅ |
+| **Multi-agent** | Swarms, workflows, graphs | ✅ | ❌ |
+| | Agents as tools | ✅ | ❌ |
+| **Session management** | File, S3, repository managers | ✅ | ❌ |
+| **Observability** | OpenTelemetry integration | ✅ | ❌ |
+| **Experimental** | Bidirectional streaming | ✅ | ❌ |
+
+</details>
+
+## Next Steps
+
+- [Quickstart: Python](quickstart/python.md) — build your first agent
+- [Quickstart: TypeScript](quickstart/typescript.md) — if you prefer TypeScript
+- [Adding Tools](concepts/tools/index.md) — give your agent capabilities
+- [Multi-Agent Systems](concepts/multi-agent/multi-agent-patterns.md) — coordinate multiple agents

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,7 +79,7 @@ const testimonials = await Promise.all(
           <span class="hero-highlight">in a few lines of code</span>
         </h1>
         <div class="hero-cta">
-          <a href={withBase('/docs/user-guide/quickstart/overview/')} class="cta-button primary">Get Started</a>
+          <a href={withBase('/docs/user-guide/quickstart/python/')} class="cta-button primary">Get Started</a>
         </div>
       </div>
     </section>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -7,7 +7,7 @@ import { renderEntryToMarkdown } from '@util/render-to-markdown'
 import path from 'node:path'
 
 // Sections to pull from sidebar (with their nav labels)
-const SIDEBAR_SECTIONS = ['User Guide', 'Examples', 'Community']
+const SIDEBAR_SECTIONS = ['Docs', 'Examples', 'Community']
 
 /**
  * Recursively extract links from sidebar items

--- a/src/route-middleware.ts
+++ b/src/route-middleware.ts
@@ -28,23 +28,35 @@ export function findCurrentNavSection(currentPath: string, links: NavLink[]): Na
       bestMatch = link
       bestMatchLength = basePath.length
     }
+    // Also check additionalBasePaths (e.g., Community tab owns /docs/labs/ and /docs/contribute/)
+    if (link.additionalBasePaths) {
+      for (const additionalPath of link.additionalBasePaths) {
+        if (currentPath.startsWith(additionalPath) && additionalPath.length > bestMatchLength) {
+          bestMatch = link
+          bestMatchLength = additionalPath.length
+        }
+      }
+    }
   }
 
   return bestMatch
 }
 
 /**
- * Filter sidebar entries to only include items matching a base path.
+ * Filter sidebar entries to only include items matching one or more base paths.
  * If the result is a single top-level group, unwrap it to return just its entries.
  */
-export function filterSidebarByBasePath(entries: SidebarEntry[], basePath: string): SidebarEntry[] {
+export function filterSidebarByBasePath(entries: SidebarEntry[], basePath: string | string[]): SidebarEntry[] {
+  const basePaths = Array.isArray(basePath) ? basePath : [basePath]
+  const matchesAnyBase = (href: string) => basePaths.some((bp) => href.startsWith(bp))
+
   const filtered = entries
     .map((entry) => {
       if (entry.type === 'link') {
-        return entry.href.startsWith(basePath) ? entry : null
+        return matchesAnyBase(entry.href) ? entry : null
       }
       if (entry.type === 'group') {
-        const filteredEntries = filterSidebarByBasePath(entry.entries, basePath)
+        const filteredEntries = filterSidebarByBasePath(entry.entries, basePaths)
         return filteredEntries.length > 0 ? { ...entry, entries: filteredEntries } : null
       }
       return null
@@ -102,34 +114,8 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   const currentPath = context.url.pathname
   const currentSlug = starlightRoute.id
 
-  // Check if we're on a Python API page
-  if (currentSlug.startsWith('docs/api/python')) {
-    const docs = await getCollection('docs')
-    const docInfos: DocInfo[] = docs.map((doc: { id: string; data: { title: unknown } }) => ({
-      id: doc.id,
-      title: doc.data.title as string,
-    }))
-
-    const pythonSidebar = buildPythonApiSidebar(docInfos, currentSlug)
-
-    // Add index link at the top
-    pythonSidebar.unshift({
-      type: 'link',
-      label: 'Overview',
-      href: pathWithBase('/docs/api/python/'),
-      isCurrent: currentSlug === 'docs/api/python',
-      badge: undefined,
-      attrs: {},
-    })
-
-    const titlesByHref = await buildTitlesByHref()
-    starlightRoute.sidebar = pythonSidebar
-    starlightRoute.pagination = getPrevNextLinks(pythonSidebar, titlesByHref)
-    return
-  }
-
-  // Check if we're on a TypeScript API page
-  if (currentSlug.startsWith('docs/api/typescript')) {
+  // Check if we're on an API page (Python or TypeScript)
+  if (currentSlug.startsWith('docs/api/')) {
     const docs = await getCollection('docs')
     const docInfos: DocInfo[] = docs.map((doc: { id: string; data: { title: unknown; category?: unknown } }) => ({
       id: doc.id,
@@ -137,21 +123,35 @@ export const onRequest = defineRouteMiddleware(async (context) => {
       category: doc.data.category as string | undefined,
     }))
 
-    const tsSidebar = buildTypeScriptApiSidebar(docInfos, currentSlug)
+    // Build sidebar for the current language only
+    const isOnPython = currentSlug.startsWith('docs/api/python')
+    let apiSidebar: SidebarEntry[]
 
-    // Add index link at the top
-    tsSidebar.unshift({
-      type: 'link',
-      label: 'Overview',
-      href: pathWithBase('/docs/api/typescript/'),
-      isCurrent: currentSlug === 'docs/api/typescript',
-      badge: undefined,
-      attrs: {},
-    })
+    if (isOnPython) {
+      apiSidebar = buildPythonApiSidebar(docInfos, currentSlug)
+      apiSidebar.unshift({
+        type: 'link',
+        label: 'Overview',
+        href: pathWithBase('/docs/api/python/'),
+        isCurrent: currentSlug === 'docs/api/python',
+        badge: undefined,
+        attrs: {},
+      })
+    } else {
+      apiSidebar = buildTypeScriptApiSidebar(docInfos, currentSlug)
+      apiSidebar.unshift({
+        type: 'link',
+        label: 'Overview',
+        href: pathWithBase('/docs/api/typescript/'),
+        isCurrent: currentSlug === 'docs/api/typescript',
+        badge: undefined,
+        attrs: {},
+      })
+    }
 
     const titlesByHref = await buildTitlesByHref()
-    starlightRoute.sidebar = tsSidebar
-    starlightRoute.pagination = getPrevNextLinks(tsSidebar, titlesByHref)
+    starlightRoute.sidebar = apiSidebar
+    starlightRoute.pagination = getPrevNextLinks(apiSidebar, titlesByHref)
     return
   }
 
@@ -166,7 +166,8 @@ export const onRequest = defineRouteMiddleware(async (context) => {
 
   // Otherwise filter it down to the major section that we're in
   const basePath = currentNav.basePath || currentNav.href
-  const filteredSidebar = filterSidebarByBasePath(sidebar, basePath)
+  const allBasePaths = [basePath, ...(currentNav.additionalBasePaths || [])]
+  const filteredSidebar = filterSidebarByBasePath(sidebar, allBasePaths)
   const expandedSidebar = expandFirstLevelGroups(filteredSidebar)
   starlightRoute.sidebar = expandedSidebar
 
@@ -175,8 +176,9 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   // labels with actual page titles instead of sidebar nav labels.
   const titlesByHref = await buildTitlesByHref()
   const { prev, next } = starlightRoute.pagination
+  const inSection = (href: string) => allBasePaths.some((bp) => href.startsWith(bp))
   starlightRoute.pagination = {
-    prev: prev?.href.startsWith(basePath) ? { ...prev, label: titlesByHref.get(prev.href) ?? prev.label } : undefined,
-    next: next?.href.startsWith(basePath) ? { ...next, label: titlesByHref.get(next.href) ?? next.label } : undefined,
+    prev: prev && inSection(prev.href) ? { ...prev, label: titlesByHref.get(prev.href) ?? prev.label } : undefined,
+    next: next && inSection(next.href) ? { ...next, label: titlesByHref.get(next.href) ?? next.label } : undefined,
   }
 })

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -111,7 +111,7 @@ export function convertNavItem(item: unknown, ctx: ConvertContext = { contentDir
     if (typeof value === 'string') {
       const slug = mdPathToSlug(value)
       if (!contentExists(slug, ctx.contentDir)) return null
-      return { slug }
+      return { slug, label }
     }
 
     // Nested group: { "Label": [...] }

--- a/test/sidebar.test.ts
+++ b/test/sidebar.test.ts
@@ -39,19 +39,18 @@ describe('Sidebar Generation', () => {
     const item = convertNavItem({
       Quickstart: [{ 'Getting Started': 'overview.md' }, { Python: 'python.md' }],
     })
-    // Internal links omit labels - Starlight uses page title from frontmatter
     expect(item).toEqual({
       label: 'Quickstart',
-      items: [{ slug: 'docs/overview' }, { slug: 'docs/python' }],
+      items: [{ slug: 'docs/overview', label: 'Getting Started' }, { slug: 'docs/python', label: 'Python' }],
     })
   })
 
-  it('should omit labels for internal links in final output (uses page title from frontmatter)', () => {
-    // The final Starlight output should not include labels for internal links
-    // Starlight will automatically use the page's title frontmatter
+  it('should include mkdocs nav labels for internal links', () => {
+    // Labels from mkdocs.yml nav are preserved so the sidebar shows
+    // task-oriented labels (e.g., "Voice & Realtime") instead of page titles
     const sidebar = loadSidebarFromMkdocs(pathToMkdocsYaml)
 
-    // Find a leaf item (internal link) and verify it has slug but no label
+    // Find a leaf item (internal link) and verify it has both slug and label
     function findLeafItem(items: StarlightSidebarItem[]): StarlightSidebarItem | null {
       for (const item of items) {
         if ('slug' in item && !('items' in item)) {
@@ -68,7 +67,7 @@ describe('Sidebar Generation', () => {
     const leafItem = findLeafItem(sidebar)
     expect(leafItem).toBeDefined()
     expect(leafItem).toHaveProperty('slug')
-    expect(leafItem).not.toHaveProperty('label')
+    expect(leafItem).toHaveProperty('label')
   })
 })
 


### PR DESCRIPTION
This PR is a draft to solicit feedback on a first crack at reorganizing the documentation from concept-first to task-first, based on some lightweight information architecture research I did on the agent SDK and developer docs space (e.g. LangChain, Vercel, Stripe). 

What changed:
  - 9 nav tabs → 6 — merged Labs + Contribute into Community, merged Python API + TypeScript API into API Reference (though this part needs verification with the build process), renamed User Guide →
  Docs
  - New "Build" section in sidebar — task-oriented entry points (Adding Tools, Using MCP Tools, Multi-Agent Systems, etc.) above Concepts
  - Deploy promoted from last sidebar section to after Model Providers
  - Homepage CTA links directly to Python quickstart (skips overview routing page)
  - New "Why Strands?" page — model-driven vs workflow-driven explainer with code comparison and feature matrix (initial draft / needs edits)
  - Sidebar labels now come from mkdocs.yml nav instead of page frontmatter titles (Astro would have us use frontmatter metadata but I wanted to keep this low-touch for now) 