### PR TITLE
fix: update TypeScript conversation manager docs for abstract base class

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -325,29 +325,9 @@ To create a custom conversation manager, extend the abstract [`ConversationManag
 For proactive management alongside overflow recovery, override `initAgent`:
 
 ```typescript
-import { Agent, ConversationManager, AfterInvocationEvent, type AgentData, type ConversationManagerReduceOptions } from '@strands-agents/sdk'
+--8<-- "user-guide/concepts/agents/conversation-management_imports.ts:custom_conversation_manager_proactive_imports"
 
-class MyManager extends ConversationManager {
-  readonly name = 'my:manager'
-  private readonly _maxMessages = 5
-
-  reduce({ agent }: ConversationManagerReduceOptions): boolean {
-    return this._trim(agent.messages)
-  }
-
-  override initAgent(agent: AgentData): void {
-    super.initAgent(agent) // preserves overflow recovery
-    agent.addHook(AfterInvocationEvent, (event) => {
-      this._trim(event.agent.messages)
-    })
-  }
-
-  private _trim(messages: AgentData['messages']): boolean {
-    if (messages.length <= this._maxMessages) return false
-    messages.splice(0, messages.length - this._maxMessages)
-    return true
-  }
-}
+--8<-- "user-guide/concepts/agents/conversation-management.ts:custom_conversation_manager_proactive"
 ```
 
 See the [SlidingWindowConversationManager](https://github.com/strands-agents/sdk-typescript/blob/main/src/conversation-manager/sliding-window-conversation-manager.ts) implementation as a reference example.

--- a/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -1,4 +1,4 @@
-import { Agent, ConversationManager, NullConversationManager, SlidingWindowConversationManager, type ConversationManagerReduceOptions } from '@strands-agents/sdk'
+import { Agent, ConversationManager, AfterInvocationEvent, NullConversationManager, SlidingWindowConversationManager, type AgentData, type ConversationManagerReduceOptions } from '@strands-agents/sdk'
 
 async function nullConversationManagerAgent() {
   // --8<-- [start:null_conversation_manager]
@@ -37,3 +37,27 @@ const agent = new Agent({
   conversationManager: new Last10MessagesManager(),
 })
 // --8<-- [end:custom_conversation_manager]
+
+// --8<-- [start:custom_conversation_manager_proactive]
+class MyManager extends ConversationManager {
+  readonly name = 'my:manager'
+  private readonly _maxMessages = 5
+
+  reduce({ agent }: ConversationManagerReduceOptions): boolean {
+    return this._trim(agent.messages)
+  }
+
+  override initAgent(agent: AgentData): void {
+    super.initAgent(agent) // preserves overflow recovery
+    agent.addHook(AfterInvocationEvent, (event) => {
+      this._trim(event.agent.messages)
+    })
+  }
+
+  private _trim(messages: AgentData['messages']): boolean {
+    if (messages.length <= this._maxMessages) return false
+    messages.splice(0, messages.length - this._maxMessages)
+    return true
+  }
+}
+// --8<-- [end:custom_conversation_manager_proactive]

--- a/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
+++ b/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
@@ -11,3 +11,7 @@ import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [start:custom_conversation_manager_imports]
 import { Agent, ConversationManager, type ConversationManagerReduceOptions } from '@strands-agents/sdk'
 // --8<-- [end:custom_conversation_manager_imports]
+
+// --8<-- [start:custom_conversation_manager_proactive_imports]
+import { Agent, ConversationManager, AfterInvocationEvent, type AgentData, type ConversationManagerReduceOptions } from '@strands-agents/sdk'
+// --8<-- [end:custom_conversation_manager_proactive_imports]


### PR DESCRIPTION
## Description

Updates the TypeScript "Creating a ConversationManager" section to reflect the new `ConversationManager` abstract base class introduced in [strands-agents/sdk-typescript#664](https://github.com/strands-agents/sdk-typescript/pull/664).

Previously the docs stated that TypeScript had no base interface and that custom managers should implement `Plugin` directly by wiring `AfterModelCallEvent` hooks manually. The SDK now exports `ConversationManager` as a proper abstract class with a single required method (`reduce`) — the base class handles overflow recovery automatically.

## Related Issues

strands-agents/sdk-typescript#664

## Type of Change

- [x] Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
