### PR TITLE
feat: Generate tables for integrations & model providers automatically

### DIFF
--- a/src/components/SimpleTable.astro
+++ b/src/components/SimpleTable.astro
@@ -1,0 +1,57 @@
+---
+/**
+ * A reusable table component. Column headers and styles are defined via the
+ * `columns` prop. Cell content is rendered by the default slot, which is called
+ * as a function with `(item, colIndex)` for each cell.
+ *
+ * Because the slot runs in the caller's Astro/MDX context, it has full access to
+ * `import.meta.env.BASE_URL` and can render any JSX elements.
+ *
+ * @example
+ * ---
+ * const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+ * const columns = [
+ *   { header: "Package" },
+ *   { header: "Python", style: { textAlign: 'center' } },
+ * ]
+ * ---
+ * <SimpleTable data={tools} {columns}>
+ *   {(item, col) => [
+ *     <a href={`${base}${item.href}`}>{item.displayTitle}</a>,
+ *     item.pythonSupport ? '✅' : '❌',
+ *   ][col]}
+ * </SimpleTable>
+ */
+
+interface Column {
+  header: string
+  style?: Record<string, string>
+}
+
+interface Props {
+  data: Record<string, any>[]
+  columns: Column[]
+}
+
+const { data, columns } = Astro.props
+---
+
+<table>
+  <thead>
+    <tr>
+      {columns.map((col) => (
+        <th style={col.style}>{col.header}</th>
+      ))}
+    </tr>
+  </thead>
+  <tbody>
+    {await Promise.all(data.map(async (item) => (
+      <tr>
+        {await Promise.all(columns.map(async (col, colIndex) => {
+          const html = await Astro.slots.render('default', [item, colIndex])
+          return <td style={col.style} set:html={html} />
+        }))}
+      </tr>
+    )))}
+  </tbody>
+</table>

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -11,6 +11,8 @@ const { languages, community, experimental } = starlightRoute.entry.data;
 <div class="sl-markdown-content">
   {experimental && <ExperimentalAside />}
   {community && <CommunityContributionAside />}
-  {languages && <LanguageSupportAside languages={languages} />}
+  {/* Language support aside is omitted for community pages — the CommunityContributionAside already
+      contextualizes the page, and language support is listed in the community catalog table instead. */}
+  {languages && !community && <LanguageSupportAside languages={languages} />}
   <slot />
 </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -82,6 +82,10 @@ export const collections = {
         experimental: z.boolean().default(false),
         // Category for TypeScript API docs (classes, interfaces, type-aliases, functions)
         category: z.string().optional(),
+        // Integration type for filtering (e.g., 'model-provider' for model providers)
+        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'integration', 'plugin']).optional(),
+        // Short description for catalog listings
+        description: z.string().optional(),
         // Array of slugs that should redirect to this page (e.g., old URLs)
         redirectFrom: z.array(z.string()).optional(),
       }),

--- a/src/content/docs/community/community-packages.mdx
+++ b/src/content/docs/community/community-packages.mdx
@@ -4,55 +4,79 @@ sidebar:
   label: "Community Catalog"
 ---
 
+import { getCollection } from 'astro:content'
+import { getIntegrationEntries } from '@util/integration-content'
+import SimpleTable from '@components/SimpleTable.astro'
+import PageLink from '@components/PageLink.astro'
+
+export const allDocs = await getCollection('docs')
+export const communityIntegrations = getIntegrationEntries(allDocs, 'integration', true)
+export const communityPlugins = getIntegrationEntries(allDocs, 'plugin', true)
+export const communityModelProviders = getIntegrationEntries(allDocs, 'model-provider', true)
+export const communitySessionManagers = getIntegrationEntries(allDocs, 'session-manager', true)
+export const communityTools = getIntegrationEntries(allDocs, 'tool', true)
+
+export const packageColumns = [
+  { header: "Package" },
+  { header: "Description" },
+  { header: "Python", style: { textAlign: 'center' } },
+  { header: "TypeScript", style: { textAlign: 'center' } },
+]
+
+export const renderCell = (item, colIndex) => [
+    <PageLink href={item.href}>{item.displayTitle}</PageLink>,
+    item.description ?? '',
+    item.pythonSupport ? '✅' : '❌',
+    item.typescriptSupport ? '✅' : '❌',
+  ][colIndex]
+
 The Strands community has built tools and integrations for a variety of use cases. This catalog helps you discover what's available and find packages that solve your specific needs.
 
