### PR TITLE
feat: global language selector with implicit tabs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -100,6 +100,9 @@ export default defineConfig({
           ],
           './src/components/AutoSyncTabs.astro': [
             ['default', "Tabs"]
+          ],
+          './src/components/LanguageContent.astro': [
+            ['default', "LanguageContent"]
           ]
         },
       ],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -51,6 +51,27 @@ export default defineConfig({
         },
       },
     }),
+    // AutoImport MUST come before mdx() so auto-imports work in .mdx files.
+    // See: https://github.com/delucis/astro-auto-import#usage
+    AutoImport({
+      imports: [
+        {
+          '@astrojs/starlight/components': [
+            ['TabItem', 'Tab']
+          ],
+          './src/components/AutoSyncTabs.astro': [
+            ['default', "Tabs"]
+          ],
+          './src/components/LanguageContent.astro': [
+            ['default', "LanguageContent"]
+          ]
+        },
+      ],
+      defaultComponents: {
+        // override 'a' links so that we can use relative urls
+        a: './src/components/PageLink.astro'
+      }
+    }),
     mdx(),
     starlight({
       head: [
@@ -91,25 +112,6 @@ export default defineConfig({
       cacheExternalLinks: false,      // Optional: cache verified external links to disk (default: true)
       throwError: true,               // Optional: fail the build if broken links are found (default: false)
       linkCheckerDir: '.link-checker' // Optional: directory for cache and log files (default: '.link-checker')
-    }),
-   AutoImport({
-      imports: [
-        {
-          '@astrojs/starlight/components': [
-            ['TabItem', 'Tab']
-          ],
-          './src/components/AutoSyncTabs.astro': [
-            ['default', "Tabs"]
-          ],
-          './src/components/LanguageContent.astro': [
-            ['default', "LanguageContent"]
-          ]
-        },
-      ],
-      defaultComponents: {
-        // override 'a' links so that we can use relative urls
-        a: './src/components/PageLink.astro'
-      }
     }),
   ],
 })

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,6 +64,9 @@ export default defineConfig({
           ],
           './src/components/LanguageContent.astro': [
             ['default', "LanguageContent"]
+          ],
+          './src/components/Lang.astro': [
+            ['default', "Lang"]
           ]
         },
       ],

--- a/src/components/Lang.astro
+++ b/src/components/Lang.astro
@@ -1,0 +1,39 @@
+---
+/**
+ * Inline language-conditional content — for use WITHIN paragraphs.
+ *
+ * Renders as a `<span>` so it can sit inside `<p>`, `<li>`, headings, etc.
+ * Use this to swap method names, API references, or short phrases inline:
+ *
+ *   Use the <Lang lang="python">`@tool` decorator</Lang><Lang lang="typescript">`tool()` function</Lang> to register tools.
+ *
+ * For block-level content (multiple paragraphs, code blocks, sections),
+ * use `<LanguageContent>` instead.
+ *
+ * Props:
+ *   lang — "python" | "typescript" (case-insensitive)
+ */
+interface Props {
+  lang: 'python' | 'typescript' | 'Python' | 'TypeScript';
+}
+
+const { lang } = Astro.props;
+
+const normalised = lang.charAt(0).toUpperCase() + lang.slice(1).toLowerCase();
+const label = lang.toLowerCase() === 'typescript' ? 'TypeScript' : normalised;
+---
+
+<span class="lang-inline" data-lang={label}><slot /></span>
+
+<style>
+  .lang-inline {
+    /* No visual chrome — content just appears inline */
+  }
+
+  :global(html[data-strands-language='Python']) .lang-inline[data-lang='TypeScript'] {
+    display: none;
+  }
+  :global(html[data-strands-language='TypeScript']) .lang-inline[data-lang='Python'] {
+    display: none;
+  }
+</style>

