### PR TITLE
docs: update feature availability matrix for TypeScript accuracy and add links

### DIFF
--- a/src/content/docs/user-guide/quickstart/overview.mdx
+++ b/src/content/docs/user-guide/quickstart/overview.mdx
@@ -35,29 +35,30 @@ The table below compares feature availability between the Python and TypeScript 
 
 | Category | Feature | Python | TypeScript |
 |----------|---------|:------:|:----------:|
-| **Core** | Agent creation and invocation | ✅ | ✅ |
-| | Streaming responses | ✅ | ✅ |
-| | Structured output | ✅ | ❌ |
-| **Model providers** | Amazon Bedrock | ✅ | ✅ |
-| | OpenAI | ✅ | ✅ |
-| | Anthropic | ✅ | ❌ |
-| | Ollama | ✅ | ❌ |
-| | LiteLLM | ✅ | ❌ |
-| | Custom providers | ✅ | ✅ |
-| **Tools** | Custom function tools | ✅ | ✅ |
-| | MCP (Model Context Protocol) | ✅ | ✅ |
-| | Built-in tools | 30+ via community package | 4 built-in |
-| **Conversation** | Null manager | ✅ | ✅ |
-| | Sliding window manager | ✅ | ✅ |
-| | Summarizing manager | ✅ | ❌ |
-| **Hooks** | Lifecycle hooks | ✅ | ✅ |
-| | Custom hook providers | ✅ | ✅ |
-| **Multi-agent** | Swarms | ✅ | ✅ |
-| | Graphs | ✅ | ✅ |
-| | Workflows | ✅ | ✅ |
-| | Agents as tools | ✅ | ✅ |
-| | Agent-to-Agent (A2A) | ✅ | ✅ |
-| **Session management** | File, S3, repository managers | ✅ | ❌ |
-| **Observability** | OpenTelemetry integration | ✅ | ❌ |
-| **Experimental** | Bidirectional streaming | ✅ | ❌ |
-| | Agent steering | ✅ | ❌ |
+| **Core** | [Agent creation and invocation](../concepts/agents/agent-loop/) | ✅ | ✅ |
+| | [Streaming responses](../concepts/streaming/) | ✅ | ✅ |
+| | [Structured output](../concepts/agents/structured-output/) | ✅ | ✅ |
+| **Model providers** | [Amazon Bedrock](../concepts/model-providers/amazon-bedrock/) | ✅ | ✅ |
+| | [OpenAI](../concepts/model-providers/openai/) | ✅ | ✅ |
+| | [Anthropic](../concepts/model-providers/anthropic/) | ✅ | ✅ |
+| | [Ollama](../concepts/model-providers/ollama/) | ✅ | ❌ |
+| | [LiteLLM](../concepts/model-providers/litellm/) | ✅ | ❌ |
+| | [Custom providers](../concepts/model-providers/custom_model_provider/) | ✅ | ✅ |
+| | [Additional providers](../concepts/model-providers/) | 5+ | 1+ |
+| **Tools** | [Custom function tools](../concepts/tools/custom-tools/) | ✅ | ✅ |
+| | [MCP (Model Context Protocol)](../concepts/tools/mcp-tools/) | ✅ | ✅ |
+| | [Built-in tools](../concepts/tools/community-tools-package/) | 30+ via community package | 4 built-in |
+| **Conversation** | [Null manager](../concepts/agents/conversation-management/) | ✅ | ✅ |
+| | [Sliding window manager](../concepts/agents/conversation-management/) | ✅ | ✅ |
+| | [Summarizing manager](../concepts/agents/conversation-management/) | ✅ | ❌ |
+| **Hooks** | [Lifecycle hooks](../concepts/agents/hooks/) | ✅ | ✅ |
+| | [Custom hook providers](../concepts/agents/hooks/) | ✅ | ✅ |
+| **Multi-agent** | [Swarms](../concepts/multi-agent/swarm/) | ✅ | ✅ |
+| | [Graphs](../concepts/multi-agent/graph/) | ✅ | ✅ |
+| | [Workflows](../concepts/multi-agent/workflow/) | ✅ | ✅ |
+| | [Agents as tools](../concepts/multi-agent/agents-as-tools/) | ✅ | ✅ |
+| | [Agent-to-Agent (A2A)](../concepts/multi-agent/agent-to-agent/) | ✅ | ✅ |
+| **Session management** | [File, S3, repository managers](../concepts/agents/session-management/) | ✅ | ✅ |
+| **Observability** | [OpenTelemetry integration](../observability-evaluation/observability/) | ✅ | ✅ |
+| **Experimental** | [Bidirectional streaming](../concepts/bidirectional-streaming/quickstart/) | ✅ | ❌ |
+| | [Agent steering](../concepts/plugins/steering/) | ✅ | ❌ |


### PR DESCRIPTION
## Summary

Updates the feature availability matrix on the Getting Started page to accurately reflect current TypeScript SDK capabilities and adds documentation links to all feature names for better navigation.

## Changes

### TypeScript Accuracy Updates

Based on analysis of the [TypeScript SDK repository](https://github.com/strands-agents/sdk-typescript/), the following features were incorrectly marked as unavailable:

| Feature | Previous | Updated | Evidence |
|---------|----------|---------|----------|
| Structured output | ❌ | ✅ | `src/structured-output/` directory |
| Anthropic | ❌ | ✅ | `src/models/anthropic.ts` |
| Session management | ❌ | ✅ | `src/session/file-storage.ts`, `src/session/s3-storage.ts` |
| OpenTelemetry | ❌ | ✅ | `src/telemetry/` directory |

### New Row Added

Added "Additional providers" row in Model Providers section:
- Python: 5+
- TypeScript: 1+ (Gemini exists)

### Documentation Links

All feature names now link to their corresponding documentation pages using relative paths, improving navigation and discoverability.

## Testing

- ✅ All tests pass (291 passed)
- ✅ Format check passes
- ✅ Links use relative paths from the overview.mdx location

Resolves #678