### PR TITLE
fix: update astro dev global-setup with astro:content mock for vitest to improve consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ package-lock.json
 
 # Generated documentation
 docs/api-reference/
-__*__/
 .build
 
 CLAUDE.md

--- a/test/__mocks__/astro-content.ts
+++ b/test/__mocks__/astro-content.ts
@@ -1,0 +1,54 @@
+/**
+ * Mock for the `astro:content` virtual module.
+ *
+ * Implements getCollection/getEntry directly from the pre-built data store,
+ * bypassing the astro:data-layer-content virtual module which isn't available
+ * outside of Vite/Astro's build pipeline.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import * as devalue from 'devalue'
+
+export { defineCollection, defineLiveCollection } from 'astro/content/runtime'
+export { z } from 'astro/zod'
+
+// Load the data store once at module init time
+const raw = readFileSync(resolve('.astro/data-store.json'), 'utf-8')
+const collections: Map<string, Map<string, unknown>> = devalue.unflatten(JSON.parse(raw))
+
+export async function getCollection(collection: string, filter?: (entry: unknown) => unknown) {
+  const col = collections.get(collection)
+  if (!col) {
+    console.warn(`The collection ${JSON.stringify(collection)} does not exist or is empty.`)
+    return []
+  }
+  const entries = [...col.values()].map((raw: any) => ({ ...raw, collection }))
+  return filter ? entries.filter(filter) : entries
+}
+
+export async function getEntry(collectionOrRef: string | { collection: string; id: string }, id?: string) {
+  const [collection, entryId] =
+    typeof collectionOrRef === 'object'
+      ? [collectionOrRef.collection, collectionOrRef.id]
+      : [collectionOrRef, id!]
+  return collections.get(collection)?.get(entryId) ?? undefined
+}
+
+export async function getEntries(entries: { collection: string; id: string }[]) {
+  return Promise.all(entries.map((e) => getEntry(e)))
+}
+
+export function reference(collection: string) {
+  return (id: string) => ({ collection, id })
+}
+
+// Stubs for live collections (not used in tests)
+export async function getLiveCollection() {
+  return { entries: [] }
+}
+export async function getLiveEntry() {
+  return { error: new Error('getLiveEntry not supported in tests') }
+}
+export async function render() {
+  throw new Error('render() not supported in tests')
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,12 @@
 import { getViteConfig } from 'astro/config'
+import { resolve } from 'node:path'
 
 export default getViteConfig({
   test: {
     include: ['test/**/*.test.ts'],
     globalSetup: ['test/global-setup.ts'],
+    alias: {
+      'astro:content': resolve('./test/__mocks__/astro-content.ts'),
+    },
   },
 })


### PR DESCRIPTION
## Description

Tests that call `getCollection()` from `astro:content` were broken in vitest because `astro:content` is a Vite virtual module — it only resolves inside Astro's build pipeline and depending on the version of astro may not work in tests. 

The fix aliases `astro:content` in vitest to a lightweight mock (`test/__mocks__/astro-content.ts`) that reads `.astro/data-store.json` directly using `devalue.unflatten` — the same serialization format Astro uses internally — and implements `getCollection`/`getEntry` against that in-memory map.

The `global-setup.ts` is kept to populate the data store when it doesn't exist (e.g. fresh CI checkout) or local development. `astro sync` was investigated as a lighter alternative but does not produce the data store. The setup is skipped when the data store is already present, so local re-runs are fast.

The `__*__/` gitignore pattern that was inadvertently suppressing the `__mocks__` directory is also removed.

## Related Issues

N/A

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
