### PR TITLE
blog: fix date and plugin link in Agent Control post

### DIFF
--- a/src/content/blog/strands-agents-with-agent-control.mdx
+++ b/src/content/blog/strands-agents-with-agent-control.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Runtime Guardrails for Strands Agents with Agent Control"
-date: 2026-03-10
+date: 2026-03-11
 description: "Define what your Strands agents can and can't do at runtime, without changing a line of agent code."
 authors:
   - ryan-coleman
@@ -46,7 +46,7 @@ Controls live on the server. Agents fetch their assigned controls at runtime and
 }
 ```
 
-The Strands integration ships as part of the AgentControl SDK as a [Strands Plugin](/docs/user-guide/concepts/plugins/). `AgentControlPlugin` and `AgentControlSteeringHandler` are available once you install the `strands-agents` extra.
+The Strands integration ships as part of the AgentControl SDK as a [Strands Plugin](/docs/community/plugins/agent-control/). `AgentControlPlugin` and `AgentControlSteeringHandler` are available once you install the `strands-agents` extra.
 
 ## AgentControlPlugin
 


### PR DESCRIPTION
## Description
Bug fix to agent_control blog (date was off, and link to Plugin is now more specific to this integration. 

## Checklist
<!-- Mark completed items with an [x] -->

- [ X] I have read the CONTRIBUTING document
- [ X] My changes follow the project's documentation style
- [ X] I have tested the documentation locally using `npm run dev`
- [ X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
