### PR TITLE
docs: add id, name, description to A2AAgent TypeScript config options

### DIFF
--- a/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -115,6 +115,9 @@ The `A2AAgent` constructor accepts a config object with these properties.
 |----------|------|---------|-------------|
 | `url` | `string` | Required | Base URL of the remote A2A agent |
 | `agentCardPath` | `string` | `/.well-known/agent-card.json` | Path to the agent card endpoint |
+| `id` | `string` | The `url` value | Unique identifier for the agent instance |
+| `name` | `string` | From agent card | Agent name (auto-populated from agent card if not provided) |
+| `description` | `string` | From agent card | Agent description (auto-populated from agent card if not provided) |
 
 The agent card is fetched lazily on the first `invoke()` or `stream()` call.
 


### PR DESCRIPTION
## Description

The TypeScript SDK added `id`, `name`, and `description` to `A2AAgentConfig` (see [strands-agents/sdk-typescript#663](https://github.com/strands-agents/sdk-typescript/pull/663)). This updates the A2A documentation page to include these new properties in the TypeScript configuration options table.

## Related Issues

Companion to [strands-agents/sdk-typescript#663](https://github.com/strands-agents/sdk-typescript/pull/663).

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] Links in the documentation are valid and working