--- a/src/components/LanguageContent.astro
+++ b/src/components/LanguageContent.astro
@@ -2,25 +2,24 @@
 /**
  * Conditionally displays content based on the globally‑selected language.
  *
- * Usage in MDX:
+ * Renders as a transparent wrapper — no label, no visual chrome.
+ * Content just appears/disappears based on the language preference.
+ *
+ * For block-level content (paragraphs, sections):
  *
  *   <LanguageContent lang="python">
  *     Python uses the `@tool` decorator to register tools.
  *   </LanguageContent>
  *
- *   <LanguageContent lang="typescript">
- *     TypeScript uses the `tool()` function to register tools.
- *   </LanguageContent>
+ * For inline content within paragraphs (method names, API links), use
+ * the companion `<Lang>` component instead — it renders as a `<span>`.
  *
- * The component renders BOTH blocks in the HTML (SEO‑friendly) and uses
- * CSS (`data-strands-language` on <html>) + a tiny JS upgrade to toggle
- * visibility.  If JS is disabled, both blocks are visible (graceful
- * degradation).
+ * Both blocks render in the HTML (SEO‑friendly). CSS toggles visibility
+ * based on `data-strands-language` on <html>. If JS is disabled, both
+ * blocks are visible (graceful degradation).
  *
  * Props:
- *   lang — "python" | "typescript" (case‑insensitive, matched against
- *          the `data-strands-language` attribute which stores "Python" /
- *          "TypeScript" with capital first letter).
+ *   lang — "python" | "typescript" (case‑insensitive)
  */
 interface Props {
   lang: 'python' | 'typescript' | 'Python' | 'TypeScript';
@@ -30,7 +29,6 @@ const { lang } = Astro.props;
 
 // Normalise to the label used by the selector ("Python" / "TypeScript")
 const normalised = lang.charAt(0).toUpperCase() + lang.slice(1).toLowerCase();
-// For TypeScript the naive toUpperCase+toLowerCase gives "Typescript" — fix:
 const label = lang.toLowerCase() === 'typescript' ? 'TypeScript' : normalised;
 ---
 
@@ -40,13 +38,17 @@ const label = lang.toLowerCase() === 'typescript' ? 'TypeScript' : normalised;
 
 <style>
   /*
-   * When a global language preference is active, hide the block that
-   * does NOT match.  The `data-strands-language` attribute on <html>
-   * is set by LanguageSelector (both server‑inline and client‑side).
+   * Transparent wrapper — `display: contents` makes the div invisible to
+   * layout.  Children render as if the wrapper didn't exist.  When the
+   * other language is selected, the whole block hides via `display: none`.
    *
-   * When NO preference is set (first visit, no JS), both blocks remain
+   * When NO preference is set (first visit / no JS), both blocks remain
    * visible — content is never lost.
    */
+  .language-content {
+    display: contents;
+  }
+
   :global(html[data-strands-language='Python']) .language-content[data-lang='TypeScript'] {
     display: none;
   }

--- a/src/components/LanguageContent.astro
+++ b/src/components/LanguageContent.astro
@@ -1,0 +1,56 @@
+---
+/**
+ * Conditionally displays content based on the globally‑selected language.
+ *
+ * Usage in MDX:
+ *
+ *   <LanguageContent lang="python">
+ *     Python uses the `@tool` decorator to register tools.
+ *   </LanguageContent>
+ *
+ *   <LanguageContent lang="typescript">
+ *     TypeScript uses the `tool()` function to register tools.
+ *   </LanguageContent>
+ *
+ * The component renders BOTH blocks in the HTML (SEO‑friendly) and uses
+ * CSS (`data-strands-language` on <html>) + a tiny JS upgrade to toggle
+ * visibility.  If JS is disabled, both blocks are visible (graceful
+ * degradation).
+ *
+ * Props:
+ *   lang — "python" | "typescript" (case‑insensitive, matched against
+ *          the `data-strands-language` attribute which stores "Python" /
+ *          "TypeScript" with capital first letter).
+ */
+interface Props {
+  lang: 'python' | 'typescript' | 'Python' | 'TypeScript';
+}
+
+const { lang } = Astro.props;
+
+// Normalise to the label used by the selector ("Python" / "TypeScript")
+const normalised = lang.charAt(0).toUpperCase() + lang.slice(1).toLowerCase();
+// For TypeScript the naive toUpperCase+toLowerCase gives "Typescript" — fix:
+const label = lang.toLowerCase() === 'typescript' ? 'TypeScript' : normalised;
+---
+
+<div class="language-content" data-lang={label}>
+  <slot />
+</div>
+
+<style>
+  /*
+   * When a global language preference is active, hide the block that
+   * does NOT match.  The `data-strands-language` attribute on <html>
+   * is set by LanguageSelector (both server‑inline and client‑side).
+   *
+   * When NO preference is set (first visit, no JS), both blocks remain
+   * visible — content is never lost.
+   */
+  :global(html[data-strands-language='Python']) .language-content[data-lang='TypeScript'] {
+    display: none;
+  }
+  :global(html[data-strands-language='TypeScript']) .language-content[data-lang='Python'] {
+    display: none;
+  }
+</style>

--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -17,10 +17,11 @@
  *  5. Applies `data-strands-language` on <html> so CSS can conditionally
  *     show / hide content.
  *
- * The component renders as a segmented‑control pill (Python | TypeScript)
+ * The component renders as a segmented‑control pill (Python | TS)
  * that follows the site's Strands design tokens.
  *
- * On mobile, uses compact labels (PY | TS) to save horizontal space.
+ * On mobile, it lives inside the nav dropdown menu (not in the header row)
+ * to keep the header clean. On desktop, it's in the header right group.
  */
 
 // Compute the syncKey that AutoSyncTabs generates for Python|TypeScript
@@ -46,8 +47,7 @@ const syncKey = hashString('Python|TypeScript');
       aria-checked="true"
       data-lang="Python"
     >
-      <span class="lang-full">Python</span>
-      <span class="lang-short">PY</span>
+      Python
     </button>
     <button
       class="lang-btn"
@@ -55,8 +55,7 @@ const syncKey = hashString('Python|TypeScript');
       aria-checked="false"
       data-lang="TypeScript"
     >
-      <span class="lang-full">TS</span>
-      <span class="lang-short">TS</span>
+      TS
     </button>
   </div>
 </strands-language-selector>
@@ -222,16 +221,6 @@ const syncKey = hashString('Python|TypeScript');
     :global([data-theme='light']) .lang-btn.active,
     :global([data-theme='light']) .lang-btn[aria-checked='true'] {
       color: #fff;
-    }
-
-    /* Mobile: show short labels, hide full labels */
-    .lang-short { display: inline; }
-    .lang-full { display: none; }
-
-    /* Desktop: show full labels, hide short labels */
-    @media (min-width: 50rem) {
-      .lang-short { display: none; }
-      .lang-full { display: inline; }
     }
   }
 </style>

