### PR TITLE
docs: update OpenAI TypeScript examples from gpt-4o to gpt-5.4

### DIFF
--- a/src/content/docs/user-guide/concepts/model-providers/index.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/index.ts
@@ -22,7 +22,7 @@ async function basicUsage() {
   const openaiModel = new OpenAIModel({
     api: 'chat',
     apiKey: process.env.OPENAI_API_KEY,
-    modelId: 'gpt-4.1',
+    modelId: 'gpt-5.4',
   })
   agent = new Agent({ model: openaiModel })
   response = await agent.invoke('What can you help me with?')

--- a/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -117,7 +117,7 @@ The model configuration sets parameters for inference:
 
 |  Parameter | Description | Example | Options |
 |------------|-------------|---------|---------|
-| `modelId` | ID of a model to use | `gpt-4.1` | [reference](https://platform.openai.com/docs/models)
+| `modelId` | ID of a model to use | `gpt-5.4` | [reference](https://platform.openai.com/docs/models)
 | `maxTokens` | Maximum tokens to generate | `1000` | [reference](https://platform.openai.com/docs/api-reference/chat/create)
 | `temperature` | Controls randomness (0-2) | `0.7` | [reference](https://platform.openai.com/docs/api-reference/chat/create)
 | `topP` | Nucleus sampling (0-1) | `0.9` | [reference](https://platform.openai.com/docs/api-reference/chat/create)

--- a/src/content/docs/user-guide/concepts/model-providers/openai.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/openai.ts
@@ -14,7 +14,7 @@ async function basicUsage() {
   const model = new OpenAIModel({
     api: 'chat',
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
-    modelId: 'gpt-4.1',
+    modelId: 'gpt-5.4',
     maxTokens: 1000,
     temperature: 0.7,
   })
@@ -34,7 +34,7 @@ async function customServer() {
     clientConfig: {
       baseURL: '<URL>',
     },
-    modelId: 'gpt-4.1',
+    modelId: 'gpt-5.4',
   })
 
   const agent = new Agent({ model })
@@ -48,7 +48,7 @@ async function customConfig() {
   const model = new OpenAIModel({
     api: 'chat',
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
-    modelId: 'gpt-4.1',
+    modelId: 'gpt-5.4',
     maxTokens: 1000,
     temperature: 0.7,
     topP: 0.9,
@@ -68,7 +68,7 @@ async function updateConfig() {
   const model = new OpenAIModel({
     api: 'chat',
     apiKey: process.env.OPENAI_API_KEY || '<KEY>',
-    modelId: 'gpt-4.1',
+    modelId: 'gpt-5.4',
     temperature: 0.7,
   })
 


### PR DESCRIPTION
## Description

Updates OpenAI model IDs in TypeScript code examples and the configuration table from `gpt-4o` to `gpt-5.4`, matching the new SDK default in strands-agents/sdk-typescript#723.

GPT-5.4 is OpenAI's current recommended flagship model, succeeding GPT-4.1 and GPT-4o with improved coding performance, reasoning, and multimodal capabilities.

Python examples are left unchanged as the Python SDK default has not been updated yet.

## Related Issues

https://github.com/strands-agents/sdk-typescript/pull/723

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.