### PR TITLE
Remove references to old files/commands (after transition to CMS)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@
 
 - [ ] I have read the CONTRIBUTING document
 - [ ] My changes follow the project's documentation style
-- [ ] I have tested the documentation locally using `mkdocs serve`
+- [ ] I have tested the documentation locally using `npm run dev`
 - [ ] Links in the documentation are valid and working
 
 ----

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,8 @@ npm run dev
 
 Pre-commit hooks automatically run:
 - Unit tests (via npm test)
-- Linting (via npm run lint)
 - Format checking (via npm run format:check)
-- Type checking (via npm run type-check)
+- Type checking (via npm run typecheck)
 
 All checks must pass before commit is allowed.
 
@@ -175,7 +174,7 @@ import type { Options, Config } from '../types'
 - **README.md**: Public-facing documentation, links to strandsagents.com
 - **SITE-ARCHITECTURE.md**: Comprehensive documentation of Astro/Starlight customizations, components, and plugins
 - **package.json**: Defines scripts for building, testing, and linting
-- **mkdocs.yml**: Defines the navigation structure (loaded by `src/sidebar.ts` for Astro)
+- **src/config/navigation.yml**: Defines the navigation structure (loaded by `src/sidebar.ts` for Astro)
 
 ## Additional Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ For full details on the Astro setup, custom components, frontmatter fields, and 
 Before committing, run:
 
 ```bash
-npm test           # TypeScript type checking
-npm run lint       # linting
+npm test              # run tests
+npm run typecheck     # TypeScript type checking
 npm run format:check  # formatting
 ```
 

--- a/src/content/docs/community/get-featured.mdx
+++ b/src/content/docs/community/get-featured.mdx
@@ -22,7 +22,7 @@ We're not looking for example agents or one-off projects — the focus is on pac
 
 1. **Create a PR** to [strands-agents/docs](https://github.com/strands-agents/docs)
 2. **Add your doc file** in the appropriate `community/` subdirectory
-3. **Update `mkdocs.yml`** to include your new page in the nav
+3. **Update `src/config/navigation.yml`** to include your new page in the nav
 
 ## Directory Structure
 
@@ -84,17 +84,21 @@ service:
 ---
 ```
 
-## Update mkdocs.yml
+## Update navigation.yml
 
-Add your page to the `nav` section under Community:
+Add your page to `src/config/navigation.yml` under the Community section:
 
 ```yaml
-nav:
-  - Community:
-      - Model Providers:
-        - Your Provider: community/model-providers/your-provider.md
-      - Tools:
-        - your-tool: community/tools/your-tool.md
+- label: Community
+  items:
+    - label: Model Providers
+      items:
+        - label: Your Provider
+          link: community/model-providers/your-provider
+    - label: Tools
+      items:
+        - label: your-tool
+          link: community/tools/your-tool
 ```
 
 ## Examples to Follow

--- a/src/content/docs/contribute/contributing/core-sdk.mdx
+++ b/src/content/docs/contribute/contributing/core-sdk.mdx
@@ -114,10 +114,8 @@ You can also run individual checks.
 
 ```bash
 npm test                    # Run unit tests
-npm run test:coverage       # Run with coverage (80%+ required)
-npm run lint                # Run ESLint
+npm run typecheck           # TypeScript type checking
 npm run format              # Format code with Prettier
-npm run type-check          # TypeScript type checking
 ```
 
 **Development tips:**

--- a/src/content/docs/contribute/contributing/documentation.mdx
+++ b/src/content/docs/contribute/contributing/documentation.mdx
@@ -20,28 +20,20 @@ We're looking for contributions that improve the developer experience. Documenta
 
 ## Setup
 
-:::caution[Migration in progress]
-This section will be rewritten as we migrate to a new CMS.
-:::
-
-Let's get the docs running locally so you can preview your changes as you work. The docs are built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+Let's get the docs running locally so you can preview your changes as you work. The docs are built with [Astro](https://astro.build/) and the [Starlight](https://starlight.astro.build/) theme.
 
 ```bash
 # Clone the docs repository
 git clone https://github.com/strands-agents/docs.git
 cd docs
 
-# Create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
-
 # Install dependencies
-pip install -e .
+npm install
 
 # Start the local development server
-mkdocs serve
+npm run dev
 
-# Preview at http://localhost:8000
+# Preview at http://localhost:4321
 ```
 
 The development server automatically reloads when you save changes, so you can see your edits immediately.
@@ -53,7 +45,7 @@ The submission process varies based on the size of your change. Small fixes can 
 1. **Fork the docs repository** on GitHub
 2. **Create a branch** with a descriptive name like `docs/clarify-tools-usage` or `docs/fix-typo-agent-loop`
 3. **Make your changes** in your favorite editor
-4. **Preview locally** with `mkdocs serve` to verify formatting and links work correctly
+4. **Preview locally** with `npm run dev` to verify formatting and links work correctly
 5. **Submit a pull request** with a clear description of what you changed and why
 
 **For small changes** (typos, grammar fixes, minor clarifications), you can skip local preview and go straight to PR. We'll catch any issues in review.


### PR DESCRIPTION
## Description

Remove references to old files/commands (after transition to CMS)

## Related Issues

#441 

## Type of Change
<!-- What kind of change are you making -->

- Structure/organization improvement

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
