### PR TITLE
feat: automatically reload the server when updating the navigation.yml

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from '@astrojs/starlight'
 import path from 'node:path'
 import remarkMkdocsSnippets from './src/plugins/remark-mkdocs-snippets.ts'
 import sdkSetupPlugin from './src/plugins/vite-plugin-sdk-setup.ts'
+import watchNavigationPlugin from './src/plugins/vite-plugin-watch-navigation.ts'
 
 import { loadSidebarFromConfig } from "./src/sidebar.ts"
 import AutoImport from './src/plugins/astro-auto-import.ts'
@@ -26,7 +27,7 @@ export default defineConfig({
     '/latest': '/',
   },
   vite: {
-    plugins: [sdkSetupPlugin()],
+    plugins: [sdkSetupPlugin(), watchNavigationPlugin()],
     // TODO once we separate out CMS build from TS verification, fix this
     // https://github.com/withastro/astro/issues/14117
 		ssr: {

--- a/src/plugins/vite-plugin-watch-navigation.ts
+++ b/src/plugins/vite-plugin-watch-navigation.ts
@@ -1,0 +1,26 @@
+/**
+ * Vite plugin that watches navigation.yml and triggers a full server restart
+ * when it changes, so the Astro/Starlight sidebar and navbar stay in sync
+ * during development without needing a manual restart.
+ */
+import path from 'node:path'
+import type { Plugin } from 'vite'
+
+const NAVIGATION_CONFIG = path.resolve('./src/config/navigation.yml')
+
+export default function watchNavigationPlugin(): Plugin {
+  return {
+    name: 'vite-plugin-watch-navigation',
+    configureServer(server) {
+      // Tell Vite to watch the file
+      server.watcher.add(NAVIGATION_CONFIG)
+
+      server.watcher.on('change', (file) => {
+        if (file === NAVIGATION_CONFIG) {
+          console.log('[watch-navigation] navigation.yml changed — restarting server...')
+          server.restart()
+        }
+      })
+    },
+  }
+}


### PR DESCRIPTION
## Description

Right now you have to manually restart the server on making changes to navigation.yml; this makes it so that the server auto-restarts instead.

## Related Issues

#441 

## Type of Change
<!-- What kind of change are you making -->

- Content update/revision

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `mkdocs serve`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
