### PR TITLE
Add snapshots documentation for point-in-time agent state capture and restore

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -73,6 +73,7 @@ sidebar:
           - docs/user-guide/concepts/agents/hooks
           - docs/user-guide/concepts/agents/conversation-management
           - docs/user-guide/concepts/agents/retry-strategies
+          - docs/user-guide/concepts/agents/snapshots
           - docs/user-guide/concepts/interrupts
           - label: Tools
             items:

--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -69,11 +69,11 @@ sidebar:
           - docs/user-guide/concepts/agents/agent-loop
           - docs/user-guide/concepts/agents/state
           - docs/user-guide/concepts/agents/session-management
+          - docs/user-guide/concepts/agents/snapshots
           - docs/user-guide/concepts/agents/prompts
           - docs/user-guide/concepts/agents/hooks
           - docs/user-guide/concepts/agents/conversation-management
           - docs/user-guide/concepts/agents/retry-strategies
-          - docs/user-guide/concepts/agents/snapshots
           - docs/user-guide/concepts/interrupts
           - label: Tools
             items:

--- a/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -37,7 +37,7 @@ The `"session"` preset captures `messages`, `state`, `conversation_manager_state
 --8<-- "user-guide/concepts/agents/snapshots.ts:take_snapshot"
 ```
 
-The `"session"` preset captures `messages`, `state`, `systemPrompt` (TS only), `modelState`, and `interrupts`.
+The `"session"` preset captures `messages`, `state`, `systemPrompt`, `modelState`, and `interrupts`.
 </Tab>
 </Tabs>
 

--- a/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -34,6 +34,8 @@ The `"session"` preset captures `messages`, `state`, `conversation_manager_state
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+
 --8<-- "user-guide/concepts/agents/snapshots.ts:take_snapshot"
 ```
 
@@ -71,6 +73,8 @@ print(len(agent.messages))  # Only the messages from before the jokes
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+
 --8<-- "user-guide/concepts/agents/snapshots.ts:load_snapshot"
 ```
 </Tab>
@@ -80,7 +84,7 @@ Only fields present in the snapshot are restored. If a field was not included wh
 
 ## Field Selection
 
-Snapshots support flexible field selection through presets, includes, and excludes. The resolution order is: **preset → include → exclude**.
+Snapshots support flexible field selection through presets, includes, and excludes. The resolution order is: **preset → include → exclude** — start with the fields defined by the preset, add any fields listed in `include`, then remove any fields listed in `exclude`.
 
 <Tabs>
 <Tab label="Python">
@@ -130,6 +134,8 @@ snapshot = agent.take_snapshot(preset="session", exclude=["interrupt_state"])
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+
 --8<-- "user-guide/concepts/agents/snapshots.ts:field_selection"
 ```
 </Tab>
@@ -162,6 +168,8 @@ print(snapshot.app_data["user_display_name"])  # "Alice"
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+
 --8<-- "user-guide/concepts/agents/snapshots.ts:app_data"
 ```
 </Tab>
@@ -205,6 +213,8 @@ new_agent.load_snapshot(restored_snapshot)
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:imports_snapshot"
+
 --8<-- "user-guide/concepts/agents/snapshots.ts:serialization"
 ```
 </Tab>
