### PR TITLE
docs: add resume flag documentation for AfterInvocationEvent

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -964,7 +964,7 @@ async def summarize_after_tools(event: AfterInvocationEvent):
         event.resume = "Now summarize what you just did in one sentence."
 
 agent = Agent()
-agent.hooks.add_callback(AfterInvocationEvent, summarize_after_tools)
+agent.add_hook(summarize_after_tools)
 
 # The agent processes the initial request, then automatically
 # performs a second invocation to generate the summary
@@ -999,7 +999,7 @@ async def iterative_refinement(event: AfterInvocationEvent):
         event.resume = f"Review your previous response and improve it. Iteration {iteration} of {MAX_ITERATIONS}."
 
 agent = Agent()
-agent.hooks.add_callback(AfterInvocationEvent, iterative_refinement)
+agent.add_hook(iterative_refinement)
 
 result = agent("Draft a haiku about programming")
 ```
@@ -1050,8 +1050,8 @@ async def auto_approve(event: AfterInvocationEvent):
         event.resume = responses
 
 agent = Agent(tools=[send_email])
-agent.hooks.add_callback(BeforeToolCallEvent, require_approval)
-agent.hooks.add_callback(AfterInvocationEvent, auto_approve)
+agent.add_hook(require_approval)
+agent.add_hook(auto_approve)
 
 # The interrupt is handled automatically by the hook—
 # the caller receives the final result directly


### PR DESCRIPTION
Updates documentation for sdk-python PR #1767

- Add AfterInvocationEvent.resume to event properties reference
- Update AfterInvocationEvent description in events table
- Add resume loop to single-agent lifecycle diagram
- Add Invocation resume cookbook section with examples
- Add interrupt handling with resume subsection

## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