-Browse by category below to find tools, model providers, session managers, and platform integrations built by the community. 
+Browse by category below to find tools, model providers, session managers, and platform integrations built by the community.
 
 :::note[Community maintained]
 These packages are maintained by their authors, not the Strands team. Review packages before using them in production. Quality and support may vary.
 :::
 
-## Tools
+## Integrations
 
-Tools extend your agents with capabilities for specific services and platforms. Each package provides one or more tools you can add to your agents.
+Platform integrations help you connect Strands agents with external services and user interfaces.
 
-| Package | Description |
-|---------|-------------|
-| [strands-deepgram](./tools/strands-deepgram.md) | Deepgram speech-to-text |
-| [strands-hubspot](./tools/strands-hubspot.md) | HubSpot CRM integration |
-| [strands-teams](./tools/strands-teams.md) | Microsoft Teams |
-| [strands-telegram](./tools/strands-telegram.md) | Telegram bot |
-| [strands-telegram-listener](./tools/strands-telegram-listener.md) | Telegram listener |
-| [UTCP](./tools/utcp.md) | Universal Tool Calling Protocol |
+<SimpleTable data={communityIntegrations} columns={packageColumns}>
+  {renderCell}
+</SimpleTable>
+
+## Plugins
+
+Plugins extend agent behavior by hooking into lifecycle events. Use these to add cross-cutting capabilities like policy enforcement, logging, or output control without modifying your agent code.
+
+<SimpleTable data={communityPlugins} columns={packageColumns}>
+  {renderCell}
+</SimpleTable>
 
 ## Model providers
 
 Model providers add support for additional LLM services beyond the built-in providers. Use these to integrate with specialized or regional LLM platforms.
 
-| Package | Description |
-|---------|-------------|
-| [Cohere](./model-providers/cohere.md) | Cohere LLM |
-| [CLOVA Studio](./model-providers/clova-studio.md) | Naver CLOVA Studio |
-| [Fireworks AI](./model-providers/fireworksai.md) | Fireworks AI |
-| [Nebius](./model-providers/nebius-token-factory.md) | Nebius Token Factory |
+<SimpleTable data={communityModelProviders} columns={packageColumns}>
+ {renderCell}
+</SimpleTable>
 
 ## Session managers
 
 Session managers provide alternative storage backends for conversation history. Use these when you need persistent, scalable, or distributed session storage.
 
-| Package | Description |
-|---------|-------------|
-| [AgentCore Memory](./session-managers/agentcore-memory.md) | Amazon AgentCore |
-| [Valkey](./session-managers/strands-valkey-session-manager.md) | Valkey session manager |
+<SimpleTable data={communitySessionManagers} columns={packageColumns}>
+  {renderCell}
+</SimpleTable>
 
-## Integrations
+## Tools
 
-Platform integrations help you connect Strands agents with external services and user interfaces.
+Tools extend your agents with capabilities for specific services and platforms. Each package provides one or more tools you can add to your agents.
 
-| Package | Description |
-|---------|-------------|
-| [AG-UI](./integrations/ag-ui.md) | AG-UI integration |
-| [Datadog AI Guard](./plugins/datadog-ai-guard.md) | Real-time AI security with Datadog AI Guard |
+<SimpleTable data={communityTools} columns={packageColumns}>
+  {renderCell}
+</SimpleTable>
 
 ---
 

--- a/src/content/docs/community/integrations/ag-ui.mdx
+++ b/src/content/docs/community/integrations/ag-ui.mdx
@@ -1,6 +1,9 @@
 ---
 title: Build chat experiences with AG-UI and CopilotKit
 community: true
+description: AG-UI integration
+integrationType: integration
+languages: Python
 sidebar:
   label: "AG-UI"
 ---

