### PR TITLE
feat: add tool cancellation typescript example

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -357,10 +357,10 @@ Most event properties are read-only to prevent unintended modifications. However
 <Tab label="TypeScript">
 
 - `BeforeToolsEvent`
-    - `cancelTool` - Cancel all tool calls in a batch with a message. See [Limit Tool Counts](#limit-tool-counts).
+    - `cancel` - Cancel all tool calls in a batch with a message. See [Limit Tool Counts](#limit-tool-counts).
 
 - `BeforeToolCallEvent`
-    - `cancelTool` - Cancel tool execution with a message. See [Limit Tool Counts](#limit-tool-counts).
+    - `cancel` - Cancel tool execution with a message. See [Limit Tool Counts](#limit-tool-counts).
 
 - `AfterModelCallEvent`
     - `retry` - Request a retry of the model invocation.

--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -356,6 +356,12 @@ Most event properties are read-only to prevent unintended modifications. However
 </Tab>
 <Tab label="TypeScript">
 
+- `BeforeToolsEvent`
+    - `cancelTool` - Cancel all tool calls in a batch with a message. See [Limit Tool Counts](#limit-tool-counts).
+
+- `BeforeToolCallEvent`
+    - `cancelTool` - Cancel tool execution with a message. See [Limit Tool Counts](#limit-tool-counts).
+
 - `AfterModelCallEvent`
     - `retry` - Request a retry of the model invocation.
 
@@ -795,8 +801,8 @@ class LimitToolCounts(HookProvider):
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// This feature is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks.ts:limit_tool_counts_class"
 ```
 </Tab>
 </Tabs>
@@ -819,8 +825,8 @@ agent("Sleep once")
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// This feature is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks.ts:limit_tool_counts_usage"
 ```
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -83,7 +83,7 @@ async function toolInterceptionExample() {
     name = 'tool-interceptor'
 
     initAgent(agent: LocalAgent): void {
-      agent.addHook(BeforeToolCallEvent, (ev) => this.interceptTool(ev))
+      agent.addHook(BeforeToolCallEvent, (event) => this.interceptTool(event))
     }
 
     private interceptTool(event: BeforeToolCallEvent): void {
@@ -245,7 +245,7 @@ async function limitToolCountsExample() {
 
     initAgent(agent: LocalAgent): void {
       agent.addHook(BeforeInvocationEvent, () => this.resetCounts())
-      agent.addHook(BeforeToolCallEvent, (ev) => this.interceptTool(ev))
+      agent.addHook(BeforeToolCallEvent, (event) => this.interceptTool(event))
     }
 
     private resetCounts(): void {

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -5,6 +5,7 @@ import {
   AfterInvocationEvent,
   BeforeToolCallEvent,
   AfterToolCallEvent,
+  BeforeToolsEvent,
   BeforeModelCallEvent,
   AfterModelCallEvent,
   MessageAddedEvent,
@@ -224,6 +225,60 @@ async function fixedToolArgumentsExample() {
   // --8<-- [end:fixed_tool_arguments_usage]
 }
 
+async function limitToolCountsExample() {
+  // --8<-- [start:limit_tool_counts_class]
+  class LimitToolCounts implements Plugin {
+    private maxToolCounts: Record<string, number>
+    private toolCounts: Record<string, number> = {}
+
+    /**
+     * Initialize with maximum allowed invocations per tool.
+     *
+     * @param maxToolCounts - A dictionary mapping tool names to their maximum
+     *     allowed invocation counts per agent invocation.
+     */
+    constructor(maxToolCounts: Record<string, number>) {
+      this.maxToolCounts = maxToolCounts
+    }
+
+    name = 'limit-tool-counts'
+
+    initAgent(agent: LocalAgent): void {
+      agent.addHook(BeforeInvocationEvent, () => this.resetCounts())
+      agent.addHook(BeforeToolCallEvent, (ev) => this.interceptTool(ev))
+    }
+
+    private resetCounts(): void {
+      this.toolCounts = {}
+    }
+
+    private interceptTool(event: BeforeToolCallEvent): void {
+      const toolName = event.toolUse.name
+      const maxToolCount = this.maxToolCounts[toolName]
+      const toolCount = (this.toolCounts[toolName] ?? 0) + 1
+      this.toolCounts[toolName] = toolCount
+
+      if (maxToolCount !== undefined && toolCount > maxToolCount) {
+        event.cancelTool =
+          `Tool '${toolName}' has been invoked too many times and is now being throttled. ` +
+          `DO NOT CALL THIS TOOL ANYMORE`
+      }
+    }
+  }
+  // --8<-- [end:limit_tool_counts_class]
+
+  // --8<-- [start:limit_tool_counts_usage]
+  const limitHook = new LimitToolCounts({ sleep: 3 })
+
+  const agent = new Agent({ tools: [sleep], plugins: [limitHook] })
+
+  // This call will only have 3 successful sleeps
+  await agent.invoke('Sleep 5 times for 10ms each or until you can\'t anymore')
+  // This will sleep successfully again because the count resets every invocation
+  await agent.invoke('Sleep once')
+  // --8<-- [end:limit_tool_counts_usage]
+}
+
 // =====================
 // Multi-Agent Hook Examples
 // =====================
@@ -342,6 +397,7 @@ async function layeredHooksExample() {
 }
 
 // Suppress unused function warnings
+void limitToolCountsExample
 void orchestratorCallbackExample
 void conditionalNodeExecutionExample
 void orchestratorAgnosticDesignExample

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -5,7 +5,6 @@ import {
   AfterInvocationEvent,
   BeforeToolCallEvent,
   AfterToolCallEvent,
-  BeforeToolsEvent,
   BeforeModelCallEvent,
   AfterModelCallEvent,
   MessageAddedEvent,

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -258,7 +258,7 @@ async function limitToolCountsExample() {
       this.toolCounts[toolName] = toolCount
 
       if (maxToolCount !== undefined && toolCount > maxToolCount) {
-        event.cancelTool =
+        event.cancel =
           `Tool '${toolName}' has been invoked too many times and is now being throttled. ` +
           `DO NOT CALL THIS TOOL ANYMORE`
       }
@@ -267,9 +267,9 @@ async function limitToolCountsExample() {
   // --8<-- [end:limit_tool_counts_class]
 
   // --8<-- [start:limit_tool_counts_usage]
-  const limitHook = new LimitToolCounts({ sleep: 3 })
+  const limitPlugin = new LimitToolCounts({ sleep: 3 })
 
-  const agent = new Agent({ tools: [sleep], plugins: [limitHook] })
+  const agent = new Agent({ tools: [sleep], plugins: [limitPlugin] })
 
   // This call will only have 3 successful sleeps
   await agent.invoke('Sleep 5 times for 10ms each or until you can\'t anymore')


### PR DESCRIPTION
## Description

Adds TypeScript code examples for the `cancel` feature on `BeforeToolCallEvent` and `BeforeToolsEvent` hooks, corresponding to [strands-agents/sdk-typescript#696](https://github.com/strands-agents/sdk-typescript/pull/696). Replaces the "not yet available" placeholders in the Limit Tool Counts cookbook section and adds `cancel` to the Event Properties table.

## Related Issues

strands-agents/sdk-typescript#696

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.