### PR TITLE
docs(telemetry): added the usage of OTEL_SEMCONV_STABILITY_OPT_IN

### DIFF
--- a/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -112,6 +112,9 @@ export OTEL_EXPORTER_OTLP_ENDPOINT="http://collector.example.com:4318"
 # Set Default OTLP Headers
 export OTEL_EXPORTER_OTLP_HEADERS="key1=value1,key2=value2"
 
+# To use OTEL latest semantic conventions, and send tool defenitions as spans
+export OTEL_SEMCONV_STABILITY_OPT_IN="gen_ai_latest_experimental,gen_ai_tool_definitions"
+
 ```
 
 ### Code Configuration


### PR DESCRIPTION
## Description
Added the usage of `OTEL_SEMCONV_STABILITY_OPT_IN` so that user can switch the conventions and/or send the tool definitions to the destination.

## Related Issues
N/A


## Type of Change

- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
