### PR TITLE
fix: update sitemap testing to verify deployed urls

### DIFF
--- a/SITE-ARCHITECTURE.md
+++ b/SITE-ARCHITECTURE.md
@@ -695,7 +695,7 @@ Helper builders from `src/utils/regex.ts`:
 ### Testing
 
 - **`test/redirect.test.ts`** — unit tests for `resolveRedirect` and `resolveRedirectFromUrl` covering slug transforms, URL normalisation, and trailing-slash preservation.
-- **`test/sitemap-coverage.test.ts`** — integration test that fetches the live sitemap from `https://strandsagents.com/1.x/sitemap.xml` (cached in `.build/sitemap-cache.xml` for 4 hours) and asserts every old URL either exists in the CMS collection or has a valid redirect rule pointing to an existing page.
+- **`test/sitemap-coverage.test.ts`** — integration test that fetches the live sitemap from `https://strandsagents.com/sitemap-index.xml` using the `sitemapper` npm package (cached in `.build/sitemap-cache.json` for 4 hours) and asserts every URL either exists in the CMS collection (docs, blog posts, author pages, tag pages) or has a valid redirect rule pointing to an existing page. API reference paths (`/docs/api/python/` and `/docs/api/typescript/`) are excluded. Controlled by the `VERIFY_LIVE_SITEMAP=true` environment variable — skipped by default locally, intended to enabled in CI before deployment.
 
 Run with:
 ```bash

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pino-pretty": "^13.0.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
+    "sitemapper": "^4.1.4",
     "tsx": "^4.21.0",
     "typedoc": "^0.28.14",
     "typedoc-plugin-markdown": "^4.10.0",

--- a/test/sitemap-coverage.test.ts
+++ b/test/sitemap-coverage.test.ts
@@ -2,59 +2,68 @@ import { describe, it, expect } from 'vitest'
 import { getCollection } from 'astro:content'
 import fs from 'node:fs'
 import path from 'node:path'
+import Sitemapper from 'sitemapper'
 import { resolveRedirectFromUrl } from '../src/util/redirect'
+import { tagToSlug, getAllTags, getPublishedPosts } from '../src/util/blog'
 
 const KNOWN_ROUTES_PATH = path.resolve('test/known-routes.json')
-const SITEMAP_URL = 'https://strandsagents.com/sitemap.xml'// Sitemap URLs look like: https://strandsagents.com/latest/documentation/docs/<path>/
-// We extract the full URL for each entry and pass it through resolveRedirectFromUrl,
-// which strips the domain, version prefix, and /documentation/ segment.
-const SITEMAP_ENTRY = /^https:\/\/strandsagents\.com\/.+$/
-const CACHE_PATH = path.resolve('.build/sitemap-cache.xml')
+const SITEMAP_URL = 'https://strandsagents.com/sitemap-index.xml'
+const CACHE_PATH = path.resolve('.build/sitemap-cache.json')
 const CACHE_TTL_MS = 4 * 60 * 60 * 1000 // 4 hours
 
-// Sitemap URLs under /documentation/docs/api-reference/ are excluded — API docs are
-// regenerated from source and old module paths are not redirected.
-const API_REFERENCE_URL = /\/documentation\/docs\/api-reference\//
+// Sitemap URLs under API reference paths are excluded — regenerated from source.
+const API_REFERENCE_URL = /\/docs\/api\/(python|typescript)\//
 
 /**
- * Fetch and parse all non-API doc URLs from the live sitemap, with a 4-hour file cache in .build/.
+ * Fetch all non-API doc URLs from the live sitemap index using sitemapper, with a 4-hour file cache.
  * Returns full URLs (e.g. "https://strandsagents.com/1.x/documentation/docs/user-guide/quickstart/").
  */
 async function fetchSitemapUrls(): Promise<string[]> {
-  let xml: string
-
   const cacheValid =
     fs.existsSync(CACHE_PATH) && Date.now() - fs.statSync(CACHE_PATH).mtimeMs < CACHE_TTL_MS
 
+  let allUrls: string[]
+
   if (cacheValid) {
-    xml = fs.readFileSync(CACHE_PATH, 'utf-8')
+    allUrls = JSON.parse(fs.readFileSync(CACHE_PATH, 'utf-8'))
   } else {
-    const res = await fetch(SITEMAP_URL)
-    if (!res.ok) throw new Error(`Failed to fetch sitemap: ${res.status} ${res.statusText}`)
-    xml = await res.text()
+    const sitemap = new Sitemapper({ url: SITEMAP_URL, timeout: 15000 })
+    const { sites } = await sitemap.fetch()
+    allUrls = sites
     fs.mkdirSync(path.dirname(CACHE_PATH), { recursive: true })
-    fs.writeFileSync(CACHE_PATH, xml, 'utf-8')
+    fs.writeFileSync(CACHE_PATH, JSON.stringify(allUrls), 'utf-8')
   }
 
-  const urls: string[] = []
-  for (const match of xml.matchAll(/<loc>(.*?)<\/loc>/g)) {
-    const url = match[1].trim()
-    if (SITEMAP_ENTRY.test(url) && !API_REFERENCE_URL.test(url)) {
-      urls.push(url)
-    }
-  }
-
-  return urls
+  return allUrls.filter((url) => !API_REFERENCE_URL.test(url))
 }
 
-// Need to skip these as the sitemap was being pulled from the old site not the new one
-describe('Sitemap Coverage', { skip: true }, () => {
+/**
+ * Build the set of all valid URL slugs across docs, blog, authors, and tag pages.
+ */
+async function buildValidSlugs(): Promise<Set<string>> {
+  const [docs, posts, authors, tags] = await Promise.all([
+    getCollection('docs'),
+    getPublishedPosts(),
+    getCollection('authors'),
+    getAllTags(),
+  ])
+
+  return new Set([
+    ...docs.map((doc) => doc.id),
+    'blog',
+    ...posts.map((post) => `blog/${post.id}`),
+    ...authors.map((author) => `blog/authors/${author.id}`),
+    ...tags.map((tag) => `blog/tags/${tagToSlug(tag)}`),
+  ])
+}
+
+const VERIFY_LIVE_SITEMAP = process.env.VERIFY_LIVE_SITEMAP === 'true'
+
+describe('Sitemap Coverage', { skip: !VERIFY_LIVE_SITEMAP }, () => {
   it('every page in the live sitemap has a corresponding CMS entry (or a known redirect)', async () => {
-    const [sitemapUrls, docs] = await Promise.all([fetchSitemapUrls(), getCollection('docs')])
+    const [sitemapUrls, validIds] = await Promise.all([fetchSitemapUrls(), buildValidSlugs()])
 
     expect(sitemapUrls.length).toBeGreaterThan(0)
-
-    const validIds = new Set(docs.map((doc) => doc.id))
 
     const missing: string[] = []
     const redirected: Array<{ from: string; to: string }> = []
@@ -103,8 +112,7 @@ describe('Sitemap Coverage', { skip: true }, () => {
   // Redirect rule unit tests live in test/redirect.test.ts.
   // This test verifies that redirect targets actually exist in the CMS collection.
   it('redirect targets all resolve to valid CMS entries', async () => {
-    const [sitemapUrls, docs] = await Promise.all([fetchSitemapUrls(), getCollection('docs')])
-    const validIds = new Set(docs.map((doc) => doc.id))
+    const [sitemapUrls, validIds] = await Promise.all([fetchSitemapUrls(), buildValidSlugs()])
 
     const brokenRedirects: Array<{ from: string; to: string }> = []
     for (const url of sitemapUrls) {


### PR DESCRIPTION
## Description

Updates the sitemap coverage tests to work correctly with the new site structure with blog & tags & etc. The test is not yet enabled on builds as I'm still verifying everything works as we want it to, but now it works & passes 100%.

I also switched to `sitemapper` NPM package as our sitemap.xml is more complex now and I'd rather delegate to a library than have us have to handle it

## Related Issues

#441 

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
