### PR TITLE
docs: graduate steering from experimental to plugins

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
         - Community Tools Package: user-guide/concepts/tools/community-tools-package.md
       - Plugins:
         - Overview: user-guide/concepts/plugins/index.md
+        - Steering: user-guide/concepts/plugins/steering.md
       - Model Providers:
         - Overview: user-guide/concepts/model-providers/index.md
         - Amazon Bedrock: user-guide/concepts/model-providers/amazon-bedrock.md
@@ -154,7 +155,6 @@ nav:
         - Session Management: user-guide/concepts/bidirectional-streaming/session-management.md
       - Experimental:
         - AgentConfig: user-guide/concepts/experimental/agent-config.md
-        - Steering: user-guide/concepts/experimental/steering.md
     - Safety & Security:
       - Responsible AI: user-guide/safety-security/responsible-ai.md
       - Guardrails: user-guide/safety-security/guardrails.md

--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -65,6 +65,7 @@ sidebar:
           - label: Plugins
             items:
               - docs/user-guide/concepts/plugins
+              - docs/user-guide/concepts/plugins/steering
           - label: Model Providers
             items:
               - docs/user-guide/concepts/model-providers
@@ -117,7 +118,6 @@ sidebar:
           - label: Experimental
             items:
               - docs/user-guide/concepts/experimental/agent-config
-              - docs/user-guide/concepts/experimental/steering
       - label: Safety & Security
         items:
           - docs/user-guide/safety-security/responsible-ai

--- a/src/content/docs/user-guide/concepts/plugins/index.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/index.mdx
@@ -2,11 +2,11 @@
 title: Plugins
 ---
 
-Plugins allow you to change the typical behavior of an agent. They enable you to introduce concepts like [Skills](https://agentskills.io/specification), [steering](../experimental/steering.md), or other behavioral modifications into the agentic loop. Plugins work by taking advantage of the low-level primitives exposed by the Agent class—`model`, `system_prompt`, `messages`, `tools`, and `hooks`—and executing logic to improve an agent's behavior.
+Plugins allow you to change the typical behavior of an agent. They enable you to introduce concepts like [Skills](https://agentskills.io/specification), [steering](./steering), or other behavioral modifications into the agentic loop. Plugins work by taking advantage of the low-level primitives exposed by the Agent class—`model`, `system_prompt`, `messages`, `tools`, and `hooks`—and executing logic to improve an agent's behavior.
 
 The Strands SDK provides built-in plugins that you can use out of the box:
 
-- **[Steering](../experimental/steering)** - Modular prompting for complex agent tasks through context-aware guidance
+- **[Steering](./steering)** - Modular prompting for complex agent tasks through context-aware guidance
 
 You can also build and distribute your own plugins to extend agent functionality. See [Get Featured](/docs/community/get-featured) to share your plugins with the community.
 
@@ -19,7 +19,7 @@ Plugins are passed to agents during initialization via the `plugins` parameter:
 
 ```python
 from strands import Agent
-from strands.experimental.steering import LLMSteeringHandler
+from strands.vended_plugins.steering import LLMSteeringHandler
 
 # Create an agent with plugins
 agent = Agent(
@@ -264,5 +264,5 @@ class AsyncConfigPlugin(Plugin):
 ## Next Steps
 
 - [Hooks](../agents/hooks.mdx) - Learn about the underlying hook system
-- [Steering](../experimental/steering.mdx) - Explore the built-in steering plugin
+- [Steering](./steering) - Explore the built-in steering plugin
 - [Get Featured](/docs/community/get-featured) - Share your plugins with the community

--- a/src/content/docs/user-guide/concepts/plugins/steering.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/steering.mdx
@@ -1,14 +1,9 @@
 ---
 title: Steering
-experimental: true
-sidebar:
-  badge:
-    text: Experimental
-    variant: note
 ---
 
 
-Strands Steering explores new approaches to modular prompting for complex agent tasks through context-aware guidance that appears when relevant, rather than front-loading all instructions in monolithic prompts. This experimental feature enables developers to assign agents complex, multi-step tasks while maintaining effectiveness through just-in-time feedback loops.
+Strands Steering provides modular prompting for complex agent tasks through context-aware guidance that appears when relevant, rather than front-loading all instructions in monolithic prompts. This enables developers to assign agents complex, multi-step tasks while maintaining effectiveness through just-in-time feedback loops.
 
 ## What Is Steering?
 
@@ -87,7 +82,7 @@ For best practices for defining the prompts, use the [Agent Standard Operating P
 
 ```python
 from strands import Agent, tool
-from strands.experimental.steering import LLMSteeringHandler
+from strands.vended_plugins.steering import LLMSteeringHandler
 
 @tool
 def send_email(recipient: str, subject: str, message: str) -> str:

--- a/test/known-routes.json
+++ b/test/known-routes.json
@@ -69,7 +69,7 @@
   "/latest/documentation/docs/user-guide/concepts/bidirectional-streaming/quickstart/",
   "/latest/documentation/docs/user-guide/concepts/bidirectional-streaming/session-management/",
   "/latest/documentation/docs/user-guide/concepts/experimental/agent-config/",
-  "/latest/documentation/docs/user-guide/concepts/experimental/steering/",
+  "/latest/documentation/docs/user-guide/concepts/plugins/steering/",
   "/latest/documentation/docs/user-guide/concepts/interrupts/",
   "/latest/documentation/docs/user-guide/concepts/model-providers/",
   "/latest/documentation/docs/user-guide/concepts/model-providers/amazon-bedrock/",


### PR DESCRIPTION

## Description
Move steering documentation out of the experimental section into plugins
to reflect its promotion to production in sdk-python#1853. Updates import
paths from strands.experimental.steering to strands.vended_plugins.steering.


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
