### PR TITLE
docs: update TypeScript SDK model provider class names and import paths

### DIFF
--- a/SITE-ARCHITECTURE.md
+++ b/SITE-ARCHITECTURE.md
@@ -510,7 +510,7 @@ Namespaces
   └── telemetry
 Classes
   ├── Agent
-  ├── BedrockModel
+  ├── ConverseModel
   └── Tool
 Interfaces
   ├── AgentConfig

--- a/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md
+++ b/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md
@@ -215,7 +215,7 @@ const myCustomTool = strands.tool({
 })
 
 const agent = new strands.Agent({
-  model: new strands.BedrockModel({
+  model: new strands.ConverseModel({
     region: 'ap-southeast-2',
   }),
   tools: [calculatorTool, myCustomTool], // Add your tool here

--- a/docs/examples/typescript/deploy_to_bedrock_agentcore/index.ts
+++ b/docs/examples/typescript/deploy_to_bedrock_agentcore/index.ts
@@ -29,7 +29,7 @@ const calculatorTool = strands.tool({
 
 // Configure the agent with Amazon Bedrock
 const agent = new strands.Agent({
-  model: new strands.BedrockModel({
+  model: new strands.ConverseModel({
     region: 'ap-southeast-2', // Change to your preferred region
   }),
   tools: [calculatorTool],

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -188,7 +188,7 @@ response = agent("Tell me about Amazon Bedrock.")
 </Tab>
 <Tab label="TypeScript">
 
-The [`BedrockModel`](@api/typescript/BedrockModel) provider is used by default when creating a basic Agent, and uses the [Claude Sonnet 4.5](https://aws.amazon.com/blogs/aws/introducing-claude-sonnet-4-5-in-amazon-bedrock-anthropics-most-intelligent-model-best-for-coding-and-complex-agents/) model by default. This basic example creates an agent using this default setup:
+The [`ConverseModel`](@api/typescript/ConverseModel) provider is used by default when creating a basic Agent, and uses the [Claude Sonnet 4.5](https://aws.amazon.com/blogs/aws/introducing-claude-sonnet-4-5-in-amazon-bedrock-anthropics-most-intelligent-model-best-for-coding-and-complex-agents/) model by default. This basic example creates an agent using this default setup:
 
 ```typescript
 --8<-- "user-guide/concepts/model-providers/amazon-bedrock_imports.ts:basic_default_imports"
@@ -235,7 +235,7 @@ response = agent("Tell me about Amazon Bedrock.")
 </Tab>
 <Tab label="TypeScript">
 
-For more control over model configuration, you can create an instance of the [`BedrockModel`](@api/typescript/BedrockModel) class:
+For more control over model configuration, you can create an instance of the [`ConverseModel`](@api/typescript/ConverseModel) class:
 
 ```typescript
 --8<-- "user-guide/concepts/model-providers/amazon-bedrock.ts:basic_model_instance"
@@ -265,7 +265,7 @@ Common configuration parameters include:
 </Tab>
 <Tab label="TypeScript">
 
-The [`BedrockModel`](@api/typescript/BedrockModelOptions) supports various configuration parameters. For a complete list of available options, see the [BedrockModelOptions API reference](@api/typescript/BedrockModelOptions).
+The [`ConverseModel`](@api/typescript/ConverseModelOptions) supports various configuration parameters. For a complete list of available options, see the [ConverseModelOptions API reference](@api/typescript/ConverseModelOptions).
 
 Common configuration parameters include:
 
@@ -485,7 +485,7 @@ guardrail_agent = Agent(model=bedrock_model)
 response = guardrail_agent("Can you tell me about the Strands SDK?")
 ```
 
-Amazon Bedrock supports guardrails to help ensure model outputs meet your requirements. Strands allows you to configure guardrails with your [`BedrockModel`](@api/typescript/BedrockModel).
+Amazon Bedrock supports guardrails to help ensure model outputs meet your requirements. Strands allows you to configure guardrails with your [`ConverseModel`](@api/typescript/ConverseModel).
 
 When a guardrail is triggered:
 
@@ -499,7 +499,7 @@ When `guardrail_latest_message=True`, only the most recent user message is sent 
 </Tab>
 <Tab label="TypeScript">
 
-Amazon Bedrock supports guardrails to help ensure model outputs meet your requirements. Strands allows you to configure guardrails with your [`BedrockModel`](@api/typescript/BedrockModel):
+Amazon Bedrock supports guardrails to help ensure model outputs meet your requirements. Strands allows you to configure guardrails with your [`ConverseModel`](@api/typescript/ConverseModel):
 
 ```typescript
 --8<-- "user-guide/concepts/model-providers/amazon-bedrock.ts:guardrails"
@@ -857,7 +857,7 @@ response = agent("If a train travels at 120 km/h and needs to cover 450 km, how 
 </Tab>
 <Tab label="TypeScript">
 
-Strands allows you to enable and configure reasoning capabilities with your [`BedrockModel`](@api/typescript/BedrockModel):
+Strands allows you to enable and configure reasoning capabilities with your [`ConverseModel`](@api/typescript/ConverseModel):
 
 ```typescript
 --8<-- "user-guide/concepts/model-providers/amazon-bedrock.ts:reasoning"

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -1,11 +1,11 @@
 /**
  * TypeScript examples for Amazon Bedrock model provider documentation.
- * These examples demonstrate common usage patterns for the BedrockModel.
+ * These examples demonstrate common usage patterns for the ConverseModel.
  */
 // @ts-nocheck
 // Imports are in amazon-bedrock_imports.ts
 
-import { Agent, BedrockModel, DocumentBlock, CachePointBlock, Message } from '@strands-agents/sdk'
+import { Agent, ConverseModel, DocumentBlock, CachePointBlock, Message } from '@strands-agents/sdk'
 
 // Basic usage examples
 async function basicUsageDefault() {
@@ -28,13 +28,13 @@ async function basicUsageModelId() {
 async function basicUsageModelInstance() {
   // --8<-- [start:basic_model_instance]
   // Create a Bedrock model instance
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'us.amazon.nova-premier-v1:0',
     temperature: 0.3,
     topP: 0.8,
   })
 
-  // Create an agent using the BedrockModel instance
+  // Create an agent using the ConverseModel instance
   const agent = new Agent({ model: bedrockModel })
 
   // Use the agent
@@ -46,7 +46,7 @@ async function basicUsageModelInstance() {
 async function configurationExample() {
   // --8<-- [start:configuration]
   // Create a configured Bedrock model
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
     region: 'us-east-1', // Specify a different region than the default
     temperature: 0.3,
@@ -70,13 +70,13 @@ async function configurationExample() {
 async function streamingExample() {
   // --8<-- [start:streaming]
   // Streaming model (default)
-  const streamingModel = new BedrockModel({
+  const streamingModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
     stream: true, // This is the default
   })
 
   // Non-streaming model
-  const nonStreamingModel = new BedrockModel({
+  const nonStreamingModel = new ConverseModel({
     modelId: 'us.meta.llama3-2-90b-instruct-v1:0',
     stream: false, // Disable streaming
   })
@@ -87,7 +87,7 @@ async function streamingExample() {
 async function updateConfiguration() {
   // --8<-- [start:update_config]
   // Create the model with initial configuration
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
     temperature: 0.7,
   })
@@ -120,7 +120,7 @@ async function toolBasedConfigUpdate() {
   })
 
   const agent = new Agent({
-    model: new BedrockModel({ modelId: 'anthropic.claude-sonnet-4-20250514-v1:0' }),
+    model: new ConverseModel({ modelId: 'anthropic.claude-sonnet-4-20250514-v1:0' }),
     tools: [updateTemperature],
   })
   // --8<-- [end:tool_update_config]
@@ -130,7 +130,7 @@ async function toolBasedConfigUpdate() {
 async function reasoningSupport() {
   // --8<-- [start:reasoning]
   // Create a Bedrock model with reasoning configuration
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
     additionalRequestFields: {
       thinking: {
@@ -157,7 +157,7 @@ async function customCredentials() {
   // See AWS SDK for JavaScript documentation for all credential options:
   // https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html
 
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
     region: 'us-west-2',
     clientConfig: {
@@ -174,7 +174,7 @@ async function customCredentials() {
 // Multimodal support
 async function multimodalSupport() {
   // --8<-- [start:multimodal_full]
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
   })
 
@@ -197,7 +197,7 @@ async function multimodalSupport() {
 // S3 location support for multimodal content
 async function s3LocationSupport() {
   // --8<-- [start:s3_location]
-  const agent = new Agent({ model: new BedrockModel() })
+  const agent = new Agent({ model: new ConverseModel() })
 
   const response = await agent.invoke([
     new DocumentBlock({
@@ -256,7 +256,7 @@ async function systemPromptCachingFull() {
 // Tool caching
 async function toolCachingFull() {
   // --8<-- [start:tool_caching_full]
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
     cacheConfig: { strategy: 'auto' },
   })
@@ -294,7 +294,7 @@ async function toolCachingFull() {
 // Automatic cache strategy for messages
 async function automaticCacheStrategy() {
   // --8<-- [start:automatic_cache_strategy]
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
     cacheConfig: { strategy: 'auto' },
   })
@@ -395,8 +395,8 @@ async function cacheMetrics() {
 // Guardrails configuration
 async function guardrailsExample() {
   // --8<-- [start:guardrails]
-  // Using guardrails with BedrockModel
-  const bedrockModel = new BedrockModel({
+  // Using guardrails with ConverseModel
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
     guardrailConfig: {
       guardrailIdentifier: 'your-guardrail-id',

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
@@ -10,5 +10,5 @@ import { z } from 'zod'
 // --8<-- [end:tool_update_config_imports]
 
 // --8<-- [start:custom_credentials_imports]
-import { BedrockModel } from '@strands-agents/sdk/bedrock'
+import { ConverseModel } from '@strands-agents/sdk/models/bedrock'
 // --8<-- [end:custom_credentials_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.ts
@@ -3,7 +3,7 @@
  * These examples demonstrate how to implement a custom model provider.
  */
 
-import { Agent, BedrockModel, type BedrockModelConfig } from '@strands-agents/sdk'
+import { Agent, ConverseModel, type ConverseModelConfig } from '@strands-agents/sdk'
 import type {
   Model,
   BaseModelConfig,
@@ -16,9 +16,9 @@ import type {
   ModelMessageStopEventData,
 } from '@strands-agents/sdk'
 
-// Example wrapper around BedrockModel for demonstration
-class YourCustomModel extends BedrockModel {
-  constructor(config: BedrockModelConfig = {
+// Example wrapper around ConverseModel for demonstration
+class YourCustomModel extends ConverseModel {
+  constructor(config: ConverseModelConfig = {
   modelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0'
 }) {
     super(config)

--- a/src/content/docs/user-guide/concepts/model-providers/gemini.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/gemini.mdx
@@ -62,9 +62,9 @@ print(response)
 
 ```typescript
 import { Agent } from '@strands-agents/sdk'
-import { GeminiModel } from '@strands-agents/sdk/gemini'
+import { GenAIModel } from '@strands-agents/sdk/models/google'
 
-const model = new GeminiModel({
+const model = new GenAIModel({
   apiKey: '<KEY>',
   modelId: 'gemini-2.5-flash',
   params: {
@@ -333,11 +333,11 @@ print(response)
 ```typescript
 import { GoogleGenAI } from '@google/genai'
 import { Agent } from '@strands-agents/sdk'
-import { GeminiModel } from '@strands-agents/sdk/gemini'
+import { GenAIModel } from '@strands-agents/sdk/models/google'
 
 const client = new GoogleGenAI({ apiKey: '<KEY>' })
 
-const model = new GeminiModel({
+const model = new GenAIModel({
   client,
   modelId: 'gemini-2.5-flash',
   params: {
@@ -396,9 +396,9 @@ response = agent([
 
 ```typescript
 import { Agent, ImageBlock, TextBlock } from '@strands-agents/sdk'
-import { GeminiModel } from '@strands-agents/sdk/gemini'
+import { GenAIModel } from '@strands-agents/sdk/models/google'
 
-const model = new GeminiModel({
+const model = new GenAIModel({
   apiKey: '<KEY>',
   modelId: 'gemini-2.5-flash',
 })

--- a/src/content/docs/user-guide/concepts/model-providers/index.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/index.ts
@@ -6,20 +6,20 @@
 // Imports are in index_imports.ts
 
 import { Agent } from '@strands-agents/sdk'
-import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
-import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+import { ConverseModel } from '@strands-agents/sdk/models/bedrock'
+import { ChatModel } from '@strands-agents/sdk/models/openai'
 
 async function basicUsage() {
   // --8<-- [start:basic_usage]
   // Use Bedrock
-  const bedrockModel = new BedrockModel({
+  const bedrockModel = new ConverseModel({
     modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
   })
   let agent = new Agent({ model: bedrockModel })
   let response = await agent.invoke('What can you help me with?')
 
   // Alternatively, use OpenAI by just switching model provider
-  const openaiModel = new OpenAIModel({
+  const openaiModel = new ChatModel({
     apiKey: process.env.OPENAI_API_KEY,
     modelId: 'gpt-4o',
   })

--- a/src/content/docs/user-guide/concepts/model-providers/index_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/index_imports.ts
@@ -2,6 +2,6 @@
 
 // --8<-- [start:basic_usage_imports]
 import { Agent } from '@strands-agents/sdk'
-import { BedrockModel } from '@strands-agents/sdk/bedrock'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { ConverseModel } from '@strands-agents/sdk/models/bedrock'
+import { ChatModel } from '@strands-agents/sdk/models/openai'
 // --8<-- [end:basic_usage_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/openai.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/openai.ts
@@ -1,17 +1,17 @@
 /**
  * TypeScript examples for OpenAI model provider documentation.
- * These examples demonstrate common usage patterns for the OpenAIModel.
+ * These examples demonstrate common usage patterns for the ChatModel.
  */
 // @ts-nocheck
 // Imports are in openai_imports.ts
 
 import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { ChatModel } from '@strands-agents/sdk/models/openai'
 
 // Basic usage
 async function basicUsage() {
   // --8<-- [start:basic_usage]
-  const model = new OpenAIModel({
+  const model = new ChatModel({
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
     modelId: 'gpt-4o',
     maxTokens: 1000,
@@ -27,7 +27,7 @@ async function basicUsage() {
 // Custom server
 async function customServer() {
   // --8<-- [start:custom_server]
-  const model = new OpenAIModel({
+  const model = new ChatModel({
     apiKey: '<KEY>',
     clientConfig: {
       baseURL: '<URL>',
@@ -43,7 +43,7 @@ async function customServer() {
 // Configuration
 async function customConfig() {
   // --8<-- [start:custom_config]
-  const model = new OpenAIModel({
+  const model = new ChatModel({
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
     modelId: 'gpt-4o',
     maxTokens: 1000,
@@ -62,7 +62,7 @@ async function customConfig() {
 // Update configuration
 async function updateConfig() {
   // --8<-- [start:update_config]
-  const model = new OpenAIModel({
+  const model = new ChatModel({
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
     modelId: 'gpt-4o',
     temperature: 0.7,

--- a/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
@@ -2,5 +2,5 @@
 
 // --8<-- [start:basic_usage_imports]
 import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { ChatModel } from '@strands-agents/sdk/models/openai'
 // --8<-- [end:basic_usage_imports]

--- a/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
+++ b/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/typescript.mdx
@@ -119,7 +119,7 @@ const calculatorTool = strands.tool({
 
 // Configure the agent with Amazon Bedrock
 const agent = new strands.Agent({
-  model: new strands.BedrockModel({
+  model: new strands.ConverseModel({
     region: 'ap-southeast-2', // Change to your preferred region
   }),
   tools: [calculatorTool],

--- a/src/content/docs/user-guide/deploy/deploy_to_docker/imports.ts
+++ b/src/content/docs/user-guide/deploy/deploy_to_docker/imports.ts
@@ -1,6 +1,6 @@
 // --8<-- [start: imports]
 import { Agent } from '@strands-agents/sdk'
 import express, { type Request, type Response } from 'express'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { ChatModel } from '@strands-agents/sdk/models/openai'
 
 // --8<-- [end: imports]

--- a/src/content/docs/user-guide/deploy/deploy_to_docker/index.ts
+++ b/src/content/docs/user-guide/deploy/deploy_to_docker/index.ts
@@ -1,13 +1,13 @@
 import { Agent } from '@strands-agents/sdk'
 import express, { type Request, type Response } from 'express'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { ChatModel } from '@strands-agents/sdk/models/openai'
 
 // --8<-- [start: agent]
 const PORT = Number(process.env.PORT) || 8080
 
 // Note: Any supported model provider can be configured
 // Automatically uses process.env.OPENAI_API_KEY
-const model = new OpenAIModel()
+const model = new ChatModel()
 
 const agent = new Agent({ model })
 

--- a/src/content/docs/user-guide/deploy/deploy_to_docker/typescript.mdx
+++ b/src/content/docs/user-guide/deploy/deploy_to_docker/typescript.mdx
@@ -73,13 +73,13 @@ npm pkg set scripts.build="tsc" scripts.start="node dist/index.js" scripts.dev="
 cat > index.ts << 'EOF'
 import { Agent } from '@strands-agents/sdk'
 import express, { type Request, type Response } from 'express'
-import { OpenAIModel } from '@strands-agents/sdk/openai'
+import { ChatModel } from '@strands-agents/sdk/models/openai'
 
 const PORT = Number(process.env.PORT) || 8080
 
 // Note: Any supported model provider can be configured
 // Automatically uses process.env.OPENAI_API_KEY
-const model = new OpenAIModel()
+const model = new ChatModel()
 
 const agent = new Agent({ model })
 

--- a/src/content/docs/user-guide/quickstart/typescript.ts
+++ b/src/content/docs/user-guide/quickstart/typescript.ts
@@ -74,10 +74,10 @@ const specificAgent = new Agent({
 // --8<-- [end:model-string]
 
 // --8<-- [start:bedrock-model]
-import { BedrockModel } from '@strands-agents/sdk'
+import { ConverseModel } from '@strands-agents/sdk'
 
-// Create a BedrockModel with custom configuration
-const bedrockModel = new BedrockModel({
+// Create a ConverseModel with custom configuration
+const bedrockModel = new ConverseModel({
   modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
   region: 'us-west-2',
   temperature: 0.3,

--- a/src/util/api-link-converter.ts
+++ b/src/util/api-link-converter.ts
@@ -3,11 +3,11 @@
  *
  * Old formats:
  * - Python: `../api-reference/python/agent/agent_result.md#strands.agent.agent_result.AgentResult`
- * - TypeScript: `../api-reference/typescript/classes/BedrockModel.html`
+ * - TypeScript: `../api-reference/typescript/classes/ConverseModel.html`
  *
  * New formats:
  * - Python: `@api/python/strands.agent.agent_result#AgentResult`
- * - TypeScript: `@api/typescript/BedrockModel`
+ * - TypeScript: `@api/typescript/ConverseModel`
  */
 
 /**
@@ -104,15 +104,15 @@ export function convertPythonApiLink(link: string): string | null {
  * Convert an old TypeScript API link to the new @api shorthand format.
  *
  * Examples:
- * - `../api-reference/typescript/classes/BedrockModel.html` -> `@api/typescript/BedrockModel`
- * - `../api-reference/typescript/interfaces/BedrockModelOptions.html` -> `@api/typescript/BedrockModelOptions`
+ * - `../api-reference/typescript/classes/ConverseModel.html` -> `@api/typescript/ConverseModel`
+ * - `../api-reference/typescript/interfaces/ConverseModelOptions.html` -> `@api/typescript/ConverseModelOptions`
  * - `../api-reference/typescript/classes/Agent.html#constructor` -> `@api/typescript/Agent#constructor`
  */
 export function convertTypeScriptApiLink(link: string): string | null {
   const match = link.match(TS_API_PATTERN)
   if (!match) return null
 
-  const typeName = match[2] // e.g., "BedrockModel"
+  const typeName = match[2] // e.g., "ConverseModel"
   const anchor = match[4] // e.g., "constructor" or undefined
 
   if (anchor) {

--- a/test/links.test.ts
+++ b/test/links.test.ts
@@ -20,12 +20,12 @@ describe('Link Utilities', () => {
 
     it('should return true for @api/typescript links', () => {
       expect(isApiShorthand('@api/typescript/Agent')).toBe(true)
-      expect(isApiShorthand('@api/typescript/BedrockModel')).toBe(true)
+      expect(isApiShorthand('@api/typescript/ConverseModel')).toBe(true)
     })
 
     it('should return true for @api links with anchors', () => {
       expect(isApiShorthand('@api/python/strands.agent.agent#Agent')).toBe(true)
-      expect(isApiShorthand('@api/typescript/BedrockModel#constructor')).toBe(true)
+      expect(isApiShorthand('@api/typescript/ConverseModel#constructor')).toBe(true)
     })
 
     it('should return false for non-@api links', () => {
@@ -47,7 +47,7 @@ describe('Link Utilities', () => {
 
     it('should resolve TypeScript API links', () => {
       expect(resolveApiShorthand('@api/typescript/Agent')).toBe('/docs/api/typescript/Agent/')
-      expect(resolveApiShorthand('@api/typescript/BedrockModel')).toBe('/docs/api/typescript/BedrockModel/')
+      expect(resolveApiShorthand('@api/typescript/ConverseModel')).toBe('/docs/api/typescript/ConverseModel/')
     })
 
     it('should preserve anchors', () => {
@@ -55,8 +55,8 @@ describe('Link Utilities', () => {
       expect(resolveApiShorthand('@api/python/strands.agent.agent_result#AgentResult')).toBe(
         '/docs/api/python/strands.agent.agent_result/#AgentResult'
       )
-      expect(resolveApiShorthand('@api/typescript/BedrockModel#constructor')).toBe(
-        '/docs/api/typescript/BedrockModel/#constructor'
+      expect(resolveApiShorthand('@api/typescript/ConverseModel#constructor')).toBe(
+        '/docs/api/typescript/ConverseModel/#constructor'
       )
     })
 
@@ -281,9 +281,9 @@ describe('Link Utilities', () => {
     })
 
     it('should resolve @api/typescript shorthand links', () => {
-      const slugs = new Set(['docs/api/typescript/Agent', 'docs/api/typescript/BedrockModel'])
-      const result = resolveHref('@api/typescript/BedrockModel', '/user-guide/quickstart/', slugs)
-      expect(result.resolvedHref).toBe('/docs/api/typescript/BedrockModel/')
+      const slugs = new Set(['docs/api/typescript/Agent', 'docs/api/typescript/ConverseModel'])
+      const result = resolveHref('@api/typescript/ConverseModel', '/user-guide/quickstart/', slugs)
+      expect(result.resolvedHref).toBe('/docs/api/typescript/ConverseModel/')
       expect(result.found).toBe(true)
     })
 
@@ -330,7 +330,7 @@ describe('Link Resolution with Content Collection', () => {
     // Test TypeScript API links
     const tsTests = [
       { href: '@api/typescript/Agent', expectedSlug: 'api/typescript/Agent' },
-      { href: '@api/typescript/BedrockModel', expectedSlug: 'api/typescript/BedrockModel' },
+      { href: '@api/typescript/ConverseModel', expectedSlug: 'api/typescript/ConverseModel' },
     ]
 
     for (const { href, expectedSlug } of tsTests) {

--- a/test/update-docs.test.ts
+++ b/test/update-docs.test.ts
@@ -33,20 +33,20 @@ describe('API link conversion', () => {
     })
 
     it('should convert TypeScript API links in markdown', () => {
-      const input = `Use the [BedrockModel](../api-reference/typescript/classes/BedrockModel.html) class.`
-      const expected = `Use the [BedrockModel](@api/typescript/BedrockModel) class.`
+      const input = `Use the [ConverseModel](../api-reference/typescript/classes/ConverseModel.html) class.`
+      const expected = `Use the [ConverseModel](@api/typescript/ConverseModel) class.`
       expect(convertApiLinks(input)).toBe(expected)
     })
 
     it('should convert multiple API links in the same content', () => {
       const input = `
 The [Agent](../api-reference/python/agent/agent.md#strands.agent.agent.Agent) class uses
-[BedrockModel](../../api-reference/typescript/classes/BedrockModel.html) by default.
+[ConverseModel](../../api-reference/typescript/classes/ConverseModel.html) by default.
 See also [AgentResult](../api-reference/python/agent/agent_result.md#strands.agent.agent_result.AgentResult).
 `
       const expected = `
 The [Agent](@api/python/strands.agent.agent#Agent) class uses
-[BedrockModel](@api/typescript/BedrockModel) by default.
+[ConverseModel](@api/typescript/ConverseModel) by default.
 See also [AgentResult](@api/python/strands.agent.agent_result#AgentResult).
 `
       expect(convertApiLinks(input)).toBe(expected)
@@ -79,8 +79,8 @@ Check out [GitHub](https://github.com/strands-agents/sdk-python).
     })
 
     it('should handle TypeScript interface links', () => {
-      const input = `Configure with [BedrockModelOptions](../api-reference/typescript/interfaces/BedrockModelOptions.html).`
-      const expected = `Configure with [BedrockModelOptions](@api/typescript/BedrockModelOptions).`
+      const input = `Configure with [ConverseModelOptions](../api-reference/typescript/interfaces/ConverseModelOptions.html).`
+      const expected = `Configure with [ConverseModelOptions](@api/typescript/ConverseModelOptions).`
       expect(convertApiLinks(input)).toBe(expected)
     })
 


### PR DESCRIPTION
## Description

Update documentation to reflect the TypeScript SDK model provider reorganization ([strands-agents/sdk-typescript#694](https://github.com/strands-agents/sdk-typescript/pull/694)).

Class renames:
- `BedrockModel` -> `ConverseModel`
- `OpenAIModel` -> `ChatModel`
- `AnthropicModel` -> `MessagesModel`
- `GeminiModel` -> `GenAIModel`

Import path changes:
- `@strands-agents/sdk/bedrock` -> `@strands-agents/sdk/models/bedrock`
- `@strands-agents/sdk/openai` -> `@strands-agents/sdk/models/openai`
- `@strands-agents/sdk/anthropic` -> `@strands-agents/sdk/models/anthropic`
- `@strands-agents/sdk/gemini` -> `@strands-agents/sdk/models/google`

The new class names describe the API each provider wraps, not the company. The subpath already communicates the provider. For example, `ConverseModel` from `@strands-agents/sdk/models/bedrock` wraps the Bedrock Converse API.

Only TypeScript code, snippets, API links, and tests are updated. All Python references are unchanged. Anthropic does not have TypeScript examples in the docs yet, so no Anthropic files are touched.

## Related Issues

N/A

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