--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -19,6 +19,8 @@
  *
  * The component renders as a segmented‑control pill (Python | TypeScript)
  * that follows the site's Strands design tokens.
+ *
+ * On mobile, uses compact labels (PY | TS) to save horizontal space.
  */
 
 // Compute the syncKey that AutoSyncTabs generates for Python|TypeScript
@@ -44,7 +46,8 @@ const syncKey = hashString('Python|TypeScript');
       aria-checked="true"
       data-lang="Python"
     >
-      Python
+      <span class="lang-full">Python</span>
+      <span class="lang-short">PY</span>
     </button>
     <button
       class="lang-btn"
@@ -52,7 +55,8 @@ const syncKey = hashString('Python|TypeScript');
       aria-checked="false"
       data-lang="TypeScript"
     >
-      TypeScript
+      <span class="lang-full">TS</span>
+      <span class="lang-short">TS</span>
     </button>
   </div>
 </strands-language-selector>
@@ -218,6 +222,16 @@ const syncKey = hashString('Python|TypeScript');
     :global([data-theme='light']) .lang-btn.active,
     :global([data-theme='light']) .lang-btn[aria-checked='true'] {
       color: #fff;
+    }
+
+    /* Mobile: show short labels, hide full labels */
+    .lang-short { display: inline; }
+    .lang-full { display: none; }
+
+    /* Desktop: show full labels, hide short labels */
+    @media (min-width: 50rem) {
+      .lang-short { display: none; }
+      .lang-full { display: inline; }
     }
   }
 </style>

--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -1,0 +1,223 @@
+---
+/**
+ * Global Language Selector — Python / TypeScript toggle.
+ *
+ * Sits in the header alongside the theme toggle.  When the user picks a
+ * language the selector:
+ *
+ *  1. Persists the choice in `localStorage` (`strands-language-preference`).
+ *  2. Writes the *same* key that Starlight's synced‑tabs use so every
+ *     `<Tabs>` / `<AutoSyncTabs>` group on every page instantly follows.
+ *  3. Emits a `strands:language-change` CustomEvent on `document` so that
+ *     the companion `<LanguageContent>` component (and any future
+ *     consumers) can react.
+ *  4. Programmatically clicks the matching tab in every `<starlight-tabs>`
+ *     on the current page to update the visible panel (Starlight only
+ *     restores from localStorage on page load — we need the live switch).
+ *  5. Applies `data-strands-language` on <html> so CSS can conditionally
+ *     show / hide content.
+ *
+ * The component renders as a segmented‑control pill (Python | TypeScript)
+ * that follows the site's Strands design tokens.
+ */
+
+// Compute the syncKey that AutoSyncTabs generates for Python|TypeScript
+// (must stay in sync with AutoSyncTabs.astro's hashString)
+function hashString(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+const syncKey = hashString('Python|TypeScript');
+---
+
+<strands-language-selector data-sync-key={syncKey}>
+  <div class="lang-selector" role="radiogroup" aria-label="Programming language">
+    <button
+      class="lang-btn"
+      role="radio"
+      aria-checked="true"
+      data-lang="Python"
+    >
+      Python
+    </button>
+    <button
+      class="lang-btn"
+      role="radio"
+      aria-checked="false"
+      data-lang="TypeScript"
+    >
+      TypeScript
+    </button>
+  </div>
+</strands-language-selector>
+
+{/* Inlined so the preference is applied before first paint — avoids FOUC */}
+<script is:inline>
+(() => {
+  // Restore preference immediately (before custom element upgrades)
+  const pref = typeof localStorage !== 'undefined'
+    ? localStorage.getItem('strands-language-preference')
+    : null;
+  if (pref) {
+    document.documentElement.setAttribute('data-strands-language', pref);
+  }
+})();
+</script>
+
+<script>
+  class StrandsLanguageSelector extends HTMLElement {
+    private buttons: HTMLButtonElement[];
+    private syncKey: string;
+    private storageKey = 'strands-language-preference';
+    // Must match the prefix Starlight uses for synced tabs
+    private starlightPrefix = 'starlight-synced-tabs__';
+
+    constructor() {
+      super();
+      this.buttons = [...this.querySelectorAll<HTMLButtonElement>('.lang-btn')];
+      this.syncKey = this.dataset.syncKey ?? '';
+
+      // Restore persisted preference
+      const saved = localStorage.getItem(this.storageKey);
+      if (saved) {
+        this.activate(saved, false);
+      }
+
+      // Wire up click handlers
+      this.buttons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const lang = btn.dataset.lang!;
+          this.activate(lang, true);
+        });
+      });
+
+      // Listen for external language-change events (e.g. from other selectors)
+      document.addEventListener('strands:language-change', ((e: CustomEvent) => {
+        this.activate(e.detail.language, false);
+      }) as EventListener);
+
+      // Also listen for Starlight tab clicks — if user manually clicks a
+      // Python/TypeScript tab, update the selector to match.
+      document.addEventListener('click', (e: MouseEvent) => {
+        const tab = (e.target as HTMLElement).closest?.('starlight-tabs [role="tab"]');
+        if (!tab) return;
+        const label = tab.textContent?.trim();
+        if (label === 'Python' || label === 'TypeScript') {
+          this.activate(label, false);
+        }
+      });
+    }
+
+    private activate(language: string, shouldSync: boolean) {
+      // Update button states
+      this.buttons.forEach((btn) => {
+        const isActive = btn.dataset.lang === language;
+        btn.setAttribute('aria-checked', String(isActive));
+        btn.classList.toggle('active', isActive);
+      });
+
+      // Persist
+      localStorage.setItem(this.storageKey, language);
+      // Also write the Starlight synced-tabs key so page loads respect it
+      localStorage.setItem(this.starlightPrefix + this.syncKey, language);
+
+      // Set data attribute on <html> for CSS-based content switching
+      document.documentElement.setAttribute('data-strands-language', language);
+
+      if (shouldSync) {
+        // Dispatch event for LanguageContent components
+        document.dispatchEvent(new CustomEvent('strands:language-change', {
+          detail: { language },
+        }));
+
+        // Programmatically switch all Starlight tab groups on this page
+        this.syncStarlightTabs(language);
+      }
+    }
+
+    private syncStarlightTabs(language: string) {
+      document.querySelectorAll('starlight-tabs').forEach((tabGroup) => {
+        const tabs = [...tabGroup.querySelectorAll<HTMLAnchorElement>('[role="tab"]')];
+        const panels = [...tabGroup.querySelectorAll<HTMLElement>(':scope > [role="tabpanel"]')];
+
+        const targetIndex = tabs.findIndex(
+          (tab) => tab.textContent?.trim() === language,
+        );
+        if (targetIndex === -1) return;
+
+        // Deselect all
+        tabs.forEach((tab) => {
+          tab.setAttribute('aria-selected', 'false');
+          tab.setAttribute('tabindex', '-1');
+        });
+        panels.forEach((panel) => {
+          panel.hidden = true;
+        });
+
+        // Select target
+        const newTab = tabs[targetIndex];
+        const newPanel = panels[targetIndex];
+        if (newTab) {
+          newTab.removeAttribute('tabindex');
+          newTab.setAttribute('aria-selected', 'true');
+        }
+        if (newPanel) {
+          newPanel.hidden = false;
+        }
+      });
+    }
+  }
+
+  customElements.define('strands-language-selector', StrandsLanguageSelector);
+</script>
+
+<style>
+  @layer starlight.components {
+    .lang-selector {
+      display: flex;
+      align-items: center;
+      background-color: var(--sl-color-gray-6);
+      border-radius: 999px;
+      padding: 2px;
+      gap: 0;
+    }
+
+    .lang-btn {
+      all: unset;
+      display: inline-flex;
+      align-items: center;
+      padding: 0.25rem 0.625rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      line-height: 1.4;
+      border-radius: 999px;
+      cursor: pointer;
+      color: var(--sl-color-gray-3);
+      transition: all 0.15s ease;
+      white-space: nowrap;
+      user-select: none;
+    }
+
+    .lang-btn:hover {
+      color: var(--sl-color-white);
+    }
+
+    .lang-btn.active,
+    .lang-btn[aria-checked='true'] {
+      background-color: var(--sl-color-accent);
+      color: var(--sl-color-black);
+      font-weight: 600;
+    }
+
+    :global([data-theme='light']) .lang-btn.active,
+    :global([data-theme='light']) .lang-btn[aria-checked='true'] {
+      color: #fff;
+    }
+  }
+</style>

