### PR TITLE
docs: add getTracer custom spans example to traces page

### DIFF
--- a/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -385,6 +385,37 @@ agent = Agent(
 </Tab>
 </Tabs>
 
+### Custom Spans
+
+You can access the configured tracer to create your own custom spans alongside the auto-instrumented ones:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from opentelemetry import trace
+
+# Get your configured tracer to optionally create your own custom spans
+tracer = trace.get_tracer(__name__)
+with tracer.start_as_current_span("my-custom-operation") as span:
+    span.set_attribute("custom.key", "value")
+    # ... do work ...
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/observability-evaluation/traces_imports.ts:custom_spans_imports"
+
+--8<-- "user-guide/observability-evaluation/traces.ts:custom_spans"
+```
+</Tab>
+</Tabs>
+
+:::tip
+`getTracer()` (TypeScript) and `trace.get_tracer()` (Python) use the global tracer provider. When you use `setupTracer()` or `StrandsTelemetry()` without a custom provider, it's automatically registered as global — so your custom spans will use the same provider as the agent's auto-instrumented spans.
+:::
+
 ### Configuring the exporters from source code
 
 <Tabs>

--- a/src/content/docs/user-guide/observability-evaluation/traces.ts
+++ b/src/content/docs/user-guide/observability-evaluation/traces.ts
@@ -1,5 +1,5 @@
 import { Agent } from '@strands-agents/sdk'
-import { setupTracer } from '@strands-agents/sdk/telemetry'
+import { setupTracer, getTracer } from '@strands-agents/sdk/telemetry'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
@@ -88,6 +88,20 @@ function configuringExporters() {
   // Register the provider with Strands
   setupTracer({ provider })
   // --8<-- [end:configuring_exporters]
+}
+
+function customSpans() {
+  // --8<-- [start:custom_spans]
+  // Set up telemetry first (or register your own NodeTracerProvider)
+  setupTracer({ exporters: { otlp: true } })
+
+  // Get a tracer and create custom spans
+  const tracer = getTracer()
+  const span = tracer.startSpan('my-custom-operation')
+  span.setAttribute('custom.key', 'value')
+  // ... do work ...
+  span.end()
+  // --8<-- [end:custom_spans]
 }
 
 async function endToEnd() {

--- a/src/content/docs/user-guide/observability-evaluation/traces_imports.ts
+++ b/src/content/docs/user-guide/observability-evaluation/traces_imports.ts
@@ -30,6 +30,10 @@ import { BatchSpanProcessor, SimpleSpanProcessor, ConsoleSpanExporter } from '@o
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 // --8<-- [end:configuring_exporters_imports]
 
+// --8<-- [start:custom_spans_imports]
+import { setupTracer, getTracer } from '@strands-agents/sdk/telemetry'
+// --8<-- [end:custom_spans_imports]
+
 // --8<-- [start:end_to_end_imports]
 import { Agent } from '@strands-agents/sdk'
 import { setupTracer } from '@strands-agents/sdk/telemetry'


### PR DESCRIPTION
## Description

Adds a new "Custom Spans" subsection to the traces documentation under Advanced Configuration. This shows users how to use `getTracer()` (TypeScript) / `trace.get_tracer()` (Python) to create their own custom OpenTelemetry spans alongside the SDK's auto-instrumented ones.

Includes:
- Python example using `opentelemetry.trace.get_tracer()`
- TypeScript example using the `getTracer` export from `@strands-agents/sdk/telemetry`
- A tip explaining that custom spans automatically use the same global tracer provider as the agent

## Related Issues
https://github.com/strands-agents/sdk-typescript/pull/604

## Type of Change

- New content

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.