### PR TITLE
fix: correct strands-evals package name to strands-agents-evals

### DIFF
--- a/src/content/docs/user-guide/evals-sdk/how-to/agentcore_evaluation_dashboard.mdx
+++ b/src/content/docs/user-guide/evals-sdk/how-to/agentcore_evaluation_dashboard.mdx
@@ -20,7 +20,7 @@ Before configuring the evaluation dashboard, ensure you have:
 1. **AWS Account** with appropriate permissions for CloudWatch and Bedrock AgentCore
 2. **CloudWatch Transaction Search enabled** (one-time setup)
 3. **ADOT SDK** installed in your environment ([guidance](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html))
-4. **Strands Evals SDK** installed (`pip install strands-evals`)
+4. **Strands Evals SDK** installed (`pip install strands-agents-evals`)
 
 ## Step 1: Enable CloudWatch Transaction Search
 
@@ -125,7 +125,7 @@ Or add to your `requirements.txt`:
 ```text
 aws-opentelemetry-distro>=0.10.0
 boto3
-strands-evals
+strands-agents-evals
 ```
 
 ## Step 4: Run Evaluations with ADOT


### PR DESCRIPTION
## Description

The AgentCore evaluation dashboard doc references `pip install strands-evals` and lists `strands-evals` in a requirements.txt example. The correct package name is `strands-agents-evals`. This PR fixes both occurrences.

## Related Issues

N/A

## Type of Change

- Typo/formatting fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `mkdocs serve`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.