### PR TITLE
docs: add TypeScript examples to agents-as-tools documentation

### DIFF
--- a/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -33,7 +33,7 @@ When implementing the "Agents as Tools" pattern with Strands Agents SDK:
 
 ## Implementing Agents as Tools with Strands Agents SDK
 
-Strands Agents SDK provides a powerful framework for implementing the "Agents as Tools" pattern through its `@tool` decorator. This allows you to transform specialized agents into callable functions that can be used by an orchestrator agent.
+Strands Agents SDK provides a powerful framework for implementing the "Agents as Tools" pattern. Specialized agents are wrapped as callable tool functions that can be used by an orchestrator agent.
 
 ```mermaid
 flowchart TD
@@ -49,7 +49,10 @@ flowchart TD
 
 ### Creating Specialized Tool Agents
 
-First, define specialized agents as tool functions using Strands Agents SDK's `@tool` decorator:
+First, define specialized agents as tool functions:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands import Agent, tool
@@ -86,8 +89,19 @@ def research_assistant(query: str) -> str:
     except Exception as e:
         return f"Error in research assistant: {str(e)}"
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/multi-agent/agents-as-tools.ts:research_assistant"
+```
+</Tab>
+</Tabs>
 
 You can create multiple specialized agents following the same pattern:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 @tool
@@ -136,10 +150,21 @@ def trip_planning_assistant(query: str) -> str:
     except Exception as e:
         return f"Error in trip planning: {str(e)}"
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/multi-agent/agents-as-tools.ts:multiple_specialists"
+```
+</Tab>
+</Tabs>
 
 ### Creating the Orchestrator Agent
 
 Next, create an orchestrator agent that has access to all specialized agents as tools:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands import Agent
@@ -163,10 +188,21 @@ orchestrator = Agent(
     tools=[research_assistant, product_recommendation_assistant, trip_planning_assistant]
 )
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/multi-agent/agents-as-tools.ts:orchestrator"
+```
+</Tab>
+</Tabs>
 
 ### Real-World Example Scenario
 
 Here's how this multi-agent system might handle a complex user query:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 # Example: E-commerce Customer Service System
