### PR TITLE
docs: add guardrail_only_user_input option to Bedrock guardrails docs

### DIFF
--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -475,6 +475,7 @@ bedrock_model = BedrockModel(
     guardrail_redact_output=False,  # Default: False
     guardrail_redact_output_message="Blocked Output!", # Default: [Assistant output redacted.]
     guardrail_latest_message=True,  # Only evaluate the latest user message (default: False)
+    guardrail_only_user_input=True,  # Evaluate only user text/image content, excluding tool results (default: False)
 )
 
 guardrail_agent = Agent(model=bedrock_model)
@@ -492,6 +493,12 @@ When a guardrail is triggered:
 
 :::note[Latest Message Evaluation]
 When `guardrail_latest_message=True`, only the most recent user message is sent to guardrails for evaluation instead of the entire conversation. This can improve performance and reduce costs in multi-turn conversations where earlier messages have already been validated.
+:::
+
+:::note[User Input Only Evaluation]
+When `guardrail_only_user_input=True`, all user text and image content across the entire conversation is wrapped in `guardContent` blocks so that only actual user input is evaluated by guardrails. Tool results are excluded from guardrail evaluation. This is useful when tool results may contain content that could trigger guardrails but should be trusted as system-generated output.
+
+If both `guardrail_latest_message` and `guardrail_only_user_input` are enabled, `guardrail_only_user_input` takes precedence as it already wraps all user messages, making `guardrail_latest_message` redundant.
 :::
 </Tab>
 <Tab label="TypeScript">


### PR DESCRIPTION

## Description
TO ADD: link to strands sdk-python PR
**Motivation**

  When using Bedrock Guardrails with multi-turn conversations, the existing
  guardrail_latest_message option only evaluates the most recent user message. This means earlier
  user messages in the conversation go unevaluated by guardrails, which is insufficient for use
  cases where all user-provided input across the entire conversation should be screened — for
  example, when guardrails enforce content policies that apply to the full conversation context
  rather than just the latest turn.

 **Public API Changes**

  BedrockModel now accepts a guardrail_only_user_input configuration option that wraps all user
  text and image content in guardContent blocks across the entire conversation, while leaving tool
  results unwrapped.

```python
  # Before: only the latest user message is evaluated by guardrails
  model = BedrockModel(
      model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
      guardrail_id="my-guardrail",
      guardrail_version="DRAFT",
      guardrail_latest_message=True,
  )
 ```
 ```python
  # After: all user text/image content across the conversation is evaluated
  model = BedrockModel(
      model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
      guardrail_id="my-guardrail",
      guardrail_version="DRAFT",
      guardrail_only_user_input=True,
  )
  ```

  The option defaults to False. When both guardrail_latest_message and guardrail_only_user_input
  are enabled, a warning is logged since guardrail_only_user_input already covers all user
  messages, making guardrail_latest_message redundant.

  Use Cases
  - Tool-aware guardrails: Evaluate only actual user-authored content while excluding tool results
  that the user did not write

## Related Issues
<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/sdk-python/issues/1671

## Type of Change
<!-- What kind of change are you making -->

- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