--- a/src/content/docs/community/model-providers/clova-studio.mdx
+++ b/src/content/docs/community/model-providers/clova-studio.mdx
@@ -1,7 +1,9 @@
 ---
 title: CLOVA Studio
-languages: Python
 community: true
+description: Naver CLOVA Studio
+integrationType: model-provider
+languages: Python
 redirectFrom:
   - docs/user-guide/concepts/model-providers/clova-studio
 ---

--- a/src/content/docs/community/model-providers/cohere.mdx
+++ b/src/content/docs/community/model-providers/cohere.mdx
@@ -1,7 +1,9 @@
 ---
 title: Cohere
-languages: Python
 community: true
+description: Cohere LLM
+integrationType: model-provider
+languages: Python
 redirectFrom:
   - docs/user-guide/concepts/model-providers/cohere
 ---

--- a/src/content/docs/community/model-providers/fireworksai.mdx
+++ b/src/content/docs/community/model-providers/fireworksai.mdx
@@ -1,7 +1,9 @@
 ---
 title: FireworksAI
-languages: Python
 community: true
+description: Fireworks AI
+integrationType: model-provider
+languages: Python
 sidebar:
   label: "Fireworks AI"
 redirectFrom:

--- a/src/content/docs/community/model-providers/mlx.mdx
+++ b/src/content/docs/community/model-providers/mlx.mdx
@@ -1,7 +1,9 @@
 ---
 title: MLX
-languages: Python
 community: true
+description: MLX
+integrationType: model-provider
+languages: Python
 ---
 
 

--- a/src/content/docs/community/model-providers/nebius-token-factory.mdx
+++ b/src/content/docs/community/model-providers/nebius-token-factory.mdx
@@ -1,7 +1,9 @@
 ---
 title: Nebius Token Factory
-languages: Python
 community: true
+description: Nebius Token Factory
+integrationType: model-provider
+languages: Python
 redirectFrom:
   - docs/user-guide/concepts/model-providers/nebius-token-factory
 ---

--- a/src/content/docs/community/model-providers/nvidia-nim.mdx
+++ b/src/content/docs/community/model-providers/nvidia-nim.mdx
@@ -1,7 +1,9 @@
 ---
 title: NVIDIA NIM
-languages: Python
 community: true
+description: NVIDIA NIM
+integrationType: model-provider
+languages: Python
 ---
 
 

--- a/src/content/docs/community/model-providers/sglang.mdx
+++ b/src/content/docs/community/model-providers/sglang.mdx
@@ -1,7 +1,9 @@
 ---
 title: SGLang
-languages: Python
 community: true
+description: SGLang
+integrationType: model-provider
+languages: Python
 ---
 
 

--- a/src/content/docs/community/model-providers/vllm.mdx
+++ b/src/content/docs/community/model-providers/vllm.mdx
@@ -1,7 +1,9 @@
 ---
 title: vLLM
-languages: Python
 community: true
+description: vLLM
+integrationType: model-provider
+languages: Python
 ---
 
 

--- a/src/content/docs/community/model-providers/xai.mdx
+++ b/src/content/docs/community/model-providers/xai.mdx
@@ -7,6 +7,10 @@ service:
   name: xAI
   link: https://x.ai/
 title: xAI
+community: true
+description: xAI Grok
+integrationType: model-provider
+languages: Python
 redirectFrom:
   - docs/user-guide/concepts/model-providers/xai
 ---

--- a/src/content/docs/community/plugins/agent-control.mdx
+++ b/src/content/docs/community/plugins/agent-control.mdx
@@ -1,6 +1,9 @@
 ---
 title: Agent Control 
 community: true
+description: Runtime policy enforcement for agents
+integrationType: plugin
+languages: Python
 project:
   pypi: https://pypi.org/project/agent-control-sdk/
   github: https://github.com/agentcontrol/agent-control

--- a/src/content/docs/community/plugins/datadog-ai-guard.mdx
+++ b/src/content/docs/community/plugins/datadog-ai-guard.mdx
@@ -1,6 +1,9 @@
 ---
 title: Datadog AI Guard
 community: true
+description: Real-time AI security with Datadog AI Guard
+integrationType: plugin
+languages: Python
 sidebar:
   label: "Datadog AI Guard"
 ---

