### PR TITLE
docs: update vended tools import paths to kebab-case

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,7 @@ Create a `.ts` file alongside your `.md` file with snippet markers:
 ```typescript
 // docs/user-guide/concepts/agents/agent-loop.ts
 import { Agent } from '@strands-agents/sdk'
-import { notebook } from '@strands-agents/sdk/vended_tools/notebook'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 
 // --8<-- [start:initialization]
 // Initialize the agent with tools, model, and configuration

--- a/src/content/docs/user-guide/concepts/streaming/async-iterators.ts
+++ b/src/content/docs/user-guide/concepts/streaming/async-iterators.ts
@@ -1,5 +1,5 @@
 import { Agent } from '@strands-agents/sdk'
-import { notebook } from '@strands-agents/sdk/vended_tools/notebook'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 import express from 'express'
 
 // Basic Usage Example

--- a/src/content/docs/user-guide/concepts/streaming/overview.ts
+++ b/src/content/docs/user-guide/concepts/streaming/overview.ts
@@ -1,5 +1,5 @@
 import { Agent, tool } from '@strands-agents/sdk'
-import { notebook } from '@strands-agents/sdk/vended_tools/notebook'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 import type { AgentStreamEvent } from '@strands-agents/sdk'
 import { z } from 'zod'
 

--- a/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -413,7 +413,7 @@ TypeScript vended tools are included in the SDK at [`vended-tools/`](https://git
 The Community Tools Package (`strands-agents-tools`) is Python-only.
 
 ```typescript
---8<-- "user-guide/concepts/tools/tools.ts:vended_tools"
+--8<-- "user-guide/concepts/tools/tools.ts:vended-tools"
 ```
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/tools/tools.ts
+++ b/src/content/docs/user-guide/concepts/tools/tools.ts
@@ -1,7 +1,7 @@
 import { Agent, tool, FunctionTool } from '@strands-agents/sdk'
 import type { ToolContext, InvokableTool } from '@strands-agents/sdk'
-import { notebook } from '@strands-agents/sdk/vended_tools/notebook'
-import { fileEditor } from '@strands-agents/sdk/vended_tools/file_editor'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
+import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { z } from 'zod'
 
 // Basic tool example
@@ -261,11 +261,11 @@ async function toolContextInvocationStateExample() {
 
 // Vended tools example
 async function vendedToolsExample() {
-  // --8<-- [start:vended_tools]
+  // --8<-- [start:vended-tools]
   const agent = new Agent({
     tools: [notebook, fileEditor],
   })
-  // --8<-- [end:vended_tools]
+  // --8<-- [end:vended-tools]
 }
 
 // Adding tools to agents example

--- a/src/content/docs/user-guide/concepts/tools/tools_imports.ts
+++ b/src/content/docs/user-guide/concepts/tools/tools_imports.ts
@@ -3,10 +3,10 @@
 // --8<-- [start:direct_invocation_imports]
 import { Agent } from '@strands-agents/sdk'
 import type { InvokableTool } from '@strands-agents/sdk'
-import { notebook } from '@strands-agents/sdk/vended_tools/notebook'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:direct_invocation_imports]
 
 // --8<-- [start:adding_tools_imports]
 import { Agent } from '@strands-agents/sdk'
-import { fileEditor } from '@strands-agents/sdk/vended_tools/file_editor'
+import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 // --8<-- [end:adding_tools_imports]

--- a/src/content/docs/user-guide/observability-evaluation/metrics.ts
+++ b/src/content/docs/user-guide/observability-evaluation/metrics.ts
@@ -1,5 +1,5 @@
 import { Agent } from '@strands-agents/sdk'
-import { notebook } from '@strands-agents/sdk/vended_tools/notebook'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 
 // Basic metrics example
 async function basicMetricsExample() {

--- a/src/content/docs/user-guide/quickstart/typescript.mdx
+++ b/src/content/docs/user-guide/quickstart/typescript.mdx
@@ -36,7 +36,7 @@ npm install @strands-agents/sdk
 The Strands Agents SDK includes optional vended tools that are built-in and production-ready for your agents to use. These tools can be imported directly as follows:
 
 ```typescript
-import { bash } from '@strands-agents/sdk/vended_tools/bash'
+import { bash } from '@strands-agents/sdk/vended-tools/bash'
 ```
 
 


### PR DESCRIPTION
## Description

Update all TypeScript SDK import paths in documentation to use kebab-case, matching the convention adopted in strands-agents/sdk-typescript.

Changes:
- `@strands-agents/sdk/vended_tools/notebook` → `@strands-agents/sdk/vended-tools/notebook`
- `@strands-agents/sdk/vended_tools/file_editor` → `@strands-agents/sdk/vended-tools/file-editor`
- `@strands-agents/sdk/vended_tools/bash` → `@strands-agents/sdk/vended-tools/bash`
- Snippet markers renamed from `vended_tools` to `vended-tools` for consistency

## Related Issues

Companion to the SDK change in strands-agents/sdk-typescript that renames vended tool directories and export paths to kebab-case.

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.