### PR TITLE
docs: rename OpenAIModel to OpenAIChatModel in TypeScript examples

### DIFF
--- a/src/content/docs/user-guide/concepts/model-providers/index.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/index.ts
@@ -6,8 +6,8 @@
 // Imports are in index_imports.ts
 
 import { Agent } from '@strands-agents/sdk'
-import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
-import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+import { BedrockModel } from '@strands-agents/sdk/bedrock'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 
 async function basicUsage() {
   // --8<-- [start:basic_usage]
@@ -19,7 +19,7 @@ async function basicUsage() {
   let response = await agent.invoke('What can you help me with?')
 
   // Alternatively, use OpenAI by just switching model provider
-  const openaiModel = new OpenAIModel({
+  const openaiModel = new OpenAIChatModel({
     apiKey: process.env.OPENAI_API_KEY,
     modelId: 'gpt-4o',
   })

--- a/src/content/docs/user-guide/concepts/model-providers/index_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/index_imports.ts
@@ -3,5 +3,5 @@
 // --8<-- [start:basic_usage_imports]
 import { Agent } from '@strands-agents/sdk'
 import { BedrockModel } from '@strands-agents/sdk/bedrock'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 // --8<-- [end:basic_usage_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/openai.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/openai.ts
@@ -1,17 +1,17 @@
 /**
  * TypeScript examples for OpenAI model provider documentation.
- * These examples demonstrate common usage patterns for the OpenAIModel.
+ * These examples demonstrate common usage patterns for the OpenAIChatModel.
  */
 // @ts-nocheck
 // Imports are in openai_imports.ts
 
 import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 
 // Basic usage
 async function basicUsage() {
   // --8<-- [start:basic_usage]
-  const model = new OpenAIModel({
+  const model = new OpenAIChatModel({
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
     modelId: 'gpt-4o',
     maxTokens: 1000,
@@ -27,7 +27,7 @@ async function basicUsage() {
 // Custom server
 async function customServer() {
   // --8<-- [start:custom_server]
-  const model = new OpenAIModel({
+  const model = new OpenAIChatModel({
     apiKey: '<KEY>',
     clientConfig: {
       baseURL: '<URL>',
@@ -43,7 +43,7 @@ async function customServer() {
 // Configuration
 async function customConfig() {
   // --8<-- [start:custom_config]
-  const model = new OpenAIModel({
+  const model = new OpenAIChatModel({
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
     modelId: 'gpt-4o',
     maxTokens: 1000,
@@ -62,7 +62,7 @@ async function customConfig() {
 // Update configuration
 async function updateConfig() {
   // --8<-- [start:update_config]
-  const model = new OpenAIModel({
+  const model = new OpenAIChatModel({
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
     modelId: 'gpt-4o',
     temperature: 0.7,

--- a/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
@@ -2,5 +2,5 @@
 
 // --8<-- [start:basic_usage_imports]
 import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 // --8<-- [end:basic_usage_imports]

--- a/src/content/docs/user-guide/deploy/deploy_to_docker/imports.ts
+++ b/src/content/docs/user-guide/deploy/deploy_to_docker/imports.ts
@@ -1,6 +1,6 @@
 // --8<-- [start: imports]
 import { Agent } from '@strands-agents/sdk'
 import express, { type Request, type Response } from 'express'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 
 // --8<-- [end: imports]

--- a/src/content/docs/user-guide/deploy/deploy_to_docker/index.ts
+++ b/src/content/docs/user-guide/deploy/deploy_to_docker/index.ts
@@ -1,13 +1,13 @@
 import { Agent } from '@strands-agents/sdk'
 import express, { type Request, type Response } from 'express'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 
 // --8<-- [start: agent]
 const PORT = Number(process.env.PORT) || 8080
 
 // Note: Any supported model provider can be configured
 // Automatically uses process.env.OPENAI_API_KEY
-const model = new OpenAIModel()
+const model = new OpenAIChatModel()
 
 const agent = new Agent({ model })
 

--- a/src/content/docs/user-guide/deploy/deploy_to_docker/typescript.mdx
+++ b/src/content/docs/user-guide/deploy/deploy_to_docker/typescript.mdx
@@ -73,13 +73,13 @@ npm pkg set scripts.build="tsc" scripts.start="node dist/index.js" scripts.dev="
 cat > index.ts << 'EOF'
 import { Agent } from '@strands-agents/sdk'
 import express, { type Request, type Response } from 'express'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { OpenAIChatModel } from '@strands-agents/sdk/openai-chat'
 
 const PORT = Number(process.env.PORT) || 8080
 
 // Note: Any supported model provider can be configured
 // Automatically uses process.env.OPENAI_API_KEY
-const model = new OpenAIModel()
+const model = new OpenAIChatModel()
 
 const agent = new Agent({ model })
 


### PR DESCRIPTION
## Description

Updates all TypeScript documentation examples to reflect the SDK rename of `OpenAIModel` to `OpenAIChatModel` and the export path change from `@strands-agents/sdk/openai` to `@strands-agents/sdk/openai-chat`.

Also fixes a pre-existing bug where `index.ts` used invalid `@strands-agents/sdk/models/bedrock` and `@strands-agents/sdk/models/openai` import paths that do not exist in the SDK package.json exports map. These have been corrected to `@strands-agents/sdk/bedrock` and `@strands-agents/sdk/openai-chat` respectively.

## Related Issues

Companion to the SDK rename PR in strands-agents/sdk-typescript.

## Type of Change

- Content update/revision
- Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.