### PR TITLE
Update Graph Import in session-management.mdx

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/session-management.mdx
+++ b/src/content/docs/user-guide/concepts/agents/session-management.mdx
@@ -71,7 +71,7 @@ The conversation, and associated state, is persisted to the underlying storage b
 Multi-agent systems (Graph/Swarm) can also use session management to persist their state:
 
 ```python
-from strands.multiagent import Graph
+from strands.multiagent import GraphBuilder
 from strands.session.file_session_manager import FileSessionManager
 
 # Create agents


### PR DESCRIPTION

## Description
Updating session-management to fix import error. Graph is not exported in multiagent's init and so is not available for import; documentation should be updated to import and use GraphBuilder instead of the Graph class. Reference: [CORRECTION] Documentation is wrong about Graph and SessionManagement #408


## Related Issues
[<!-- Link to related issues using #issue-number format -->](https://github.com/strands-agents/docs/issues/408)


## Type of Change
<!-- What kind of change are you making -->

- New content
X Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