--- a/src/content/docs/community/session-managers/agentcore-memory.mdx
+++ b/src/content/docs/community/session-managers/agentcore-memory.mdx
@@ -1,6 +1,9 @@
 ---
 title: AgentCore Memory Session Manager
 community: true
+description: Amazon AgentCore
+integrationType: session-manager
+languages: Python
 sidebar:
   label: "Amazon AgentCore Memory"
 ---

--- a/src/content/docs/community/session-managers/strands-valkey-session-manager.mdx
+++ b/src/content/docs/community/session-managers/strands-valkey-session-manager.mdx
@@ -1,6 +1,9 @@
 ---
 title: Strands Valkey Session Manager
 community: true
+description: Valkey session manager
+integrationType: session-manager
+languages: Python
 sidebar:
   label: "Valkey/Redis"
 ---

--- a/src/content/docs/community/tools/strands-deepgram.mdx
+++ b/src/content/docs/community/tools/strands-deepgram.mdx
@@ -8,6 +8,9 @@ service:
   link: https://console.deepgram.com/
 title: strands-deepgram
 community: true
+description: Deepgram speech-to-text
+integrationType: tool
+languages: Python
 sidebar:
   label: "deepgram"
 ---

--- a/src/content/docs/community/tools/strands-hubspot.mdx
+++ b/src/content/docs/community/tools/strands-hubspot.mdx
@@ -8,6 +8,9 @@ service:
   link: https://developers.hubspot.com/
 title: strands-hubspot
 community: true
+description: HubSpot CRM integration
+integrationType: tool
+languages: Python
 sidebar:
   label: "hubspot"
 ---

--- a/src/content/docs/community/tools/strands-teams.mdx
+++ b/src/content/docs/community/tools/strands-teams.mdx
@@ -8,6 +8,9 @@ service:
   link: https://teams.microsoft.com/
 title: strands-teams
 community: true
+description: Microsoft Teams
+integrationType: tool
+languages: Python
 sidebar:
   label: "teams"
 ---

--- a/src/content/docs/community/tools/strands-telegram-listener.mdx
+++ b/src/content/docs/community/tools/strands-telegram-listener.mdx
@@ -8,6 +8,9 @@ service:
   link: https://core.telegram.org/bots
 title: strands-telegram-listener
 community: true
+description: Telegram listener
+integrationType: tool
+languages: Python
 sidebar:
   label: "telegram-listener"
 ---

--- a/src/content/docs/community/tools/strands-telegram.mdx
+++ b/src/content/docs/community/tools/strands-telegram.mdx
@@ -8,6 +8,9 @@ service:
   link: https://core.telegram.org/bots
 title: strands-telegram
 community: true
+description: Telegram bot
+integrationType: tool
+languages: Python
 sidebar:
   label: "telegram"
 ---

--- a/src/content/docs/community/tools/utcp.mdx
+++ b/src/content/docs/community/tools/utcp.mdx
@@ -1,6 +1,9 @@
 ---
 title: Universal Tool Calling Protocol (UTCP)
 community: true
+description: Universal Tool Calling Protocol
+integrationType: tool
+languages: Python
 sidebar:
   label: "UTCP"
 ---

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon Bedrock
+integrationType: model-provider
 ---
 
 Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models from leading AI companies through a unified API. Strands provides native support for Amazon Bedrock, allowing you to use these powerful models in your agents with minimal configuration.

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-nova.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-nova.mdx
@@ -1,6 +1,7 @@
 ---
 title: Amazon Nova
 languages: Python