@@ -186,8 +222,16 @@ response = orchestrator(customer_query)
 # 3. Combine these specialized responses into a cohesive answer that addresses both the
 #    travel planning and product recommendation aspects of the query
 ```
+</Tab>
+<Tab label="TypeScript">
 
-This example demonstrates how Strands Agents SDK enables specialized experts to collaborate on complex queries requiring multiple domains of knowledge. The orchestrator intelligently routes different aspects of the query to the appropriate specialized agents, then synthesizes their responses into a comprehensive answer. By following the best practices outlined earlier and leveraging Strands Agents SDK's capabilities, you can build sophisticated multi-agent systems that handle complex tasks through specialized expertise and coordinated collaboration.
+```typescript
+--8<-- "user-guide/concepts/multi-agent/agents-as-tools.ts:usage"
+```
+</Tab>
+</Tabs>
+
+This example demonstrates how Strands Agents SDK enables specialized experts to collaborate on complex queries requiring multiple domains of knowledge. The orchestrator intelligently routes different aspects of the query to the appropriate specialized agents, then synthesizes their responses into a comprehensive answer.
 
 ## Remote Agents with A2A
 
@@ -195,4 +239,17 @@ You can also use remote agents as tools through the [Agent-to-Agent (A2A) protoc
 
 ## Complete Working Example
 
-For a fully implemented example of the "Agents as Tools" pattern, check out the ["Teacher's Assistant"](https://github.com/strands-agents/docs/blob/main/docs/examples/python/multi_agent_example/multi_agent_example.md) example in our repository. This example demonstrates a practical implementation of the concepts discussed in this document, showing how multiple specialized agents can work together to provide comprehensive assistance in an educational context.
+For complete implementations of this pattern, see the following examples:
+
+<Tabs>
+<Tab label="Python">
+
+The [Teacher's Assistant](../../../../examples/python/multi_agent_example/multi_agent_example/) example demonstrates an orchestrator agent that routes student queries to specialized agents for math, English, language translation, computer science, and general knowledge.
+
+</Tab>
+<Tab label="TypeScript">
+
+The [Agents as Tools](https://github.com/strands-agents/sdk-typescript/tree/main/examples/agents-as-tools) example demonstrates an orchestrator agent that routes student queries to specialized tool agents for math, English, computer science, and general knowledge.
+
+</Tab>
+</Tabs>

--- a/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.ts
+++ b/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.ts
@@ -1,0 +1,80 @@
+import { Agent, tool } from '@strands-agents/sdk'
+import { z } from 'zod'
+
+// --8<-- [start:research_assistant]
+const researchAssistant = tool({
+  name: 'research_assistant',
+  description: 'Process and respond to research-related queries requiring factual information.',
+  inputSchema: z.object({
+    query: z.string().describe('A research question requiring factual information'),
+  }),
+  callback: async (input) => {
+    const researchAgent = new Agent({
+      systemPrompt: `You are a specialized research assistant. Focus only on providing
+factual, well-sourced information in response to research questions.
+Always cite your sources when possible.`,
+    })
+
+    const response = await researchAgent.invoke(input.query)
+    return response.lastMessage.content.map((block) => ('text' in block ? block.text : '')).join('')
+  },
+})
+// --8<-- [end:research_assistant]
+
+// --8<-- [start:multiple_specialists]
+const productRecommendationAssistant = tool({
+  name: 'product_recommendation_assistant',
+  description: 'Handle product recommendation queries by suggesting appropriate products.',
+  inputSchema: z.object({
+    query: z.string().describe('A product inquiry with user preferences'),
+  }),
+  callback: async (input) => {
+    const productAgent = new Agent({
+      systemPrompt: `You are a specialized product recommendation assistant.
+Provide personalized product suggestions based on user preferences.`,
+    })
+
+    const response = await productAgent.invoke(input.query)
+    return response.lastMessage.content.map((block) => ('text' in block ? block.text : '')).join('')
+  },
+})
+
+const tripPlanningAssistant = tool({
+  name: 'trip_planning_assistant',
+  description: 'Create travel itineraries and provide travel advice.',
+  inputSchema: z.object({
+    query: z.string().describe('A travel planning request with destination and preferences'),
+  }),
+  callback: async (input) => {
+    const travelAgent = new Agent({
+      systemPrompt: `You are a specialized travel planning assistant.
+Create detailed travel itineraries based on user preferences.`,
+    })
+
+    const response = await travelAgent.invoke(input.query)
+    return response.lastMessage.content.map((block) => ('text' in block ? block.text : '')).join('')
+  },
+})
+// --8<-- [end:multiple_specialists]
+
+async function orchestratorExample() {
+  // --8<-- [start:orchestrator]
+  const orchestrator = new Agent({
+    systemPrompt: `You are an assistant that routes queries to specialized agents:
+- For research questions and factual information → Use the research_assistant tool
+- For product recommendations and shopping advice → Use the product_recommendation_assistant tool
+- For travel planning and itineraries → Use the trip_planning_assistant tool
+- For simple questions not requiring specialized knowledge → Answer directly
+
+Always select the most appropriate tool based on the user's query.`,
+    tools: [researchAssistant, productRecommendationAssistant, tripPlanningAssistant],
+  })
+  // --8<-- [end:orchestrator]
+
+  // --8<-- [start:usage]
+  const response = await orchestrator.invoke("I'm looking for hiking boots for a trip to Patagonia next month")
+  // --8<-- [end:usage]
+  void response
+}
+
+void orchestratorExample


### PR DESCRIPTION
## Description

Add TypeScript examples to the agents-as-tools documentation page.

TypeScript uses the `tool()` factory with Zod schemas to wrap agent invocations as tools, mirroring the Python `@tool` decorator pattern. All three code sections (creating specialist tools, creating the orchestrator, and usage) are now tabbed with Python and TypeScript examples.

## Related Issues

https://github.com/strands-agents/sdk-typescript/issues/391

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.