### PR TITLE
fix: update malformed alert boxes in traces and session-management pages

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/session-management.mdx
+++ b/src/content/docs/user-guide/concepts/agents/session-management.mdx
@@ -357,7 +357,8 @@ See [Basic Usage](#basic-usage) for configuration examples.
 - **Node Execution**: Synchronizes orchestrator state after node transitions.
 - **Multi-Agent Invocation**: Captures final orchestrator state after execution.
 
-:::caution[After initializing the agent, direct modifications to `agent.messages` will not be persisted. Utilize the [Conversation Manager](./conversation-management.md) to help manage context of the agent in a way that can be persisted.]
+:::note[Direct Message Modifications Not Persisted]
+After initializing the agent, direct modifications to `agent.messages` will not be persisted. Utilize the [Conversation Manager](./conversation-management.md) to help manage context of the agent in a way that can be persisted.
 :::
 
 ## Immutable Snapshots *(TypeScript only)*

--- a/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -92,11 +92,22 @@ Strands natively integrates with OpenTelemetry, an industry standard for distrib
 <Tabs>
 <Tab label="Python">
 
-!!! warning "To enable OTEL exporting, install Strands Agents with `otel` extra dependencies: `pip install 'strands-agents[otel]'`"
+:::note[Install OpenTelemetry Dependencies]
+To enable OTEL exporting, install Strands Agents with `otel` optional dependency:
+
+```shell
+pip install 'strands-agents[otel]'
+```
+:::
 </Tab>
 <Tab label="TypeScript">
 
-:::caution[To enable OTEL exporting, install the OpenTelemetry peer dependencies: `npm install @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/sdk-trace-base @opentelemetry/resources @opentelemetry/exporter-trace-otlp-http`]
+:::note[Install OpenTelemetry Dependencies]
+To enable OTEL exporting, install the OpenTelemetry peer dependencies: 
+
+```shell
+npm install @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/sdk-trace-base @opentelemetry/resources @opentelemetry/exporter-trace-otlp-http
+```
 :::
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Description

Fixes malformed alert boxes in the "Enabling Tracing" section of the traces page. The Python tab had an MkDocs-style `!!! warning` admonition and the TypeScript tab had a `:::caution` block — both were rendering incorrectly. Replaced both with properly formatted `:::note[Install OpenTelemetry Dependencies]` blocks that include the install commands in a shell code block.

Also fixes a similar malformed alert in `session-management.mdx`.

Changed to `note`s because caution looked to scary for something that is more of a "don't forget" thing.

## Related Issues

N/A

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
