### PR TITLE
docs: update A2AExpressServer import path to sdk/a2a/express

### DIFF
--- a/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -309,7 +309,7 @@ a2a_server.serve()
 <Tab label="TypeScript">
 
 ```typescript
-import { A2AExpressServer } from '@strands-agents/sdk/a2a'
+import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
 --8<-- "user-guide/concepts/multi-agent/agent-to-agent.ts:basic_server"
 ```
@@ -474,7 +474,7 @@ The TypeScript `A2AExpressServer` supports a custom `taskStore` for persisting t
 
 ```typescript
 import { Agent } from '@strands-agents/sdk'
-import { A2AExpressServer } from '@strands-agents/sdk/a2a'
+import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
 const agent = new Agent({ systemPrompt: 'You are a helpful agent.' })
 
@@ -528,7 +528,7 @@ Use the `httpUrl` option to set the public URL for the agent card. For custom pa
 
 ```typescript
 import { Agent } from '@strands-agents/sdk'
-import { A2AExpressServer } from '@strands-agents/sdk/a2a'
+import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 
 const agent = new Agent({ systemPrompt: 'A calculator agent.' })
 

--- a/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
+++ b/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.ts
@@ -2,7 +2,8 @@
 // NOTE: Type-checking is disabled because the examples reference remote services not available at build time.
 
 import { Agent, tool } from '@strands-agents/sdk'
-import { A2AAgent, A2AExpressServer } from '@strands-agents/sdk/a2a'
+import { A2AAgent } from '@strands-agents/sdk/a2a'
+import { A2AExpressServer } from '@strands-agents/sdk/a2a/express'
 import { z } from 'zod'
 
 async function basicUsageExample() {


### PR DESCRIPTION
## Description

The TypeScript SDK moved `A2AExpressServer` from the `./a2a` barrel export to a dedicated `./a2a/express` subpath export for browser compatibility (strands-agents/sdk-typescript#721). This updates all A2A documentation to use the new import path.

```typescript
// Before
import { A2AExpressServer } from "@strands-agents/sdk/a2a"

// After
import { A2AExpressServer } from "@strands-agents/sdk/a2a/express"
```

## Related Issues

strands-agents/sdk-typescript#721

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.