### PR TITLE
docs: add TypeScript API references alongside Python links

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/prompts.mdx
+++ b/src/content/docs/user-guide/concepts/agents/prompts.mdx
@@ -87,7 +87,7 @@ response = agent([
 </Tab>
 </Tabs>
 
-For a complete list of supported content types, please refer to the [API Reference](@api/python/strands.types.content#ContentBlock).
+For a complete list of supported content types, refer to the API Reference: [Python](@api/python/strands.types.content#ContentBlock) | [TypeScript](@api/typescript/ContentBlock).
 
 
 ### Direct Tool Calls

--- a/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -445,4 +445,4 @@ The agent automatically cleans up background tasks, model connections, I/O chann
 - [I/O Channels](io.md) - Building custom input/output channels
 - [Model Providers](models/nova_sonic.md) - Provider-specific configuration
 - [Quickstart](quickstart.md) - Getting started guide
-- [API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation
+- [Python API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation

--- a/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
@@ -349,4 +349,4 @@ For additional best practices on performance considerations, error handling, com
 - [Agent](agent.md) - Learn about BidiAgent configuration and lifecycle
 - [Session Management](session-management.md) - Persist conversations across sessions
 - [Events](events.md) - Complete guide to bidirectional streaming events
-- [API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation
+- [Python API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation

--- a/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
+++ b/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
@@ -99,4 +99,4 @@ Make sure your Google AI API key is properly set in `client_config` or as the `G
 
 - [Gemini Live API](https://ai.google.dev/gemini-api/docs/live)
 - [Gemini API Reference](https://googleapis.github.io/python-genai/genai.html#)
-- [Provider API Reference](@api/python/strands.experimental.bidi.models.gemini_live#BidiGeminiLiveModel)
+- [Python API Reference](@api/python/strands.experimental.bidi.models.gemini_live#BidiGeminiLiveModel)

--- a/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -141,4 +141,4 @@ As a reminder, Nova Sonic is only available in us-east-1, eu-north-1, and ap-nor
 
 - [Nova Sonic](https://docs.aws.amazon.com/nova/latest/userguide/speech.html)
 - [Experimental Bedrock Client](https://github.com/awslabs/aws-sdk-python/tree/develop/clients/aws-sdk-bedrock-runtime)
-- [Provider API Reference](@api/python/strands.experimental.bidi.models.nova_sonic#BidiNovaSonicModel)
+- [Python API Reference](@api/python/strands.experimental.bidi.models.nova_sonic#BidiNovaSonicModel)

--- a/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
+++ b/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
@@ -99,4 +99,4 @@ Ensure your OpenAI API key is properly configured. Set the `OPENAI_API_KEY` envi
 
 - [OpenAI Realtime API](https://platform.openai.com/docs/guides/realtime)
 - [OpenAI API Reference](https://platform.openai.com/docs/api-reference/realtime)
-- [Provider API Reference](@api/python/strands.experimental.bidi.models.openai_realtime#BidiOpenAIRealtimeModel)
+- [Python API Reference](@api/python/strands.experimental.bidi.models.openai_realtime#BidiOpenAIRealtimeModel)

--- a/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -541,5 +541,5 @@ Ready to learn more? Check out these resources:
     - [Nova Sonic](models/nova_sonic.md) - Amazon Bedrock's bidirectional streaming model
     - [OpenAI Realtime](models/openai_realtime.md) - OpenAI's Realtime API
     - [Gemini Live](models/gemini_live.md) - Google's Gemini Live API
-- [API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation
+- [Python API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation
 

--- a/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
+++ b/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
@@ -215,4 +215,4 @@ For best practices on session ID management, session cleanup, error handling, st
 - [Agent](agent.md) - Learn about BidiAgent configuration and lifecycle
 - [Hooks](hooks.md) - Extend agent functionality with hooks
 - [Events](events.md) - Complete guide to bidirectional streaming events
-- [API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation
+- [Python API Reference](@api/python/strands.experimental.bidi.agent.agent) - Complete API documentation

--- a/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -104,7 +104,7 @@ Interrupts in Strands are comprised of the following components:
 - `event.cancel_tool` - Cancel tool execution based on interrupt response
     - You can either set `cancel_tool` to `True` or provide a custom cancellation message.
 
-For additional details on each of these components, please refer to the [API Reference](@api/python/strands.types.interrupt) pages.
+For additional details on each of these components, refer to the [Python API Reference](@api/python/strands.types.interrupt).
 
 ### Rules
 

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -111,6 +111,6 @@ print(f"Rating: {result.rating}")
 
 ## References
 
-- [API](@api/python/strands.models.model)
+- [Python API](@api/python/strands.models.model)
 - [Anthropic](https://docs.anthropic.com/en/home)
 

--- a/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -492,7 +492,7 @@ const result = await agent.invoke([
 
 ## References
 
-- [API](@api/python/strands.models.model)
+- [Python API](@api/python/strands.models.model)
 - [Google Gemini](https://ai.google.dev/api)
 - [Google GenAI SDK documentation](https://googleapis.github.io/python-genai/)
 - [Google AI Studio](https://aistudio.google.com/)

--- a/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -179,5 +179,5 @@ print(f"Rating: {result.rating}")
 
 ## References
 
-- [API](@api/python/strands.models.model)
+- [Python API](@api/python/strands.models.model)
 - [LiteLLM](https://docs.litellm.ai/docs/)

--- a/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -112,5 +112,5 @@ print(f"Rating: {result.rating}")
 
 ## References
 
-- [API](@api/python/strands.models.model)
+- [Python API](@api/python/strands.models.model)
 - [LlamaAPI](https://llama.developer.meta.com/docs/)

--- a/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
@@ -213,7 +213,7 @@ response = agent([image_message])
 
 ## References
 
-- [API](@api/python/strands.models.model)
+- [Python API](@api/python/strands.models.model)
 - [llama.cpp](https://github.com/ggml-org/llama.cpp)
 - [llama.cpp Server Documentation](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)
 - [GGUF Models on Hugging Face](https://huggingface.co/models?search=gguf)

--- a/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
@@ -91,5 +91,5 @@ If you encounter the error `ModuleNotFoundError: No module named 'mistralai'`, t
 
 ## References
 
-- [API Reference](@api/python/strands.models.model)
+- [Python API Reference](@api/python/strands.models.model)
 - [Mistral AI Documentation](https://docs.mistral.ai/)

--- a/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
@@ -193,7 +193,7 @@ response = agent("What is my name?")
 
 ## References
 
-- [API](@api/python/strands.models.openai_responses)
+- [Python API](@api/python/strands.models.openai_responses)
 - [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
 - [Amazon Bedrock Mantle](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)
 - [OpenAI Chat Completions](./openai) (alternative provider using the Chat Completions API)

--- a/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -236,5 +236,5 @@ if __name__ == "__main__":
 
 ## References
 
-- [API](@api/python/strands.models.model)
+- [Python API](@api/python/strands.models.model)
 - [OpenAI](https://platform.openai.com/docs/overview)

--- a/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
@@ -105,6 +105,6 @@ Ensure your deployed model supports OpenAI-compatible chat completion APIs and v
 
 ## References
 
-- [API Reference](@api/python/strands.models.model)
+- [Python API Reference](@api/python/strands.models.model)
 - [Amazon SageMaker Documentation](https://docs.aws.amazon.com/sagemaker/)
 - [SageMaker Runtime API](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html)

--- a/src/content/docs/user-guide/concepts/model-providers/writer.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/writer.mdx
@@ -284,7 +284,7 @@ Ensure your Writer API key is valid and has the necessary permissions. You can g
 
 ## References
 
-- [API Reference](@api/python/strands.models.model)
+- [Python API Reference](@api/python/strands.models.model)
 - [Writer Documentation](https://dev.writer.com/)
 - [Writer Models Guide](https://dev.writer.com/home/models)
 - [Writer API Reference](https://dev.writer.com/api-reference)

--- a/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
+++ b/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
@@ -40,7 +40,7 @@ asyncio.run(process_streaming_response())
 </Tab>
 <Tab label="TypeScript">
 
-TypeScript uses the [`stream`](@api/python/strands.agent.agent) method for streaming, which is async by default. This is ideal for frameworks like Express.js or NestJS.
+TypeScript uses the [`stream`](@api/typescript/Agent) method for streaming, which is async by default. This is ideal for frameworks like Express.js or NestJS.
 
 ```typescript
 --8<-- "user-guide/concepts/streaming/async-iterators.ts:basic_usage"

--- a/src/content/docs/user-guide/concepts/streaming/index.mdx
+++ b/src/content/docs/user-guide/concepts/streaming/index.mdx
@@ -396,4 +396,4 @@ orchestrator_callback("What is 3+3?")
 
 - Learn about [Async Iterators](async-iterators.md) for asynchronous streaming
 - Explore [Callback Handlers](callback-handlers.md) for synchronous event processing
-- See the [Agent API Reference](@api/python/strands.agent.agent) for complete method documentation
+- See the Agent API Reference for complete method documentation: [Python](@api/python/strands.agent.agent) | [TypeScript](@api/typescript/Agent)


### PR DESCRIPTION
## Summary

Implements the **quick wins** from #745 — fixing wrong API links and adding TypeScript API references alongside Python ones across the docs.

## Changes (21 files)

### Bug fix
- **`streaming/async-iterators.mdx`**: Fixed TypeScript tab that was wrongly linking to `@api/python/strands.agent.agent` instead of `@api/typescript/Agent`

### Dual-language API links (pages covering both SDKs)
- **`streaming/index.mdx`**: Next Steps section now links to both Python and TypeScript Agent API references
- **`agents/prompts.mdx`**: ContentBlock API reference now links to both Python and TypeScript

### Python-only labels (explicitly labeled to set correct expectations)
- **10 model provider pages** (llamacpp, google, mistral, writer, sagemaker, anthropic, litellm, llamaapi, openai, openai-responses): Generic "API" / "API Reference" links now labeled as "Python API" / "Python API Reference"
- **7 bidirectional streaming pages** (hooks, quickstart, agent, session-management, gemini_live, openai_realtime, nova_sonic): "API Reference" / "Provider API Reference" links now labeled as "Python API Reference"
- **`interrupts.mdx`**: "API Reference" link now labeled as "Python API Reference" (interrupts not yet in TypeScript SDK)

## Why

The audit in #745 found 96 Python API references vs only 7 TypeScript references. TypeScript users clicking generic "API Reference" links were being sent to Python docs. These quick wins make the language explicit so users know what they're clicking into, and add TypeScript links where both SDKs support the feature.

## Testing

- All changes are link text updates (no structural changes)
- Verified TypeScript API paths exist (`@api/typescript/Agent`, `@api/typescript/ContentBlock`) by checking the TypeScript SDK exports

Fixes #745

---
🤖 *AI agent response. [Strands Agents](https://github.com/strands-agents). Feedback welcome!*