### PR TITLE
Remove community flag from get-featured.mdx

### DIFF
--- a/src/content/docs/community/get-featured.mdx
+++ b/src/content/docs/community/get-featured.mdx
@@ -1,6 +1,5 @@
 ---
 title: Get Featured in the Docs
-community: true
 sidebar:
   label: "Get Featured"
 ---


### PR DESCRIPTION
## Description

The community flag adds the "This is a community package" warning on the top which is not applicable to this page

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