@@ -240,6 +250,8 @@ agent("Focus specifically on multi-agent systems and summarize")
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+
 --8<-- "user-guide/concepts/agents/snapshots.ts:checkpointing"
 ```
 </Tab>
@@ -261,19 +273,21 @@ agent("Write the opening paragraph of a mystery novel")
 # Save the branch point
 branch_point = agent.take_snapshot(preset="session")
 
-# Branch A: noir style
-agent("Continue in a noir detective style")
-noir_snapshot = agent.take_snapshot(preset="session")
+# Branch A: formal tone
+agent("Continue in a formal, academic tone")
+formal_snapshot = agent.take_snapshot(preset="session")
 
-# Branch B: go back and try cozy mystery
+# Branch B: go back and try casual tone
 agent.load_snapshot(branch_point)
-agent("Continue in a cozy mystery style")
-cozy_snapshot = agent.take_snapshot(preset="session")
+agent("Continue in a casual, conversational tone")
+casual_snapshot = agent.take_snapshot(preset="session")
 ```
 </Tab>
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+
 --8<-- "user-guide/concepts/agents/snapshots.ts:branching"
 ```
 </Tab>

--- a/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -1,0 +1,290 @@
+---
+title: Snapshots
+description: "Capture and restore agent state at any point in time. Use snapshots for checkpointing, undo/redo, branching conversations, and custom persistence."
+---
+
+Snapshots provide a point-in-time capture of agent state that can be saved and restored later. You control which fields are included, and serialization is left to you — snapshots are plain JSON-serializable objects that you can persist however you like.
+
+## Basic Usage
+
+### Taking a Snapshot
+
+Use the `"session"` preset to capture the most common fields:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+
+agent = Agent(system_prompt="You are a helpful assistant")
+agent("Hello!")
+agent.state.set("user_id", "user-123")
+
+# Capture a snapshot with the session preset
+snapshot = agent.take_snapshot(preset="session")
+
+print(snapshot.schema_version)  # "1.0"
+print(snapshot.created_at)      # ISO 8601 timestamp
+print(snapshot.data.keys())     # messages, state, conversation_manager_state, interrupt_state
+```
+
+The `"session"` preset captures `messages`, `state`, `conversation_manager_state`, and `interrupt_state`. The `system_prompt` field is not included by default — see [Field Selection](#field-selection) to customize which fields are captured.
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:take_snapshot"
+```
+
+The `"session"` preset captures `messages`, `state`, `systemPrompt` (TS only), `modelState`, and `interrupts`.
+</Tab>
+</Tabs>
+
+### Restoring a Snapshot
+
+Load a snapshot to restore the agent to a previous state:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+
+agent = Agent(system_prompt="You are a helpful assistant")
+agent("Hello!")
+
+# Take a snapshot
+snapshot = agent.take_snapshot(preset="session")
+
+# Continue the conversation
+agent("Tell me a joke")
+agent("Tell me another one")
+
+# Restore to the earlier state
+agent.load_snapshot(snapshot)
+
+# The agent is back to the state after "Hello!"
+print(len(agent.messages))  # Only the messages from before the jokes
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:load_snapshot"
+```
+</Tab>
+</Tabs>
+
+Only fields present in the snapshot are restored. If a field was excluded when the snapshot was taken, the agent's current value for that field is left unchanged.
+
+## Field Selection
+
+Snapshots support flexible field selection through presets, includes, and excludes. The resolution order is: **preset → include → exclude**.
+
+<Tabs>
+<Tab label="Python">
+
+| Field | Description |
+|-------|-------------|
+| `messages` | Conversation history |
+| `state` | Agent key-value state |
+| `conversation_manager_state` | Conversation manager internal state |
+| `interrupt_state` | Human-in-the-loop interrupt state |
+| `system_prompt` | System prompt content |
+
+</Tab>
+<Tab label="TypeScript">
+
+| Field | Description |
+|-------|-------------|
+| `messages` | Conversation history |
+| `state` | Agent key-value state (appState) |
+| `systemPrompt` | System prompt content |
+| `modelState` | Model provider state (e.g. response IDs for stateful models) |
+| `interrupts` | Human-in-the-loop interrupt state |
+
+</Tab>
+</Tabs>
+
+:::note
+The `"session"` preset is currently the only available preset. It includes the same fields that the [Session Manager](./session-management.mdx) persists by default.
+:::
+
+Use `include` to select specific fields without a preset, or to add fields on top of a preset. Use `exclude` to remove fields from a preset:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+# Capture only messages and state (no preset)
+snapshot = agent.take_snapshot(include=["messages", "state"])
+
+# Session preset plus system_prompt
+snapshot = agent.take_snapshot(preset="session", include=["system_prompt"])
+
+# Session preset minus interrupt_state
+snapshot = agent.take_snapshot(preset="session", exclude=["interrupt_state"])
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:field_selection"
+```
+</Tab>
+</Tabs>
+
+## Application Data
+
+Snapshots support an `app_data` (Python) / `appData` (TypeScript) field for storing application-owned data alongside the agent state. Strands does not read or modify this data — it's passed through verbatim.
+
+This is useful for attaching metadata like a display name for the snapshot, the current step in a workflow, user preferences, or any other context your application needs to associate with a particular point in time.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+snapshot = agent.take_snapshot(
+    preset="session",
+    app_data={
+        "snapshot_label": "After onboarding",
+        "workflow_step": 3,
+        "user_display_name": "Alice",
+    },
+)
+
+# Access app data later
+print(snapshot.app_data["snapshot_label"])     # "After onboarding"
+print(snapshot.app_data["user_display_name"])  # "Alice"
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:app_data"
+```
+</Tab>
+</Tabs>
+
+## Serialization
+
+Snapshots are JSON-serializable, making them easy to persist to any storage backend.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import json
+from strands import Agent, Snapshot
+
+agent = Agent()
+agent("Hello!")
+
+# Take a snapshot
+snapshot = agent.take_snapshot(preset="session")
+
+# Serialize to JSON
+json_str = json.dumps(snapshot.to_dict())
+
+# Store to file, database, S3, etc.
+with open("snapshot.json", "w") as f:
+    f.write(json_str)
+
+# Later, restore from JSON
+with open("snapshot.json", "r") as f:
+    data = json.loads(f.read())
+
+restored_snapshot = Snapshot.from_dict(data)
+
+# Load into a new agent
+new_agent = Agent()
+new_agent.load_snapshot(restored_snapshot)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:serialization"
+```
+</Tab>
+</Tabs>
+
+## Use Cases
+
+### Checkpointing
+
+Save agent state at key points in a workflow so you can resume from the last checkpoint if something goes wrong:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+
+agent = Agent(system_prompt="You are a research assistant")
+
+# Step 1: Gather information
+agent("Research the latest trends in AI agents")
+checkpoint_1 = agent.take_snapshot(preset="session")
+
+# Step 2: Analyze (might fail or produce poor results)
+agent("Analyze the key themes and summarize")
+checkpoint_2 = agent.take_snapshot(preset="session")
+
+# If step 2 didn't go well, roll back to checkpoint 1
+agent.load_snapshot(checkpoint_1)
+agent("Focus specifically on multi-agent systems and summarize")
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:checkpointing"
+```
+</Tab>
+</Tabs>
+
+### Branching Conversations
+
+Create multiple conversation branches from the same starting point:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+
+agent = Agent(system_prompt="You are a creative writer")
+agent("Write the opening paragraph of a mystery novel")
+
+# Save the branch point
+branch_point = agent.take_snapshot(preset="session")
+
+# Branch A: noir style
+agent("Continue in a noir detective style")
+noir_snapshot = agent.take_snapshot(preset="session")
+
+# Branch B: go back and try cozy mystery
+agent.load_snapshot(branch_point)
+agent("Continue in a cozy mystery style")
+cozy_snapshot = agent.take_snapshot(preset="session")
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/snapshots.ts:branching"
+```
+</Tab>
+</Tabs>
+
+## Relationship to Session Management
+
+[Session management](./session-management.mdx) handles persistence automatically — state is saved and restored at the right lifecycle points without you writing any persistence code. Snapshots give you manual control: you decide when to capture state, what to include, and where to store it. Use session management when you want hands-off persistence, and snapshots when you need precise control over save points.
+
+## See Also
+
+- [State Management](./state.mdx) — Conversation history, agent state, and request state
+- [Session Management](./session-management.mdx) — Automatic persistence with file or S3 storage
+- [Conversation Management](./conversation-management.mdx) — Managing conversation history and context window

--- a/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -3,7 +3,7 @@ title: Snapshots
 description: "Capture and restore agent state at any point in time. Use snapshots for checkpointing, undo/redo, branching conversations, and custom persistence."
 ---
 
-Snapshots provide a point-in-time capture of agent state that can be saved and restored later. You control which fields are included, and serialization is left to you — snapshots are plain JSON-serializable objects that you can persist however you like.
+Snapshots capture agent state at a point in time so you can save and restore it later. You choose which fields to include — either by picking a preset (a preconfigured set of fields) or by specifying fields directly — and you can further refine with includes and excludes. Snapshots are plain JSON-serializable objects — persistence is up to you.
 
 ## Basic Usage
 
@@ -76,7 +76,7 @@ print(len(agent.messages))  # Only the messages from before the jokes
 </Tab>
 </Tabs>
 
-Only fields present in the snapshot are restored. If a field was excluded when the snapshot was taken, the agent's current value for that field is left unchanged.
+Only fields present in the snapshot are restored. If a field was not included when the snapshot was taken, the agent's current value for that field is left unchanged.
 
 ## Field Selection
 

--- a/src/content/docs/user-guide/concepts/agents/snapshots.mdx
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.mdx
@@ -34,7 +34,7 @@ The `"session"` preset captures `messages`, `state`, `conversation_manager_state
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+--8<-- "user-guide/concepts/agents/snapshots_imports.ts:imports"
 
 --8<-- "user-guide/concepts/agents/snapshots.ts:take_snapshot"
 ```
@@ -73,7 +73,7 @@ print(len(agent.messages))  # Only the messages from before the jokes
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+--8<-- "user-guide/concepts/agents/snapshots_imports.ts:imports"
 
 --8<-- "user-guide/concepts/agents/snapshots.ts:load_snapshot"
 ```
@@ -134,7 +134,7 @@ snapshot = agent.take_snapshot(preset="session", exclude=["interrupt_state"])
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+--8<-- "user-guide/concepts/agents/snapshots_imports.ts:imports"
 
 --8<-- "user-guide/concepts/agents/snapshots.ts:field_selection"
 ```
@@ -168,7 +168,7 @@ print(snapshot.app_data["user_display_name"])  # "Alice"
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+--8<-- "user-guide/concepts/agents/snapshots_imports.ts:imports"
 
 --8<-- "user-guide/concepts/agents/snapshots.ts:app_data"
 ```
@@ -213,7 +213,7 @@ new_agent.load_snapshot(restored_snapshot)
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/snapshots.ts:imports_snapshot"
+--8<-- "user-guide/concepts/agents/snapshots_imports.ts:imports_snapshot"
 
 --8<-- "user-guide/concepts/agents/snapshots.ts:serialization"
 ```
@@ -250,7 +250,7 @@ agent("Focus specifically on multi-agent systems and summarize")
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+--8<-- "user-guide/concepts/agents/snapshots_imports.ts:imports"
 
 --8<-- "user-guide/concepts/agents/snapshots.ts:checkpointing"
 ```
@@ -286,7 +286,7 @@ casual_snapshot = agent.take_snapshot(preset="session")
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/agents/snapshots.ts:imports"
+--8<-- "user-guide/concepts/agents/snapshots_imports.ts:imports"
 
 --8<-- "user-guide/concepts/agents/snapshots.ts:branching"
 ```

--- a/src/content/docs/user-guide/concepts/agents/snapshots.ts
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.ts
@@ -1,0 +1,134 @@
+import { Agent, type Snapshot } from '@strands-agents/sdk'
+
+// Take snapshot example
+async function takeSnapshotExample() {
+  // --8<-- [start:take_snapshot]
+  const agent = new Agent({ systemPrompt: 'You are a helpful assistant' })
+  await agent.invoke('Hello!')
+  agent.appState.set('user_id', 'user-123')
+
+  // Capture a snapshot with the session preset
+  const snapshot = agent.takeSnapshot({ preset: 'session' })
+
+  console.log(snapshot.schemaVersion) // "1.0"
+  console.log(snapshot.createdAt) // ISO 8601 timestamp
+  console.log(Object.keys(snapshot.data)) // messages, state, systemPrompt, modelState, interrupts
+  // --8<-- [end:take_snapshot]
+}
+
+// Load snapshot example
+async function loadSnapshotExample() {
+  // --8<-- [start:load_snapshot]
+  const agent = new Agent({ systemPrompt: 'You are a helpful assistant' })
+  await agent.invoke('Hello!')
+
+  // Take a snapshot
+  const snapshot = agent.takeSnapshot({ preset: 'session' })
+
+  // Continue the conversation
+  await agent.invoke('Tell me a joke')
+  await agent.invoke('Tell me another one')
+
+  // Restore to the earlier state
+  agent.loadSnapshot(snapshot)
+
+  // The agent is back to the state after "Hello!"
+  console.log(agent.messages.length) // Only the messages from before the jokes
+  // --8<-- [end:load_snapshot]
+}
+
+// Field selection example
+async function fieldSelectionExample() {
+  const agent = new Agent()
+
+  // --8<-- [start:field_selection]
+  // Capture only messages and state (no preset)
+  const messagesOnly = agent.takeSnapshot({ include: ['messages', 'state'] })
+
+  // Session preset minus systemPrompt
+  const noPrompt = agent.takeSnapshot({ preset: 'session', exclude: ['systemPrompt'] })
+  // --8<-- [end:field_selection]
+}
+
+// App data example
+async function appDataExample() {
+  const agent = new Agent()
+
+  // --8<-- [start:app_data]
+  const snapshot = agent.takeSnapshot({
+    preset: 'session',
+    appData: {
+      snapshotLabel: 'After onboarding',
+      workflowStep: 3,
+      userDisplayName: 'Alice',
+    },
+  })
+
+  // Access app data later
+  console.log(snapshot.appData.snapshotLabel) // "After onboarding"
+  console.log(snapshot.appData.userDisplayName) // "Alice"
+  // --8<-- [end:app_data]
+}
+
+// Serialization example
+async function serializationExample() {
+  // --8<-- [start:serialization]
+  const agent = new Agent()
+  await agent.invoke('Hello!')
+
+  // Take a snapshot
+  const snapshot = agent.takeSnapshot({ preset: 'session' })
+
+  // Serialize to JSON string
+  const jsonString = JSON.stringify(snapshot)
+
+  // Store to file, database, S3, etc.
+  // ...
+
+  // Later, restore from JSON
+  const parsed: Snapshot = JSON.parse(jsonString)
+
+  // Load into a new agent
+  const newAgent = new Agent()
+  newAgent.loadSnapshot(parsed)
+  // --8<-- [end:serialization]
+}
+
+// Checkpointing example
+async function checkpointingExample() {
+  // --8<-- [start:checkpointing]
+  const agent = new Agent({ systemPrompt: 'You are a research assistant' })
+
+  // Step 1: Gather information
+  await agent.invoke('Research the latest trends in AI agents')
+  const checkpoint1 = agent.takeSnapshot({ preset: 'session' })
+
+  // Step 2: Analyze (might fail or produce poor results)
+  await agent.invoke('Analyze the key themes and summarize')
+  const checkpoint2 = agent.takeSnapshot({ preset: 'session' })
+
+  // If step 2 didn't go well, roll back to checkpoint 1
+  agent.loadSnapshot(checkpoint1)
+  await agent.invoke('Focus specifically on multi-agent systems and summarize')
+  // --8<-- [end:checkpointing]
+}
+
+// Branching conversations example
+async function branchingExample() {
+  // --8<-- [start:branching]
+  const agent = new Agent({ systemPrompt: 'You are a creative writer' })
+  await agent.invoke('Write the opening paragraph of a mystery novel')
+
+  // Save the branch point
+  const branchPoint = agent.takeSnapshot({ preset: 'session' })
+
+  // Branch A: noir style
+  await agent.invoke('Continue in a noir detective style')
+  const noirSnapshot = agent.takeSnapshot({ preset: 'session' })
+
+  // Branch B: go back and try cozy mystery
+  agent.loadSnapshot(branchPoint)
+  await agent.invoke('Continue in a cozy mystery style')
+  const cozySnapshot = agent.takeSnapshot({ preset: 'session' })
+  // --8<-- [end:branching]
+}

--- a/src/content/docs/user-guide/concepts/agents/snapshots.ts
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.ts
@@ -1,13 +1,5 @@
 import { Agent, type Snapshot } from '@strands-agents/sdk'
 
-// --8<-- [start:imports]
-import { Agent } from '@strands-agents/sdk'
-// --8<-- [end:imports]
-
-// --8<-- [start:imports_snapshot]
-import { Agent, type Snapshot } from '@strands-agents/sdk'
-// --8<-- [end:imports_snapshot]
-
 // Take snapshot example
 async function takeSnapshotExample() {
   // --8<-- [start:take_snapshot]

--- a/src/content/docs/user-guide/concepts/agents/snapshots.ts
+++ b/src/content/docs/user-guide/concepts/agents/snapshots.ts
@@ -1,5 +1,13 @@
 import { Agent, type Snapshot } from '@strands-agents/sdk'
 
+// --8<-- [start:imports]
+import { Agent } from '@strands-agents/sdk'
+// --8<-- [end:imports]
+
+// --8<-- [start:imports_snapshot]
+import { Agent, type Snapshot } from '@strands-agents/sdk'
+// --8<-- [end:imports_snapshot]
+
 // Take snapshot example
 async function takeSnapshotExample() {
   // --8<-- [start:take_snapshot]
@@ -122,13 +130,13 @@ async function branchingExample() {
   // Save the branch point
   const branchPoint = agent.takeSnapshot({ preset: 'session' })
 
-  // Branch A: noir style
-  await agent.invoke('Continue in a noir detective style')
-  const noirSnapshot = agent.takeSnapshot({ preset: 'session' })
+  // Branch A: formal tone
+  await agent.invoke('Continue in a formal, academic tone')
+  const formalSnapshot = agent.takeSnapshot({ preset: 'session' })
 
-  // Branch B: go back and try cozy mystery
+  // Branch B: go back and try casual tone
   agent.loadSnapshot(branchPoint)
-  await agent.invoke('Continue in a cozy mystery style')
-  const cozySnapshot = agent.takeSnapshot({ preset: 'session' })
+  await agent.invoke('Continue in a casual, conversational tone')
+  const casualSnapshot = agent.takeSnapshot({ preset: 'session' })
   // --8<-- [end:branching]
 }

--- a/src/content/docs/user-guide/concepts/agents/snapshots_imports.ts
+++ b/src/content/docs/user-guide/concepts/agents/snapshots_imports.ts
@@ -1,0 +1,9 @@
+// @ts-nocheck — imports are duplicated across snippets for documentation display
+
+// --8<-- [start:imports]
+import { Agent } from '@strands-agents/sdk'
+// --8<-- [end:imports]
+
+// --8<-- [start:imports_snapshot]
+import { Agent, type Snapshot } from '@strands-agents/sdk'
+// --8<-- [end:imports_snapshot]

--- a/src/content/docs/user-guide/concepts/agents/state.mdx
+++ b/src/content/docs/user-guide/concepts/agents/state.mdx
@@ -328,4 +328,4 @@ Invocation state (`invocationState` in TypeScript, `invocation_state` / `request
 
 ## Persisting State Across Sessions
 
-For information on how to persist agent state and conversation history across multiple interactions or application restarts, see the [Session Management](session-management.md) documentation.
+For automatic persistence of agent state and conversation history across application restarts, see [Session Management](session-management.md). For manual, point-in-time capture and restore of agent state, see [Snapshots](snapshots.mdx).


### PR DESCRIPTION
## Description

Adds documentation for the new Snapshots feature, which lets users capture and restore agent state at any point in time. The page covers basic usage (take/load), field selection with presets and include/exclude, application data, serialization, and practical use cases like checkpointing and branching conversations. Both Python and TypeScript examples are included via tabbed code blocks.

Also updates the State Management page to cross-link to the new Snapshots page alongside the existing Session Management reference.

## Related Issues

https://github.com/strands-agents/sdk-python/issues/1138

## Type of Change

- New content

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