--- a/src/components/LanguageTabsMarker.astro
+++ b/src/components/LanguageTabsMarker.astro
@@ -24,22 +24,9 @@
 
       if (isLangTabs) {
         tabGroup.setAttribute('data-lang-tabs', '');
-
-        // Set the active language label
-        const activeTab = tabGroup.querySelector('[role="tab"][aria-selected="true"]');
-        if (activeTab) {
-          tabGroup.setAttribute('data-active-lang', activeTab.textContent?.trim() || '');
-        }
       }
     });
   }
-
-  // Update data-active-lang when language changes
-  document.addEventListener('strands:language-change', (e) => {
-    document.querySelectorAll('starlight-tabs[data-lang-tabs]').forEach((tabGroup) => {
-      tabGroup.setAttribute('data-active-lang', e.detail.language);
-    });
-  });
 
   // Mark tabs on load
   if (document.readyState === 'loading') {

--- a/src/components/LanguageTabsMarker.astro
+++ b/src/components/LanguageTabsMarker.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * Marks <starlight-tabs> elements that contain Python/TypeScript language tabs
+ * with a `data-lang-tabs` attribute so they can be styled as "implicit" tabs
+ * (hidden tab bar, content switched by the global LanguageSelector).
+ *
+ * Include this once per page (it's added to Head.astro).
+ * Runs immediately on DOM ready + observes new tabs added dynamically.
+ */
+---
+
+<script is:inline>
+(() => {
+  const LANG_LABELS = ['Python', 'TypeScript'];
+
+  function markLanguageTabs() {
+    document.querySelectorAll('starlight-tabs:not([data-lang-tabs-checked])').forEach((tabGroup) => {
+      tabGroup.setAttribute('data-lang-tabs-checked', '');
+      const tabs = tabGroup.querySelectorAll('[role="tab"]');
+      const labels = [...tabs].map(t => t.textContent?.trim());
+
+      // Only mark if ALL tab labels are language labels
+      const isLangTabs = labels.length > 0 && labels.every(l => LANG_LABELS.includes(l || ''));
+
+      if (isLangTabs) {
+        tabGroup.setAttribute('data-lang-tabs', '');
+
+        // Set the active language label
+        const activeTab = tabGroup.querySelector('[role="tab"][aria-selected="true"]');
+        if (activeTab) {
+          tabGroup.setAttribute('data-active-lang', activeTab.textContent?.trim() || '');
+        }
+      }
+    });
+  }
+
+  // Update data-active-lang when language changes
+  document.addEventListener('strands:language-change', (e) => {
+    document.querySelectorAll('starlight-tabs[data-lang-tabs]').forEach((tabGroup) => {
+      tabGroup.setAttribute('data-active-lang', e.detail.language);
+    });
+  });
+
+  // Mark tabs on load
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', markLanguageTabs);
+  } else {
+    markLanguageTabs();
+  }
+
+  // Also observe for dynamically added tabs (SPA-style navigation)
+  const observer = new MutationObserver(markLanguageTabs);
+  observer.observe(document.body, { childList: true, subtree: true });
+})();
+</script>

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -5,6 +5,7 @@
  * See ARCHITECTURE.md for details.
  */
 import SiteScripts from '../SiteScripts.astro'
+import LanguageTabsMarker from '../LanguageTabsMarker.astro'
 import { baseSchemas } from '../../util/structured-data'
 
 const { head } = Astro.locals.starlightRoute
@@ -79,6 +80,7 @@ const structuredData = {
 
 <!-- AWS Shortbread cookie consent -->
 <SiteScripts />
+<LanguageTabsMarker />
 
 <!-- Structured Data -->
 <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -19,6 +19,7 @@ import { Icon } from '@astrojs/starlight/components';
 import { navLinks, githubSections, type NavLink } from '../../config/navbar';
 import type { GitHubSection } from '../../sidebar';
 import GitHubDropdown from '../GitHubDropdown.astro';
+import LanguageSelector from '../LanguageSelector.astro';
 import { findCurrentNavSection } from '../../route-middleware';
 import logoHeaderDark from '../../assets/logo-header-dark.svg';
 import logoHeaderLight from '../../assets/logo-header-light.svg';
@@ -46,6 +47,7 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
     </div>
     <div class="header-spacer"></div>
     {shouldRenderSearch && <div class="search-wrapper print:hidden"><Search /></div>}
+    <div class="mobile-lang-selector md:sl-hidden print:hidden"><LanguageSelector /></div>
     {/* Mobile nav dropdown */}
     {navLinks.length > 0 && (
       <nav class="mobile-nav md:sl-hidden print:hidden" aria-label="Main navigation">
@@ -86,6 +88,7 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
       </nav>
     )}
     <div class="sl-hidden md:sl-flex print:hidden right-group">
+      <LanguageSelector />
       <GitHubDropdown />
       <ThemeSelect />
       <LanguageSelect />
@@ -452,6 +455,15 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
       .header-spacer {
         /* In grid context, this element fills the 1fr column */
       }
+    }
+  }
+</style>
+
+<style>
+  @layer starlight.core {
+    .mobile-lang-selector {
+      display: flex;
+      align-items: center;
     }
   }
 </style>

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -47,8 +47,7 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
     </div>
     <div class="header-spacer"></div>
     {shouldRenderSearch && <div class="search-wrapper print:hidden"><Search /></div>}
