### PR TITLE
Add agent fundamentals documentation for issue #367

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -51,6 +51,7 @@ sidebar:
         items:
           - label: Agents
             items:
+              - docs/user-guide/concepts/agents/what-is-an-agent
               - docs/user-guide/concepts/agents/agent-loop
               - docs/user-guide/concepts/agents/state
               - docs/user-guide/concepts/agents/session-management

--- a/src/content/docs/user-guide/concepts/agents/what-is-an-agent.mdx
+++ b/src/content/docs/user-guide/concepts/agents/what-is-an-agent.mdx
@@ -1,0 +1,202 @@
+---
+title: What is an Agent?
+description: "Understand what an agent is in Strands, the four parts that define one, and how to scope agents correctly in your application."
+---
+
+An agent is a program that uses a language model to decide what to do. Rather than following a fixed script, it reasons about a request, takes actions through tools, observes the results, and repeats until the task is complete.
+
+In Strands, an agent is a lightweight runtime that coordinates four things: a **model**, a **system prompt**, **tools**, and **context**. The SDK manages the loop between them. You define the parts; the agent decides how to use them.
+
+## The Four Parts of an Agent
+
+Every Strands agent is composed of four parts:
+
+```mermaid
+flowchart LR
+    SP[System Prompt] --> A[Agent Loop]
+    M[Model] --> A
+    T[Tools] --> A
+    C[Context] --> A
+    A --> R[Response]
+```
+
+### 1. Model
+
+The model is the language model that powers the agent's reasoning. It decides what to say, which tools to call, and when the task is done. Strands supports multiple providers — Amazon Bedrock, OpenAI, Anthropic, Ollama, and others.
+
+The model is the only required part. An agent with just a model behaves like a simple chatbot.
+
+### 2. System Prompt
+
+The system prompt defines the agent's role, constraints, and behavior. It is sent to the model at the start of every request and shapes how the model interprets user messages and selects tools.
+
+A well-written system prompt is the most effective way to control agent behavior. See [Prompts](./prompts/) for details.
+
+### 3. Tools
+
+Tools are functions the agent can call to interact with the outside world — read files, query databases, call APIs, run code. The model decides when and how to use them based on the user's request and the tool descriptions you provide.
+
+Without tools, an agent can only generate text. With tools, it can take action. See [Tools Overview](../tools/) for details.
+
+### 4. Context
+
+Context is the conversation history: the sequence of user messages, assistant responses, and tool results that accumulates as the agent works. Each iteration of the agent loop adds to this history, giving the model a growing understanding of the task.
+
+Context is managed automatically. The [Conversation Management](./conversation-management/) system keeps it within the model's token limits. For persistence across sessions, see [Session Management](./session-management/).
+
+## Putting It Together
+
+Here is a minimal agent that uses all four parts:
+
+<Tabs>
+<Tab label="Python">
+```python
+from strands import Agent, tool
+from strands.models.bedrock import BedrockModel
+
+@tool
+def weather(city: str) -> str:
+    """Get current weather for a city."""
+    return f"Weather for {city}: Sunny, 72°F"
+
+agent = Agent(
+    model=BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514"),
+    system_prompt="You are a helpful weather assistant.",
+    tools=[weather],
+)
+
+agent("What's the weather in Seattle?")
+```
+</Tab>
+<Tab label="TypeScript">
+```typescript
+import { Agent, tool } from '@strands-agents/sdk';
+import { z } from 'zod';
+
+const weatherTool = tool({
+  name: 'weather',
+  description: 'Get current weather for a city',
+  inputSchema: z.object({
+    city: z.string().describe('City name'),
+  }),
+  callback: (input) => `Weather for ${input.city}: Sunny, 72°F`,
+});
+
+const agent = new Agent({
+  systemPrompt: 'You are a helpful weather assistant.',
+  tools: [weatherTool],
+});
+
+await agent.invoke("What's the weather in Seattle?");
+```
+</Tab>
+</Tabs>
+
+When this agent receives the request, the model reads the system prompt, reasons about the question, calls the `weather` tool, receives the result, and produces a final response. The [Agent Loop](./agent-loop/) page explains this cycle in detail.
+
+## Agent Lifecycle and Scope
+
+An agent instance owns its conversation history. This is the most important thing to understand about agent scope.
+
+### One agent per conversation
+
+Each conversation should use its own agent instance. When a user starts a new conversation, create a new agent. When the conversation ends, the agent can be discarded.
+
+<Tabs>
+<Tab label="Python">
+```python
+# ✅ Correct: each request gets its own agent
+def handle_request(user_message: str) -> str:
+    agent = Agent(
+        system_prompt="You are a helpful assistant.",
+        tools=[search, calculator],
+    )
+    result = agent(user_message)
+    return str(result)
+```
+</Tab>
+<Tab label="TypeScript">
+```typescript
+// ✅ Correct: each request gets its own agent
+async function handleRequest(userMessage: string): Promise<string> {
+  const agent = new Agent({
+    systemPrompt: 'You are a helpful assistant.',
+    tools: [search, calculator],
+  });
+  const result = await agent.invoke(userMessage);
+  return String(result);
+}
+```
+</Tab>
+</Tabs>
+
+### Common anti-patterns
+
+:::caution[Don't share agents across users or conversations]
+Sharing a single agent instance across multiple users or conversations causes conversation history to bleed between them. User A's messages become visible to User B. This is both a correctness bug and a security risk.
+:::
+
+**❌ Shared singleton agent**
+
+```python
+# Wrong: all users share the same conversation history
+app_agent = Agent(system_prompt="You are a helpful assistant.")
+
+def handle_request(user_message):
+    return app_agent(user_message)  # History accumulates across all users
+```
+
+**❌ Reusing an agent across conversations**
+
+```python
+# Wrong: previous conversation leaks into the next one
+agent = Agent(system_prompt="You are a helpful assistant.")
+agent("Help me draft an email to my manager")  # Conversation 1
+agent("What is the capital of France?")          # Sees the email context
+```
+
+**✅ Sharing configuration, not instances**
+
+If multiple conversations need the same setup, share the configuration and create fresh instances:
+
+<Tabs>
+<Tab label="Python">
+```python
+AGENT_CONFIG = {
+    "system_prompt": "You are a helpful assistant.",
+    "tools": [search, calculator],
+}
+
+def handle_request(user_message: str) -> str:
+    agent = Agent(**AGENT_CONFIG)
+    return str(agent(user_message))
+```
+</Tab>
+<Tab label="TypeScript">
+```typescript
+const AGENT_CONFIG = {
+  systemPrompt: 'You are a helpful assistant.',
+  tools: [search, calculator],
+};
+
+async function handleRequest(userMessage: string): Promise<string> {
+  const agent = new Agent(AGENT_CONFIG);
+  const result = await agent.invoke(userMessage);
+  return String(result);
+}
+```
+</Tab>
+</Tabs>
+
+For multi-turn conversations that span multiple requests, use [Session Management](./session-management/) to persist and restore conversation state rather than keeping a long-lived agent instance.
+
+## What Comes Next
+
+Now that you understand what an agent is and how to scope one correctly, explore the details:
+
+- [Agent Loop](./agent-loop/) — How the reasoning-action cycle works
+- [Prompts](./prompts/) — Writing effective system prompts
+- [Tools Overview](../tools/) — Building and using tools
+- [State Management](./state/) — Conversation history, agent state, and request state
+- [Session Management](./session-management/) — Persisting conversations across requests
+- [Conversation Management](./conversation-management/) — Strategies for managing context window limits

--- a/src/content/docs/user-guide/concepts/agents/what-is-an-agent.mdx
+++ b/src/content/docs/user-guide/concepts/agents/what-is-an-agent.mdx
@@ -42,7 +42,7 @@ Without tools, an agent can only generate text. With tools, it can take action. 
 
 Context is the conversation history: the sequence of user messages, assistant responses, and tool results that accumulates as the agent works. Each iteration of the agent loop adds to this history, giving the model a growing understanding of the task.
 
-Context is managed automatically. The [Conversation Management](./conversation-management/) system keeps it within the model's token limits. For persistence across sessions, see [Session Management](./session-management/).
+Context grows with every turn. When it approaches the model's token limit, the [Conversation Management](./conversation-management/) system automatically trims or summarizes it to keep the agent working. For persistence across sessions, see [Session Management](./session-management/).
 
 ## Putting It Together
 
@@ -153,6 +153,18 @@ def handle_request(user_message):
 agent = Agent(system_prompt="You are a helpful assistant.")
 agent("Help me draft an email to my manager")  # Conversation 1
 agent("What is the capital of France?")          # Sees the email context
+```
+
+**❌ Caching agents per user**
+
+```python
+# Wrong: treats agents like user profiles instead of conversation processors
+user_agents = {}
+
+def get_agent(user_id):
+    if user_id not in user_agents:
+        user_agents[user_id] = Agent(system_prompt="You are a helpful assistant.")
+    return user_agents[user_id]  # History from old conversations leaks into new ones
 ```
 
 **✅ Sharing configuration, not instances**

--- a/src/content/docs/user-guide/concepts/agents/what-is-an-agent.mdx
+++ b/src/content/docs/user-guide/concepts/agents/what-is-an-agent.mdx
@@ -30,34 +30,34 @@ The model is the only required part. An agent with just a model behaves like a s
 
 The system prompt defines the agent's role, constraints, and behavior. It is sent to the model at the start of every request and shapes how the model interprets user messages and selects tools.
 
-A well-written system prompt is the most effective way to control agent behavior. See [Prompts](./prompts/) for details.
+A well-written system prompt is the most effective way to control agent behavior. See [Prompts](prompts.md) for details.
 
 ### 3. Tools
 
 Tools are functions the agent can call to interact with the outside world — read files, query databases, call APIs, run code. The model decides when and how to use them based on the user's request and the tool descriptions you provide.
 
-Without tools, an agent can only generate text. With tools, it can take action. See [Tools Overview](../tools/) for details.
+Without tools, an agent can only generate text. With tools, it can take action. See [Tools Overview](../tools/index.md) for details.
 
 ### 4. Context
 
 Context is the conversation history: the sequence of user messages, assistant responses, and tool results that accumulates as the agent works. Each iteration of the agent loop adds to this history, giving the model a growing understanding of the task.
 
-Context grows with every turn. When it approaches the model's token limit, the [Conversation Management](./conversation-management/) system automatically trims or summarizes it to keep the agent working. For persistence across sessions, see [Session Management](./session-management/).
+Context grows with every turn. When it approaches the model's token limit, the [Conversation Management](conversation-management.md) system automatically trims or summarizes it to keep the agent working. For persistence across sessions, see [Session Management](session-management.md).
 
 ## Putting It Together
 
 Here is a minimal agent that uses all four parts:
 
-<Tabs>
-<Tab label="Python">
 ```python
 from strands import Agent, tool
 from strands.models.bedrock import BedrockModel
+
 
 @tool
 def weather(city: str) -> str:
     """Get current weather for a city."""
     return f"Weather for {city}: Sunny, 72°F"
+
 
 agent = Agent(
     model=BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514"),
@@ -67,32 +67,12 @@ agent = Agent(
 
 agent("What's the weather in Seattle?")
 ```
-</Tab>
-<Tab label="TypeScript">
+
 ```typescript
-import { Agent, tool } from '@strands-agents/sdk';
-import { z } from 'zod';
-
-const weatherTool = tool({
-  name: 'weather',
-  description: 'Get current weather for a city',
-  inputSchema: z.object({
-    city: z.string().describe('City name'),
-  }),
-  callback: (input) => `Weather for ${input.city}: Sunny, 72°F`,
-});
-
-const agent = new Agent({
-  systemPrompt: 'You are a helpful weather assistant.',
-  tools: [weatherTool],
-});
-
-await agent.invoke("What's the weather in Seattle?");
+--8<-- "user-guide/concepts/agents/what-is-an-agent.ts:minimal_agent"
 ```
-</Tab>
-</Tabs>
 
-When this agent receives the request, the model reads the system prompt, reasons about the question, calls the `weather` tool, receives the result, and produces a final response. The [Agent Loop](./agent-loop/) page explains this cycle in detail.
+When this agent receives the request, the model reads the system prompt, reasons about the question, calls the `weather` tool, receives the result, and produces a final response. The [Agent Loop](agent-loop.md) page explains this cycle in detail.
 
 ## Agent Lifecycle and Scope
 
@@ -102,10 +82,8 @@ An agent instance owns its conversation history. This is the most important thin
 
 Each conversation should use its own agent instance. When a user starts a new conversation, create a new agent. When the conversation ends, the agent can be discarded.
 
-<Tabs>
-<Tab label="Python">
 ```python
-# ✅ Correct: each request gets its own agent
+# Correct: each request gets its own agent
 def handle_request(user_message: str) -> str:
     agent = Agent(
         system_prompt="You are a helpful assistant.",
@@ -114,21 +92,10 @@ def handle_request(user_message: str) -> str:
     result = agent(user_message)
     return str(result)
 ```
-</Tab>
-<Tab label="TypeScript">
+
 ```typescript
-// ✅ Correct: each request gets its own agent
-async function handleRequest(userMessage: string): Promise<string> {
-  const agent = new Agent({
-    systemPrompt: 'You are a helpful assistant.',
-    tools: [search, calculator],
-  });
-  const result = await agent.invoke(userMessage);
-  return String(result);
-}
+--8<-- "user-guide/concepts/agents/what-is-an-agent.ts:per_request_agent"
 ```
-</Tab>
-</Tabs>
 
 ### Common anti-patterns
 
@@ -136,7 +103,7 @@ async function handleRequest(userMessage: string): Promise<string> {
 Sharing a single agent instance across multiple users or conversations causes conversation history to bleed between them. User A's messages become visible to User B. This is both a correctness bug and a security risk.
 :::
 
-**❌ Shared singleton agent**
+**Shared singleton agent** (incorrect):
 
 ```python
 # Wrong: all users share the same conversation history
@@ -146,16 +113,16 @@ def handle_request(user_message):
     return app_agent(user_message)  # History accumulates across all users
 ```
 
-**❌ Reusing an agent across conversations**
+**Reusing an agent across conversations** (incorrect):
 
 ```python
 # Wrong: previous conversation leaks into the next one
 agent = Agent(system_prompt="You are a helpful assistant.")
 agent("Help me draft an email to my manager")  # Conversation 1
-agent("What is the capital of France?")          # Sees the email context
+agent("What is the capital of France?")  # Sees the email context
 ```
 
-**❌ Caching agents per user**
+**Caching agents per user** (incorrect):
 
 ```python
 # Wrong: treats agents like user profiles instead of conversation processors
@@ -167,12 +134,10 @@ def get_agent(user_id):
     return user_agents[user_id]  # History from old conversations leaks into new ones
 ```
 
-**✅ Sharing configuration, not instances**
+**Sharing configuration, not instances** (correct):
 
 If multiple conversations need the same setup, share the configuration and create fresh instances:
 
-<Tabs>
-<Tab label="Python">
 ```python
 AGENT_CONFIG = {
     "system_prompt": "You are a helpful assistant.",
@@ -183,32 +148,20 @@ def handle_request(user_message: str) -> str:
     agent = Agent(**AGENT_CONFIG)
     return str(agent(user_message))
 ```
-</Tab>
-<Tab label="TypeScript">
+
 ```typescript
-const AGENT_CONFIG = {
-  systemPrompt: 'You are a helpful assistant.',
-  tools: [search, calculator],
-};
-
-async function handleRequest(userMessage: string): Promise<string> {
-  const agent = new Agent(AGENT_CONFIG);
-  const result = await agent.invoke(userMessage);
-  return String(result);
-}
+--8<-- "user-guide/concepts/agents/what-is-an-agent.ts:shared_config"
 ```
-</Tab>
-</Tabs>
 
-For multi-turn conversations that span multiple requests, use [Session Management](./session-management/) to persist and restore conversation state rather than keeping a long-lived agent instance.
+For multi-turn conversations that span multiple requests, use [Session Management](session-management.md) to persist and restore conversation state rather than keeping a long-lived agent instance.
 
 ## What Comes Next
 
 Now that you understand what an agent is and how to scope one correctly, explore the details:
 
-- [Agent Loop](./agent-loop/) — How the reasoning-action cycle works
-- [Prompts](./prompts/) — Writing effective system prompts
-- [Tools Overview](../tools/) — Building and using tools
-- [State Management](./state/) — Conversation history, agent state, and request state
-- [Session Management](./session-management/) — Persisting conversations across requests
-- [Conversation Management](./conversation-management/) — Strategies for managing context window limits
+- [Agent Loop](agent-loop.md) — How the reasoning-action cycle works
+- [Prompts](prompts.md) — Writing effective system prompts
+- [Tools Overview](../tools/index.md) — Building and using tools
+- [State Management](state.md) — Conversation history, agent state, and request state
+- [Session Management](session-management.md) — Persisting conversations across requests
+- [Conversation Management](conversation-management.md) — Strategies for managing context window limits

--- a/src/content/docs/user-guide/concepts/agents/what-is-an-agent.ts
+++ b/src/content/docs/user-guide/concepts/agents/what-is-an-agent.ts
@@ -1,0 +1,82 @@
+import { Agent, tool } from '@strands-agents/sdk'
+import { z } from 'zod'
+
+// Placeholder tools referenced in the anti-pattern examples, so the
+// configuration snippet below type-checks on its own.
+const search = tool({
+  name: 'search',
+  description: 'Search the web for information',
+  inputSchema: z.object({
+    query: z.string().describe('The search query'),
+  }),
+  callback: (input) => `Results for ${input.query}`,
+})
+
+const calculator = tool({
+  name: 'calculator',
+  description: 'Evaluate a simple arithmetic expression',
+  inputSchema: z.object({
+    expression: z.string().describe('Arithmetic expression to evaluate'),
+  }),
+  callback: (input) => `Result of ${input.expression}`,
+})
+
+// Minimal agent using all four parts (model, system prompt, tools, context).
+async function minimalAgentExample() {
+  // --8<-- [start:minimal_agent]
+  const weatherTool = tool({
+    name: 'weather',
+    description: 'Get current weather for a city',
+    inputSchema: z.object({
+      city: z.string().describe('City name'),
+    }),
+    callback: (input) => `Weather for ${input.city}: Sunny, 72°F`,
+  })
+
+  const agent = new Agent({
+    systemPrompt: 'You are a helpful weather assistant.',
+    tools: [weatherTool],
+  })
+
+  await agent.invoke("What's the weather in Seattle?")
+  // --8<-- [end:minimal_agent]
+}
+
+// Correct scope: create a fresh agent per request.
+async function perRequestAgentExample() {
+  // --8<-- [start:per_request_agent]
+  async function handleRequest(userMessage: string): Promise<string> {
+    const agent = new Agent({
+      systemPrompt: 'You are a helpful assistant.',
+      tools: [search, calculator],
+    })
+    const result = await agent.invoke(userMessage)
+    return String(result)
+  }
+  // --8<-- [end:per_request_agent]
+
+  await handleRequest('Hello')
+}
+
+// Share configuration, not instances.
+async function sharedConfigExample() {
+  // --8<-- [start:shared_config]
+  const AGENT_CONFIG = {
+    systemPrompt: 'You are a helpful assistant.',
+    tools: [search, calculator],
+  }
+
+  async function handleRequest(userMessage: string): Promise<string> {
+    const agent = new Agent(AGENT_CONFIG)
+    const result = await agent.invoke(userMessage)
+    return String(result)
+  }
+  // --8<-- [end:shared_config]
+
+  await handleRequest('Hello')
+}
+
+// Keep references so the compiler does not flag them as unused.
+void minimalAgentExample
+void perRequestAgentExample
+void sharedConfigExample


### PR DESCRIPTION
Adds a new 'What is an Agent?' page as the overview/landing page for the Agents section in the User Guide. This addresses confusion about:

- What an agent actually represents in Strands
- The four parts of an agent (Model, System Prompt, Tools, Context)
- Agent lifecycle and scope (one agent per conversation)
- Anti-patterns: sharing agents across users or conversations

Closes #367

## Description
New page: src/content/docs/user-guide/concepts/agents/what-is-an-agent.mdx
Updated: src/config/navigation.yml to add the page as first item under Concepts → Agents


## Related Issues
Closes #367


## Type of Change
- [x] New content

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
