### PR TITLE
Add required dependency for CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "@opentelemetry/sdk-trace-node": "^1.30.1",
+    "@strands-agents/sdk": "github:strands-agents/sdk-typescript",
     "@types/express": "^5.0.5",
     "@types/turndown": "^5.0.6",
     "express": "^5.1.0",


### PR DESCRIPTION
To pass CI, we currently need the `@opentelemetry/sdk-trace-node` dependency after the SDK added it as a dependency.

In theory this *shouldn't* be necessary, but our type-checking is a bit odd; when/if we switch to linting code snippets from markdown instead of using snippets that get inlined into markdown, we'll revisit this

**Note**: I added `@strands-agents/sdk` back which I removed in #622 because I thought that was the fix, but it was not.