+integrationType: model-provider
 ---
 
 [Amazon Nova](https://nova.amazon.com/) is a new generation of foundation models with frontier intelligence and industry leading price performance. Generate text, code, and images with natural language prompts. The [`strands-amazon-nova`](https://pypi.org/project/strands-amazon-nova/) package ([GitHub](https://github.com/amazon-nova-api/strands-nova)) provides an integration for the Strands Agents SDK, enabling seamless use of Amazon Nova models.

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -1,6 +1,7 @@
 ---
 title: Anthropic
 languages: Python
+integrationType: model-provider
 ---
 
 [Anthropic](https://docs.anthropic.com/en/home) is an AI safety and research company focused on building reliable, interpretable, and steerable AI systems. Included in their offerings is the Claude AI family of models, which are known for their conversational abilities, careful reasoning, and capacity to follow complex instructions. The Strands Agents SDK implements an Anthropic provider, allowing users to run agents against Claude models directly.

--- a/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
@@ -2,6 +2,7 @@
 title: Creating a Custom Model Provider
 sidebar:
   label: "Custom Providers"
+integrationType: model-provider
 ---
 
 Strands Agents SDK provides an extensible interface for implementing custom model providers, allowing organizations to integrate their own LLM services while keeping implementation details private to their codebase.

--- a/src/content/docs/user-guide/concepts/model-providers/gemini.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/gemini.mdx
@@ -1,5 +1,6 @@
 ---
 title: Gemini
+integrationType: model-provider
 ---
 
 [Google Gemini](https://ai.google.dev/api) is Google's family of multimodal large language models designed for advanced reasoning, code generation, and creative tasks. The Strands Agents SDK implements a Gemini provider, allowing you to run agents against the Gemini models available through Google's AI API.

--- a/src/content/docs/user-guide/concepts/model-providers/index.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/index.mdx
@@ -4,6 +4,27 @@ sidebar:
   label: "Overview"
 ---
 
+import { getCollection } from 'astro:content'
+import { getIntegrationEntries } from '@util/integration-content'
+import SimpleTable from '@components/SimpleTable.astro'
+import PageLink from '@components/PageLink.astro'
+
+export const allDocs = await getCollection('docs')
+export const officialProviders = getIntegrationEntries(allDocs, 'model-provider', false)
+export const communityProviders = getIntegrationEntries(allDocs, 'model-provider', true)
+
+export const providerColumns = [
+  { header: "Provider" },
+  { header: "Python Supported", style: { textAlign: 'center' } },
+  { header: "TypeScript Supported", style: { textAlign: 'center' } },
+]
+
+export const renderCell = (item, col) => [
+  <PageLink href={item.href}>{item.displayTitle}</PageLink>,
+  item.pythonSupport ? '✅' : '❌',
+  item.typescriptSupport ? '✅' : '❌',
+][col]
+
 ## What are Model Providers?
 
 A model provider is a service or platform that hosts and serves large language models through an API. The Strands Agents SDK abstracts away the complexity of working with different providers, offering a unified interface that makes it easy to switch between models or use multiple providers in the same application.
@@ -12,25 +33,17 @@ A model provider is a service or platform that hosts and serves large language m
 
 The following table shows all model providers supported by Strands Agents SDK and their availability in Python and TypeScript:
 
-| Provider                                     | Python Support | TypeScript Support |
-|----------------------------------------------|----------------|-------------------|
-| [Custom Providers](custom_model_provider.md) | ✅ | ✅ |
-| [Amazon Bedrock](amazon-bedrock.md)          | ✅ | ✅ |
-| [Amazon Nova](amazon-nova.md)                | ✅ | ❌ |
-| [OpenAI](openai.md)                          | ✅ | ✅ |
-| [Anthropic](anthropic.md)                    | ✅ | ❌ |
-| [Gemini](gemini.md)                          | ✅ | ✅ |
-| [LiteLLM](litellm.md)                        | ✅ | ❌ |
-| [llama.cpp](llamacpp.md)                     | ✅ | ❌ |
-| [LlamaAPI](llamaapi.md)                      | ✅ | ❌ |
-| [MistralAI](mistral.md)                      | ✅ | ❌ |
-| [Ollama](ollama.md)                          | ✅ | ❌ |
-| [SageMaker](sagemaker.md)                    | ✅ | ❌ |
-| [Writer](writer.md)                          | ✅ | ❌ |
-| [Cohere](/docs/community/model-providers/cohere/)                          | ✅ | ❌ |
-| [CLOVA Studio](/docs/community/model-providers/clova-studio/)              | ✅ | ❌ |
-| [FireworksAI](/docs/community/model-providers/fireworksai/)                | ✅ | ❌ |
-| [xAI](/docs/community/model-providers/xai/)                                | ✅ | ❌ |
+<SimpleTable data={officialProviders} columns={providerColumns}>
+  {renderCell}
+</SimpleTable>
+
+### Community providers
+
+The following providers are built and maintained by the Strands community. Browse the [Community Catalog](/docs/community/community-packages/) to explore additional community packages.
+
+<SimpleTable data={communityProviders} columns={providerColumns}>
+  {renderCell}
+</SimpleTable>
 
 ## Getting Started
 
@@ -112,4 +125,3 @@ response = agent("What can you help me with?")
 - **[Gemini](gemini.md)** - Google's Gemini models with tool calling support
 - **[Custom Providers](custom_model_provider.md)** - Build your own model integration
 - **[Anthropic](anthropic.md)** - Direct Claude API access (Python only)
-

--- a/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -1,6 +1,7 @@
 ---
 title: LiteLLM
 languages: Python
+integrationType: model-provider
 ---
 
 [LiteLLM](https://docs.litellm.ai/docs/) is a unified interface for various LLM providers that allows you to interact with models from Amazon, Anthropic, OpenAI, and many others through a single API. The Strands Agents SDK implements a LiteLLM provider, allowing you to run agents against any model LiteLLM supports.

--- a/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -3,6 +3,7 @@ title: Llama API
 languages: Python
 sidebar:
   label: "LlamaAPI"
+integrationType: model-provider
 ---
 
 [Llama API](https://llama.developer.meta.com?utm_source=partner-strandsagent&utm_medium=website) is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.

--- a/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
@@ -1,6 +1,7 @@
 ---
 title: llama.cpp
 languages: Python
+integrationType: model-provider
 ---
 
 [llama.cpp](https://github.com/ggml-org/llama.cpp) is a high-performance C++ inference engine for running large language models locally. The Strands Agents SDK implements a llama.cpp provider, allowing you to run agents against any llama.cpp server with quantized models.

--- a/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
@@ -3,6 +3,7 @@ title: Mistral AI
 languages: Python
 sidebar:
   label: "MistralAI"
+integrationType: model-provider
 ---
 
 [Mistral AI](https://mistral.ai/)  is a research lab building the best open source models in the world.

--- a/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -1,6 +1,7 @@
 ---
 title: Ollama
 languages: Python
+integrationType: model-provider
 ---
 
 Ollama is a framework for running open-source large language models locally. Strands provides native support for Ollama, allowing you to use locally-hosted models in your agents.

--- a/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -1,5 +1,6 @@
 ---
 title: OpenAI
+integrationType: model-provider
 ---
 
 [OpenAI](https://platform.openai.com/docs/overview) is an AI research and deployment company that provides a suite of powerful language models. The Strands Agents SDK implements an OpenAI provider, allowing you to run agents against any OpenAI or OpenAI-compatible model.

--- a/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
@@ -3,6 +3,7 @@ title: Amazon SageMaker
 languages: Python
 sidebar:
   label: "SageMaker"
+integrationType: model-provider
 ---
 
 [Amazon SageMaker](https://aws.amazon.com/sagemaker/) is a fully managed machine learning service that provides infrastructure and tools for building, training, and deploying ML models at scale. The Strands Agents SDK implements a SageMaker provider, allowing you to run agents against models deployed on SageMaker inference endpoints, including both pre-trained models from SageMaker JumpStart and custom fine-tuned models. The provider is designed to work with models that support OpenAI-compatible chat completion APIs.

--- a/src/content/docs/user-guide/concepts/model-providers/writer.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/writer.mdx
@@ -1,6 +1,7 @@
 ---
 title: Writer
 languages: Python
+integrationType: model-provider
 ---
 
 [Writer](https://writer.com/) is an enterprise generative AI platform offering specialized Palmyra models for finance, healthcare, creative, and general-purpose use cases. The models excel at tool calling, structured outputs, and domain-specific tasks, with Palmyra X5 supporting a 1M token context window.

--- a/src/util/integration-content.ts
+++ b/src/util/integration-content.ts
@@ -1,0 +1,118 @@
+/**
+ * Utilities for querying and filtering integration content from the docs collection.
+ *
+ * This module provides typed helper functions for working with integration pages
+ * (model providers, tools, session managers, etc.) that have `integrationType` frontmatter.
+ */
+
+import type { CollectionEntry } from 'astro:content'
+
+/**
+ * Integration types that can be used to filter content.
+ */
+export type IntegrationType =
+  | 'model-provider'
+  | 'tool'
+  | 'session-manager'
+  | 'integration'
+  | 'plugin'
+
+/**
+ * Represents language support for an integration.
+ */
+export interface LanguageSupport {
+  python: boolean
+  typescript: boolean
+}
+
+/**
+ * Represents a processed integration entry with computed properties.
+ */
+export interface IntegrationEntry {
+  /** The document ID (path) */
+  id: string
+  /** The page title */
+  title: string
+  /** The display title (sidebar label if set, otherwise page title) */
+  displayTitle: string
+  /** The href to the page */
+  href: string
+  /** Python support status */
+  pythonSupport: boolean
+  /** TypeScript support status */
+  typescriptSupport: boolean
+  /** Whether this is a community-contributed integration */
+  community: boolean
+  /** Optional description for catalog listings */
+  description?: string | undefined
+}
+
+/**
+ * Determines language support based on the `languages` frontmatter field.
+ *
+ * Convention:
+ * - No `languages` field = both Python and TypeScript supported
+ * - `languages: 'Python'` = Python only
+ * - `languages: 'TypeScript'` = TypeScript only
+ * - `languages: ['Python', 'TypeScript']` = both supported
+ */
+export function getLanguageSupport(languages: string | string[] | undefined): LanguageSupport {
+  if (!languages) {
+    return { python: true, typescript: true }
+  }
+
+  const langArray = Array.isArray(languages) ? languages : [languages]
+
+  // Empty array means both supported
+  if (langArray.length === 0) {
+    return { python: true, typescript: true }
+  }
+
+  const normalized = langArray.map((l) => l.toLowerCase())
+  return {
+    python: normalized.includes('python'),
+    typescript: normalized.includes('typescript'),
+  }
+}
+
+/**
+ * Filters and processes docs collection entries by integration type and community flag.
+ *
+ * @param docs - The full docs collection from `getCollection('docs')`
+ * @param integrationType - The integration type to filter by
+ * @param community - When true, returns only community entries; when false, returns only official entries
+ * @returns Sorted array of integration entries (alphabetically by display name)
+ */
+export function getIntegrationEntries(
+  docs: CollectionEntry<'docs'>[],
+  integrationType: IntegrationType,
+  community: boolean = false
+): IntegrationEntry[] {
+  return docs
+    .filter((doc) => {
+      if (doc.data.integrationType !== integrationType) return false
+      if ((doc.data.community === true) !== community) return false
+      return true
+    })
+    .map((doc) => {
+      const { python, typescript } = getLanguageSupport(doc.data.languages)
+
+      // Get sidebar label if available
+      const sidebarLabel = (doc.data.sidebar as { label?: string } | undefined)?.label
+
+      // Get description if available
+      const description = (doc.data as { description?: string }).description
+
+      return {
+        id: doc.id,
+        title: doc.data.title as string,
+        displayTitle: sidebarLabel ?? (doc.data.title as string),
+        href: `/docs/${doc.id.replace(/^docs\//, '')}/`,
+        pythonSupport: python,
+        typescriptSupport: typescript,
+        community: doc.data.community === true,
+        description,
+      }
+    })
+    .sort((a, b) => a.displayTitle.localeCompare(b.displayTitle))
+}


### PR DESCRIPTION
## Description

The community catalog and model providers pages had hand-maintained Markdown tables listing available packages and providers. Every time a new community package was added, we needed to update the tables manually 

### What Changed

Replaced the hard-coded tables on the Community Catalog and Model Providers overview pages with auto-generated tables driven by content collection frontmatter.

A new `getIntegrationEntries` utility (`src/util/integration-content.ts`) queries the docs collection and filters by `integrationType` and `community` flag and all tables are generated from that utility. 

## Related Issues

N/A


## Type of Change
<!-- What kind of change are you making -->


- Content update/revision

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
