### PR TITLE
docs: update telemetry imports for SDK subpath export

### DIFF
--- a/src/content/docs/user-guide/observability-evaluation/traces.ts
+++ b/src/content/docs/user-guide/observability-evaluation/traces.ts
@@ -1,4 +1,5 @@
-import { telemetry, Agent } from '@strands-agents/sdk'
+import { Agent } from '@strands-agents/sdk'
+import { setupTracer } from '@strands-agents/sdk/telemetry'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
@@ -15,9 +16,9 @@ async function codeConfigurationOption1() {
 
 function codeConfigurationOption2() {
   // --8<-- [start:code_configuration_option2]
-  // Option 2: Use telemetry.setupTracer() to handle complete OpenTelemetry setup
+  // Option 2: Use setupTracer() to handle complete OpenTelemetry setup
   // (creates a new tracer provider and registers it as global)
-  telemetry.setupTracer({
+  setupTracer({
     exporters: { otlp: true, console: true }, // Send traces to OTLP endpoint and console debug
   })
   // --8<-- [end:code_configuration_option2]
@@ -27,7 +28,7 @@ function codeConfigurationOption3() {
   // --8<-- [start:code_configuration_option3]
   // Option 3: Use setupTracer() with your own tracer provider
   const provider = new NodeTracerProvider()
-  telemetry.setupTracer({
+  setupTracer({
     provider,
     exporters: { otlp: true, console: true },
   })
@@ -48,7 +49,7 @@ async function codeConfigurationAgent() {
 
 function consoleExporter() {
   // --8<-- [start:console_exporter]
-  telemetry.setupTracer({
+  setupTracer({
     exporters: { console: true },
   })
   // --8<-- [end:console_exporter]
@@ -85,7 +86,7 @@ function configuringExporters() {
   provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()))
 
   // Register the provider with Strands
-  telemetry.setupTracer({ provider })
+  setupTracer({ provider })
   // --8<-- [end:configuring_exporters]
 }
 
@@ -95,7 +96,7 @@ async function endToEnd() {
   process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318'
 
   // Configure telemetry
-  telemetry.setupTracer({
+  setupTracer({
     exporters: { otlp: true, console: true },
   })
 

--- a/src/content/docs/user-guide/observability-evaluation/traces_imports.ts
+++ b/src/content/docs/user-guide/observability-evaluation/traces_imports.ts
@@ -5,16 +5,18 @@ import { Agent } from '@strands-agents/sdk'
 // --8<-- [end:code_configuration_option1_imports]
 
 // --8<-- [start:code_configuration_option2_imports]
-import { telemetry, Agent } from '@strands-agents/sdk'
+import { Agent } from '@strands-agents/sdk'
+import { setupTracer } from '@strands-agents/sdk/telemetry'
 // --8<-- [end:code_configuration_option2_imports]
 
 // --8<-- [start:code_configuration_option3_imports]
-import { telemetry, Agent } from '@strands-agents/sdk'
+import { Agent } from '@strands-agents/sdk'
+import { setupTracer } from '@strands-agents/sdk/telemetry'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 // --8<-- [end:code_configuration_option3_imports]
 
 // --8<-- [start:console_exporter_imports]
-import { telemetry } from '@strands-agents/sdk'
+import { setupTracer } from '@strands-agents/sdk/telemetry'
 // --8<-- [end:console_exporter_imports]
 
 // --8<-- [start:custom_attributes_imports]
@@ -22,12 +24,13 @@ import { Agent } from '@strands-agents/sdk'
 // --8<-- [end:custom_attributes_imports]
 
 // --8<-- [start:configuring_exporters_imports]
-import { telemetry } from '@strands-agents/sdk'
+import { setupTracer } from '@strands-agents/sdk/telemetry'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 // --8<-- [end:configuring_exporters_imports]
 
 // --8<-- [start:end_to_end_imports]
-import { telemetry, Agent } from '@strands-agents/sdk'
+import { Agent } from '@strands-agents/sdk'
+import { setupTracer } from '@strands-agents/sdk/telemetry'
 // --8<-- [end:end_to_end_imports]


### PR DESCRIPTION
## Description

SDK PR [strands-agents/sdk-typescript#671](https://github.com/strands-agents/sdk-typescript/pull/671) moves the telemetry module from the main `@strands-agents/sdk` entry point to a dedicated `@strands-agents/sdk/telemetry` subpath export. This fixes TypeScript compilation errors for consumers who set `skipLibCheck: false`, since the main entry point no longer pulls in heavy OpenTelemetry type dependencies.

This PR updates the TypeScript code examples in the observability/traces documentation to use the new import path:

```typescript
// Before
import { telemetry } from '@strands-agents/sdk'
telemetry.setupTracer({ exporters: { otlp: true } })

// After
import { setupTracer } from '@strands-agents/sdk/telemetry'
setupTracer({ exporters: { otlp: true } })
```

## Related Issues

- strands-agents/sdk-typescript#669
- strands-agents/sdk-typescript#671

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.