### PR TITLE
docs(team): Add AGENT_GUIDELINES.md — conventions for agents on Stran…

### DIFF
--- a/team/AGENT_GUIDELINES.md
+++ b/team/AGENT_GUIDELINES.md
@@ -1,0 +1,73 @@
+# Agent Guidelines
+
+Guidelines for AI agents that interact with Strands repositories — PR reviews, issue triage, documentation, and autonomous improvements.
+
+Derived from the discussion in [strands-agents/docs#523](https://github.com/strands-agents/docs/pull/523).
+
+## Add Value or Stay Silent
+
+If an agent doesn't have something concrete to contribute, it should not act. Silence is better than noise.
+
+An agent should have a reason to act before acting: a reproducible test case, an actionable review suggestion, a clarifying question that moves the discussion forward, or a well-defined issue ready for implementation. When in doubt, flag for human review rather than acting independently.
+
+## Keep It Short
+
+Agent output should be concise. Lead with what matters, then stop. If there's additional context that might be useful, use progressive disclosure — a short summary up front with detailed analysis in a collapsible `<details>` block.
+
+Agents should read like a helpful teammate, not a lecture. Avoid excessive positive feedback, avoid restating the obvious, and avoid walls of text. Focus on what needs to change or what's worth calling out.
+
+## Approvals Need Reasoning
+
+When an agent doesn't approve something, it must clearly justify why — this is where the real value lies. For approvals, the bar depends on trust: early on, include brief reasoning so reviewers can calibrate the agent's judgment. As confidence grows, lighter approvals are fine, provided the agent is never the sole approver.
+
+## Scope Credentials to the Task
+
+Give agents the minimum permissions they need, nothing more. For task-specific agents (review, triage, docs), use tokens scoped to exactly those capabilities. For general-purpose agents where scoping is harder, use an external bot account (e.g. `strands-agent`) with community-level permissions rather than personal or maintainer accounts.
+
+**Never give agents maintainer tokens.** Maintainer tokens allow destructive actions (force-push, delete branches, modify settings) that may be irreversible.
+
+Security isn't just about tokens. Before deploying an agent, think through what failure looks like — spamming issues, pushing to wrong branches, runaway loops — and put explicit guardrails in place, even if the mitigation is just a system prompt. Document the tradeoffs.
+
+## Throttle Autonomous Activity
+
+Agents that act without explicit human triggering (scheduled, event-driven, continuous) should work at a pace humans can follow and respond to. If maintainers can't keep up with an agent's output, the agent is moving too fast.
+
+Prefer business-hours operation so maintainers can partner with agents in real time. Limit the number of active open items (PRs, issues) an agent maintains simultaneously. Specific rate limits will evolve as we learn — we haven't yet determined a robust framework for autonomous agents, and we should be vocal, kind, and patient with experimentation.
+
+## Own What You Deploy
+
+Every autonomous agent needs a named owner — a person, not a team. The owner is responsible for:
+
+- Access to logs and controls for the agent
+- A documented procedure to disable it quickly
+- Cleaning up mistakes — deleting bad comments, closing bad PRs, reverting changes
+- Iterating on the agent until it's genuinely useful; launching isn't enough
+
+If the owner leaves or becomes unavailable, ownership must transfer. An agent without an owner gets disabled.
+
+## Monitor What Agents Do
+
+Treat agents like any other contributor — their actions should be visible through existing tools (PR history, comment logs, audit trails). We don't build agent-specific monitoring systems when existing features suffice, but visibility into what an agent did, when, and on which repos is non-negotiable.
+
+## Maintainers Can Pull the Cord
+
+Any repository maintainer can disable any agent operating on their repo, immediately and without approval. Disabling must be fast — minutes, not hours. No negotiation required. Repository health takes precedence over agent operation.
+
+## Know That Your Agent Works
+
+Before deploying an agent to interact with the community, validate that it actually does what you intend. This can be automated evals, manual testing, or whatever makes sense for the problem space — the method matters less than the outcome. The agent should demonstrably work and not produce garbage. If a human contribution at the same quality level would be rejected, the agent's should be too.
+
+Get lightweight team buy-in before letting an autonomous agent loose on the repos. And keep evaluating — an agent that was good enough at launch may not stay good enough.
+
+## Pre-Deployment Checklist
+
+Before deploying an agent to Strands repositories:
+
+- [ ] The agent adds concrete value — not just noise
+- [ ] Output is concise and reads like a helpful teammate
+- [ ] Credentials follow principle of least privilege; failure modes documented
+- [ ] Named owner with access to logs, controls, and a documented disable procedure
+- [ ] Activity is throttled to a pace humans can keep up with
+- [ ] Actions are visible through existing tools
+- [ ] The agent has been validated (automated or manual) and team has signed off
+- [ ] Maintainers know how to shut it down immediately

--- a/team/README.md
+++ b/team/README.md
@@ -9,6 +9,7 @@ This folder contains internal documentation about how the Strands team builds an
 | [TENETS.md](./TENETS.md) | Core principles that guide SDK design and implementation |
 | [DECISIONS.md](./DECISIONS.md) | Record of design and API decisions with rationale |
 | [API_BAR_RAISING.md](./API_BAR_RAISING.md) | Process for reviewing and approving API changes |
+| [AGENT_GUIDELINES.md](./AGENT_GUIDELINES.md) | Guidelines for AI agents that interact with Strands repositories |
 
 ## For Contributors
 
@@ -17,5 +18,6 @@ When proposing changes to the SDK, please review these documents to understand:
 - **Tenets** — The principles your contribution should align with
 - **Decisions** — Past decisions that may inform your approach
 - **API Bar Raising** — The review process for API changes
+- **Agent Guidelines** — Conventions for agents operating on our repos
 
 If your contribution results in a new decision that could guide future work, consider adding it to [DECISIONS.md](./DECISIONS.md).


### PR DESCRIPTION
Adds `team/AGENT_GUIDELINES.md` — a compact reference for conventions governing AI agents that interact with Strands repositories.

This is the condensed, `team/`-format version of the guidelines discussed in #523. It distills the review feedback from that PR (48 comments across 7 reviewers) into a scannable reference that lives alongside `DECISIONS.md`, `TENETS.md`, and the other team docs.

**Guidelines covered:**
- **Add Value or Stay Silent** — agents act only when they have something concrete to contribute
- **Keep It Short** — progressive disclosure, no walls of text, no excessive praise
- **Approvals Need Reasoning** — rejections must justify; approvals calibrate to trust level
- **Scope Credentials to the Task** — principle of least privilege, never maintainer tokens, think through failure modes broadly
- **Throttle Autonomous Activity** — human-compatible pace, business hours preferred, limit active open items
- **Own What You Deploy** — named owner responsible for logs, cleanup, iteration, and kill switch
- **Monitor What Agents Do** — use existing tools, but visibility is non-negotiable
- **Maintainers Can Pull the Cord** — immediate disable, no approval needed
- **Know That Your Agent Works** — validate however makes sense (automated, manual, whatever) before deploying; team buy-in required

Also updates `team/README.md` to include the new document in the contents table.

## Related Issues

Condensed version of the design doc in #523

## Type of Change

- [x] New content
- [ ] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.