### PR TITLE
docs: add Remote Trace Providers guide for evals SDK

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -148,6 +148,9 @@ sidebar:
             items:
               - docs/user-guide/evals-sdk/simulators
               - docs/user-guide/evals-sdk/simulators/user_simulation
+          - label: Remote Trace Providers
+            items:
+              - docs/user-guide/evals-sdk/how-to/trace_providers
           - label: How-To Guides
             items:
               - docs/user-guide/evals-sdk/how-to/experiment_management

--- a/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
+++ b/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
@@ -1,0 +1,188 @@
+---
+title: Evaluating Remote Traces
+---
+
+Trace providers fetch agent execution data from observability backends and convert it into the format the evaluation pipeline expects. This lets you run evaluators against traces from production or staging agents without re-running them.
+
+## Available Providers
+
+| Provider | Backend | Auth |
+|----------|---------|------|
+| `CloudWatchProvider` | AWS CloudWatch Logs (Bedrock AgentCore runtime logs) | AWS credentials (boto3) |
+| `LangfuseProvider` | Langfuse | API keys |
+
+## Installation
+
+The CloudWatch provider works out of the box since `boto3` is a core dependency:
+
+```bash
+pip install strands-agents-evals
+```
+
+For the Langfuse provider, install the optional `langfuse` extra:
+
+```bash
+pip install strands-agents-evals[langfuse]
+```
+
+## CloudWatch Provider
+
+The `CloudWatchProvider` queries CloudWatch Logs Insights to retrieve OpenTelemetry log records from Bedrock AgentCore runtime log groups.
+
+### Setup
+
+```python
+from strands_evals.providers import CloudWatchProvider
+
+# Option 1: Provide the log group directly
+provider = CloudWatchProvider(
+    log_group="/aws/bedrock-agentcore/runtimes/my-agent-abc123-DEFAULT",
+    region="us-east-1",
+)
+
+# Option 2: Discover the log group from the agent name
+provider = CloudWatchProvider(agent_name="my-agent", region="us-east-1")
+```
+
+You must provide either `log_group` or `agent_name`. When using `agent_name`, the provider calls `describe_log_groups` to find the runtime log group automatically.
+
+The `region` parameter falls back to the `AWS_REGION` environment variable, then `AWS_DEFAULT_REGION`, then `us-east-1`.
+
+### Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `region` | `AWS_REGION` env var | AWS region for the CloudWatch client |
+| `log_group` | — | Full CloudWatch log group path |
+| `agent_name` | — | Agent name used to discover the log group |
+| `lookback_days` | `30` | How many days back to search for traces |
+| `query_timeout_seconds` | `60.0` | Maximum seconds to wait for a Logs Insights query |
+
+## Langfuse Provider
+
+The `LangfuseProvider` fetches traces and observations via the Langfuse Python SDK, converting them to typed spans for evaluation.
+
+### Setup
+
+```python
+from strands_evals.providers import LangfuseProvider
+
+# Reads LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY from env by default
+provider = LangfuseProvider()
+
+# Or pass credentials explicitly
+provider = LangfuseProvider(
+    public_key="pk-...",
+    secret_key="sk-...",
+    host="https://us.cloud.langfuse.com",
+)
+```
+
+### Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `public_key` | `LANGFUSE_PUBLIC_KEY` env var | Langfuse public API key |
+| `secret_key` | `LANGFUSE_SECRET_KEY` env var | Langfuse secret API key |
+| `host` | `LANGFUSE_HOST` env var or `https://us.cloud.langfuse.com` | Langfuse API host URL |
+| `timeout` | `120` | Request timeout in seconds |
+
+## Running Evaluations on Remote Traces
+
+All providers implement the same `TraceProvider` interface with a single method:
+
+```python
+data = provider.get_evaluation_data(session_id="my-session-id")
+# data.output     -> str (final agent response)
+# data.trajectory -> Session (traces and spans)
+```
+
+Pass the provider's data into the standard `Experiment` pipeline by wrapping it in a task function:
+
+```python
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import CoherenceEvaluator, OutputEvaluator
+from strands_evals.providers import CloudWatchProvider
+
+provider = CloudWatchProvider(log_group="/aws/...", region="us-east-1")
+
+def task(case: Case) -> dict:
+    return provider.get_evaluation_data(case.input)
+
+cases = [
+    Case(
+        name="session_1",
+        input="my-session-id",
+        expected_output="any",
+    ),
+]
+
+evaluators = [
+    OutputEvaluator(
+        rubric="Score 1.0 if the output is coherent. Score 0.0 otherwise."
+    ),
+    CoherenceEvaluator(),
+]
+
+experiment = Experiment(cases=cases, evaluators=evaluators)
+reports = experiment.run_evaluations(task)
+
+for report in reports:
+    print(f"{report.overall_score:.2f} - {report.reasons}")
+```
+
+The same pattern works with `LangfuseProvider` — just swap the provider initialization.
+
+## Error Handling
+
+Providers raise specific exceptions when traces cannot be retrieved:
+
+```python
+from strands_evals.providers import SessionNotFoundError, ProviderError
+
+try:
+    data = provider.get_evaluation_data("unknown-session")
+except SessionNotFoundError:
+    print("No traces found for that session")
+except ProviderError:
+    print("Provider unreachable or query failed")
+```
+
+Both exceptions inherit from `TraceProviderError`, so you can catch that for a single handler:
+
+```python
+from strands_evals.providers import TraceProviderError
+
+try:
+    data = provider.get_evaluation_data(session_id)
+except TraceProviderError as e:
+    print(f"Failed to retrieve traces: {e}")
+```
+
+## Implementing a Custom Provider
+
+Subclass `TraceProvider` and implement `get_evaluation_data` to integrate with any observability backend:
+
+```python
+from strands_evals.providers import TraceProvider
+from strands_evals.types.evaluation import TaskOutput
+
+class MyProvider(TraceProvider):
+    def get_evaluation_data(self, session_id: str) -> TaskOutput:
+        # 1. Fetch traces from your backend
+        # 2. Convert to a Session object with Trace and Span types
+        # 3. Extract the final agent response
+        return TaskOutput(output="final response", trajectory=session)
+```
+
+The returned `TaskOutput` must contain:
+
+- **`output`**: The final agent response text
+- **`trajectory`**: A `Session` object containing `Trace` objects with typed spans (`AgentInvocationSpan`, `InferenceSpan`, `ToolExecutionSpan`)
+
+## Related Documentation
+
+- [Getting Started](../quickstart.md): Set up your first evaluation experiment
+- [Output Evaluator](../evaluators/output_evaluator.md): Evaluate agent response quality
+- [Trajectory Evaluator](../evaluators/trajectory_evaluator.md): Evaluate tool usage and execution paths
+- [Helpfulness Evaluator](../evaluators/helpfulness_evaluator.md): Assess agent helpfulness


### PR DESCRIPTION
## Description

Add documentation for evaluating remote traces from observability backends (CloudWatch and Langfuse). Includes setup, configuration, and usage examples for running evaluations against production/staging agent traces without re-running them. Update navigation to include the new page.

<!-- If applicable, add screenshots to help explain your changes -->


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