-    <div class="mobile-lang-selector md:sl-hidden print:hidden"><LanguageSelector /></div>
-    {/* Mobile nav dropdown */}
+    {/* Mobile nav dropdown — language selector lives INSIDE here on mobile */}
     {navLinks.length > 0 && (
       <nav class="mobile-nav md:sl-hidden print:hidden" aria-label="Main navigation">
         <details class="mobile-nav-dropdown">
@@ -59,6 +58,11 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
             <Icon name="down-caret" class="mobile-nav-caret" size="1rem" />
           </summary>
           <div class="mobile-nav-menu">
+            {/* Language selector at top of mobile dropdown */}
+            <div class="mobile-nav-lang-row">
+              <LanguageSelector />
+            </div>
+            <div class="mobile-nav-divider"></div>
             {navLinks.map((link: NavLink) => {
               const isActive = activeNav?.label === link.label;
               return (
@@ -74,7 +78,7 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
             })}
             {githubSections.map((section: GitHubSection, i: number) => (
               <Fragment>
-                <div class={i === 0 ? 'mobile-nav-divider' : undefined}></div>
+                <div class="mobile-nav-divider"></div>
                 <div class="mobile-nav-section-label">{i === 0 ? 'GitHub' : section.title}</div>
                 {section.links.map((link) => (
                   <a href={link.href} target="_blank" rel="noopener noreferrer" class="mobile-nav-link">
@@ -391,6 +395,13 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     }
 
+    /* Language selector row inside mobile dropdown */
+    .mobile-nav-lang-row {
+      display: flex;
+      justify-content: center;
+      padding: 0.25rem 0.5rem;
+    }
+
     .mobile-nav-link {
       display: flex;
       align-items: center;
@@ -455,15 +466,6 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
       .header-spacer {
         /* In grid context, this element fills the 1fr column */
       }
-    }
-  }
-</style>
-
-<style>
-  @layer starlight.core {
-    .mobile-lang-selector {
-      display: flex;
-      align-items: center;
     }
   }
 </style>

--- a/src/content/docs/user-guide/concepts/agents/hooks-demo.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks-demo.mdx
@@ -1,0 +1,166 @@
+---
+title: "Hooks (Language Selector Demo)"
+description: "Demo page showing the implicit language selector feature. Compare this with the original hooks page."
+---
+
+import LanguageContent from '../../../../../components/LanguageContent.astro';
+
+This page demonstrates the **implicit language selector** feature. Use the Python / TypeScript toggle in the header to switch all code examples and language-specific content on this page.
+
+## Overview
+
+Hooks are a composable extensibility mechanism for extending agent functionality by subscribing to events throughout the agent lifecycle.
+
+## Basic Usage — Implicit Tabs
+
+The tab groups below have their tab bar hidden. The global language selector in the header controls which panel is visible. No more clicking individual tabs!
+
+### Registering Individual Hook Callbacks
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.hooks import BeforeInvocationEvent, BeforeToolCallEvent
+
+agent = Agent()
+
+# Register individual callbacks
+def my_callback(event: BeforeInvocationEvent) -> None:
+    print("Custom callback triggered")
+
+agent.add_hook(my_callback, BeforeInvocationEvent)
+
+# Type inference: If your callback has a type hint, the event type is inferred
+def typed_callback(event: BeforeToolCallEvent) -> None:
+    print(f"Tool called: {event.tool_use['name']}")
+
+agent.add_hook(typed_callback)  # Event type inferred from type hint
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+import { Agent } from "@strands-agents/sdk";
+import { BeforeToolCallEvent } from "@strands-agents/sdk/hooks";
+
+const agent = new Agent({ model });
+
+// Register with add_hook — type-safe callback
+agent.addHook(BeforeToolCallEvent, (event) => {
+  console.log(`Tool called: ${event.toolUse.name}`);
+});
+```
+</Tab>
+</Tabs>
+
+## Language-Specific Prose — LanguageContent
+
+The section below uses `<LanguageContent>` to show completely different prose depending on the selected language. This is for cases where the explanation itself differs — not just the code.
+
+<LanguageContent lang="python">
+
+### Python Hook Architecture
+
+In Python, hooks use a **decorator-based pattern** with `@hook` and are registered via `agent.add_hook()`. The hook system supports:
+
+- **Type inference** from callback type hints — no need to specify the event type explicitly
+- **`HookProvider` protocol** — classes that bundle related hooks together
+- **Plugin system** — `Plugin` base class with `@hook` decorator for packaging hooks with configuration
+
+Python hooks receive strongly-typed event dataclasses with `@property` accessors for read-only fields and explicit setters for mutable fields.
+
+</LanguageContent>
+
+<LanguageContent lang="typescript">
+
+### TypeScript Hook Architecture
+
+In TypeScript, hooks use a **class-based event pattern** where all events extend `HookableEvent`. The hook system supports:
+
+- **`agent.addHook(EventClass, callback)`** — type-safe registration with full IntelliSense
+- **Streaming integration** — all hook events are streamable via `agent.stream()` 
+- **Rich event wrappers** — `ContentBlockEvent`, `ModelMessageEvent`, `ToolResultEvent` provide structured access to streaming data
+- **Batch operations** — `BeforeToolsEvent` / `AfterToolsEvent` for intercepting tool batches
+
+TypeScript events carry their data as typed properties accessible via `.event`, `.message`, `.result`, etc.
+
+</LanguageContent>
+
+## Available Events
+
+The tables below show the different events available in each SDK. They switch automatically with the header toggle:
+
+<Tabs>
+<Tab label="Python">
+
+| Event                              | Description                                                                |
+|------------------------------------|----------------------------------------------------------------------------|
+| `AgentInitializedEvent`            | Agent construction completed                                               |
+| `BeforeInvocationEvent`            | New agent invocation starting                                              |
+| `AfterInvocationEvent`             | Agent request completed (success or failure)                               |
+| `MessageAddedEvent`                | Message added to conversation history                                      |
+| `BeforeModelCallEvent`             | Before model inference                                                     |
+| `AfterModelCallEvent`              | After model inference completes                                            |
+| `BeforeToolCallEvent`              | Before tool invocation                                                     |
+| `AfterToolCallEvent`               | After tool invocation completes                                            |
+</Tab>
+<Tab label="TypeScript">
+
+| Event                    | Description                                                                     |
+|--------------------------|---------------------------------------------------------------------------------|
+| `AgentInitializedEvent`  | Agent construction completed                                                    |
+| `BeforeInvocationEvent`  | New agent invocation starting                                                   |
+| `AfterInvocationEvent`   | Agent request completed                                                         |
+| `MessageAddedEvent`      | Message added to conversation history                                           |
+| `BeforeModelCallEvent`   | Before model inference                                                          |
+| `AfterModelCallEvent`    | After model inference completes                                                 |
+| `ModelStreamUpdateEvent` | Streaming delta from model                                                      |
+| `ContentBlockEvent`      | Fully assembled content block                                                   |
+| `ModelMessageEvent`      | Complete model message                                                          |
+| `BeforeToolCallEvent`    | Before tool invocation                                                          |
+| `AfterToolCallEvent`     | After tool invocation completes                                                 |
+| `BeforeToolsEvent`       | Before batch tool execution                                                     |
+| `AfterToolsEvent`        | After batch tool execution                                                      |
+| `ToolStreamUpdateEvent`  | Streaming progress from tools                                                   |
+| `ToolResultEvent`        | Completed tool result                                                           |
+| `AgentResultEvent`       | Final agent result                                                              |
+</Tab>
+</Tabs>
+
+## Mixed Content — Tabs + LanguageContent
+
+You can mix both approaches. Use `<Tabs>` for code blocks (where the tab UI is hidden but the switching mechanism is intact) and `<LanguageContent>` for prose sections:
+
+<LanguageContent lang="python">
+
+In Python, you modify tool parameters by accessing `event.tool_use` directly:
+
+</LanguageContent>
+
+<LanguageContent lang="typescript">
+
+In TypeScript, you modify tool parameters through the `event.toolUse` property:
+
+</LanguageContent>
+
+<Tabs>
+<Tab label="Python">
+
+```python
+def fix_args(event: BeforeToolCallEvent) -> None:
+    event.tool_use["input"]["region"] = "us-west-2"
+
+agent.add_hook(fix_args, BeforeToolCallEvent)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+agent.addHook(BeforeToolCallEvent, (event) => {
+  event.toolUse.input.region = "us-west-2";
+});
+```
+</Tab>
+</Tabs>

--- a/src/content/docs/user-guide/concepts/agents/hooks-demo.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks-demo.mdx
@@ -3,13 +3,21 @@ title: "Hooks (Language Selector Demo)"
 description: "Demo page showing the implicit language selector feature. Compare this with the original hooks page."
 ---
 
-{/* LanguageContent is auto-imported via astro.config.mjs — no explicit import needed */}
+{/* LanguageContent and Lang are auto-imported — no explicit import needed */}
 
-This page demonstrates the **implicit language selector** feature. Use the Python / TypeScript toggle in the header to switch all code examples and language-specific content on this page.
+This page demonstrates the **implicit language selector** feature. Use the **PY / TS** toggle in the header to switch all code examples and language-specific content on this page.
 
 ## Overview
 
 Hooks are a composable extensibility mechanism for extending agent functionality by subscribing to events throughout the agent lifecycle.
+
+## Inline Language Switching
+
+The `<Lang>` component lets you swap content **within** a paragraph — method names, API references, short phrases — without any visible label or wrapper.
+
+Register hooks using <Lang lang="python">`agent.add_hook()`</Lang><Lang lang="typescript">`agent.addHook()`</Lang>. The callback receives a strongly-typed event — <Lang lang="python">a dataclass with `@property` accessors</Lang><Lang lang="typescript">a class extending `HookableEvent`</Lang>.
+
+For example, to intercept tool calls, subscribe to <Lang lang="python">`BeforeToolCallEvent`</Lang><Lang lang="typescript">`BeforeToolCallEvent`</Lang> and access <Lang lang="python">`event.tool_use`</Lang><Lang lang="typescript">`event.toolUse`</Lang> to inspect or modify parameters.
 
 ## Basic Usage — Implicit Tabs
 
@@ -47,7 +55,7 @@ import { BeforeToolCallEvent } from "@strands-agents/sdk/hooks";
 
 const agent = new Agent({ model });
 
-// Register with add_hook — type-safe callback
+// Register with addHook — type-safe callback
 agent.addHook(BeforeToolCallEvent, (event) => {
   console.log(`Tool called: ${event.toolUse.name}`);
 });
@@ -129,21 +137,11 @@ The tables below show the different events available in each SDK. They switch au
 </Tab>
 </Tabs>
 
-## Mixed Content — Tabs + LanguageContent
+## Mixed Content — All Three Patterns
 
-You can mix both approaches. Use `<Tabs>` for code blocks (where the tab UI is hidden but the switching mechanism is intact) and `<LanguageContent>` for prose sections:
+You can mix all approaches. Use `<Tabs>` for code blocks (tab bar hidden), `<LanguageContent>` for prose sections, and `<Lang>` for inline swaps:
 
-<LanguageContent lang="python">
-
-In Python, you modify tool parameters by accessing `event.tool_use` directly:
-
-</LanguageContent>
-
-<LanguageContent lang="typescript">
-
-In TypeScript, you modify tool parameters through the `event.toolUse` property:
-
-</LanguageContent>
+To modify tool parameters before execution, access <Lang lang="python">`event.tool_use`</Lang><Lang lang="typescript">`event.toolUse`</Lang> in your hook callback:
 
 <Tabs>
 <Tab label="Python">
@@ -164,3 +162,5 @@ agent.addHook(BeforeToolCallEvent, (event) => {
 ```
 </Tab>
 </Tabs>
+
+See the <Lang lang="python">[Python hooks API reference](/docs/api/python/strands.agent.agent/)</Lang><Lang lang="typescript">[TypeScript hooks API reference](/docs/api/typescript/)</Lang> for the full API reference.

--- a/src/content/docs/user-guide/concepts/agents/hooks-demo.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks-demo.mdx
@@ -3,7 +3,7 @@ title: "Hooks (Language Selector Demo)"
 description: "Demo page showing the implicit language selector feature. Compare this with the original hooks page."
 ---
 
-import LanguageContent from '../../../../../components/LanguageContent.astro';
+{/* LanguageContent is auto-imported via astro.config.mjs — no explicit import needed */}
 
 This page demonstrates the **implicit language selector** feature. Use the Python / TypeScript toggle in the header to switch all code examples and language-specific content on this page.
 
@@ -80,7 +80,7 @@ Python hooks receive strongly-typed event dataclasses with `@property` accessors
 In TypeScript, hooks use a **class-based event pattern** where all events extend `HookableEvent`. The hook system supports:
 
 - **`agent.addHook(EventClass, callback)`** — type-safe registration with full IntelliSense
-- **Streaming integration** — all hook events are streamable via `agent.stream()` 
+- **Streaming integration** — all hook events are streamable via `agent.stream()`
 - **Rich event wrappers** — `ContentBlockEvent`, `ModelMessageEvent`, `ToolResultEvent` provide structured access to streaming data
 - **Batch operations** — `BeforeToolsEvent` / `AfterToolsEvent` for intercepting tool batches
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -57,3 +57,46 @@ a[aria-current="page"]:hover {
 :root {
 	--sl-content-width: 50rem;
 }
+/* ============================================================================
+ * IMPLICIT LANGUAGE TABS
+ * ============================================================================
+ * When a global language preference is set (data-strands-language on <html>),
+ * hide the tab bar on Python/TypeScript tab groups. The content still switches
+ * via the global LanguageSelector — the tabs become "implicit".
+ *
+ * Tab groups that are NOT Python/TypeScript (e.g. npm/yarn/pnpm) keep their
+ * visible tab bar.
+ * ============================================================================ */
+
+/* When a language preference is active, hide tab headers on language tab groups.
+   We target tab groups where the tabs are exactly "Python" and "TypeScript". */
+html[data-strands-language] starlight-tabs .tablist-wrapper:has(
+  [role="tab"]:first-child:is([href*="python" i], :not([href]))
+) {
+  /* Fallback: we can't reliably detect Python/TS tabs via href alone since
+     Starlight generates anchors from panel IDs. Instead we use a JS-based
+     approach below. */
+}
+
+/* JS-based: LanguageSelector adds `data-lang-tabs` to language tab groups */
+starlight-tabs[data-lang-tabs] .tablist-wrapper {
+  display: none;
+}
+
+/* Add a subtle indicator showing which language is active on implicit tabs */
+starlight-tabs[data-lang-tabs]::before {
+  content: attr(data-active-lang);
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--sl-color-gray-3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0;
+  margin-bottom: 0.25rem;
+}
+
+/* Remove the top margin that tab panels normally have (since there's no tab bar above) */
+starlight-tabs[data-lang-tabs] > [role="tabpanel"] {
+  margin-top: 0;
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -68,33 +68,13 @@ a[aria-current="page"]:hover {
  * visible tab bar.
  * ============================================================================ */
 
-/* When a language preference is active, hide tab headers on language tab groups.
-   We target tab groups where the tabs are exactly "Python" and "TypeScript". */
-html[data-strands-language] starlight-tabs .tablist-wrapper:has(
-  [role="tab"]:first-child:is([href*="python" i], :not([href]))
-) {
-  /* Fallback: we can't reliably detect Python/TS tabs via href alone since
-     Starlight generates anchors from panel IDs. Instead we use a JS-based
-     approach below. */
-}
-
-/* JS-based: LanguageSelector adds `data-lang-tabs` to language tab groups */
+/* JS-based: LanguageTabsMarker adds `data-lang-tabs` to language tab groups */
 starlight-tabs[data-lang-tabs] .tablist-wrapper {
   display: none;
 }
 
-/* Add a subtle indicator showing which language is active on implicit tabs */
-starlight-tabs[data-lang-tabs]::before {
-  content: attr(data-active-lang);
-  display: inline-block;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--sl-color-gray-3);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.25rem 0;
-  margin-bottom: 0.25rem;
-}
+/* No label — content just shows directly. The global header toggle is the
+   only indicator of which language is active. */
 
 /* Remove the top margin that tab panels normally have (since there's no tab bar above) */
 starlight-tabs[data-lang-tabs] > [role="tabpanel"] {


### PR DESCRIPTION
Implements a page-level Python/TypeScript toggle that replaces per-section tab clicking with a single global selector:

Components:
- LanguageSelector: Pill toggle in the header (Python | TypeScript)
  - Persists preference in localStorage
  - Syncs with Starlight's tab sync mechanism
  - Sets data-strands-language on <html> for CSS-based switching
  - Bidirectional: clicking a tab updates the selector too

- LanguageContent: Conditional prose blocks
  - <LanguageContent lang='python'>...</LanguageContent>
  - CSS-based show/hide using data-strands-language attribute
  - SEO-friendly: both blocks are in HTML, CSS toggles visibility
  - Graceful degradation: both visible if no JS

- LanguageTabsMarker: Auto-detects Python/TypeScript tab groups
  - Marks them with data-lang-tabs attribute
  - CSS hides the tab bar (making tabs 'implicit')
  - Shows subtle active-language indicator

- Demo page: hooks-demo.mdx showcases all patterns

How it works:
1. User clicks Python/TypeScript in header pill
2. localStorage is set (both our key + Starlight's synced-tabs key)
3. All starlight-tabs on page programmatically switch
4. LanguageContent blocks show/hide via CSS
5. Tab bars on language tabs are hidden (implicit)
6. Preference persists across page navigations

## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->


## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
