### PR TITLE
docs: add required frontmatter guide for community catalog pages

### DIFF
--- a/src/content/docs/community/get-featured.mdx
+++ b/src/content/docs/community/get-featured.mdx
@@ -13,6 +13,7 @@ We feature **reusable packages** that extend Strands Agents capabilities:
 - **Model Providers** — integrations with LLM services (OpenAI-compatible endpoints, custom APIs, etc.)
 - **Tools** — packaged tools that solve common problems (API integrations, utilities, etc.)
 - **Session Managers** — custom session/memory implementations
+- **Plugins** — extend or modify agent behavior during lifecycle events
 - **Integrations** — protocol implementations, framework bridges, etc.
 
 We're not looking for example agents or one-off projects — the focus is on packages published to PyPI that others can `pip install` or `npm install` and use in their own agents. See [Community Packages](./community-packages.md) for guidance on creating and publishing your package.
@@ -25,7 +26,8 @@ The [extension template](https://github.com/strands-agents/extension-template-py
 
 1. **Create a PR** to [strands-agents/docs](https://github.com/strands-agents/docs)
 2. **Add your doc file** in the appropriate `community/` subdirectory
-3. **Update `src/config/navigation.yml`** to include your new page in the nav
+3. **Include the required frontmatter** so your page appears in the [community catalog](./community-packages.md)
+4. **Update `src/config/navigation.yml`** to include your new page in the nav
 
 ## Directory Structure
 
@@ -33,11 +35,11 @@ Place your documentation in the right spot:
 
 | Type | Directory | Example |
 |------|-----------|---------|
-| Model Providers | `community/model-providers/` | `cohere.md` |
-| Tools | `community/tools/` | `strands-deepgram.md` |
-| Session Managers | `community/session-managers/` | `agentcore-memory.md` |
-| Plugins | `community/plugins/` | `my-plugin.md` |
-| Integrations | `community/integrations/` | `ag-ui.md` |
+| Model Providers | `community/model-providers/` | `cohere.mdx` |
+| Tools | `community/tools/` | `strands-deepgram.mdx` |
+| Session Managers | `community/session-managers/` | `agentcore-memory.mdx` |
+| Plugins | `community/plugins/` | `my-plugin.mdx` |
+| Integrations | `community/integrations/` | `ag-ui.mdx` |
 
 ## Document Layout
 
@@ -47,7 +49,6 @@ Follow this structure (see existing docs for reference):
 
 ```markdown
 # Package Name
-
 
 Brief intro explaining what your package does and why it's useful.
 
@@ -72,21 +73,39 @@ Common issues and how to fix them.
 Links to your repo, PyPI, official docs, etc.
 ```
 
-### For Tools
+### Frontmatter
 
-Add frontmatter with project metadata:
+Every community page needs frontmatter with catalog fields so it appears in the [community catalog](./community-packages.md). Without `community: true`, `integrationType`, `description`, and `languages`, your page won't show up in the catalog tables.
+
+Here's the full frontmatter for a **Tool** (adapt `integrationType` for your package type — `tool`, `model-provider`, `session-manager`, `plugin`, or `integration`):
 
 ```yaml
 ---
+title: your-package-name
+community: true
+integrationType: tool
+description: Short description of what the tool does
+languages: Python
+sidebar:
+  label: "display-name"
 project:
   pypi: https://pypi.org/project/your-package/
   github: https://github.com/your-org/your-repo
   maintainer: your-github-username
 service:
-  name: service-name
+  name: Service Name
   link: https://service-website.com/
 ---
 ```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `community` | ✅ | Must be `true` |
+| `integrationType` | ✅ | `tool`, `model-provider`, `session-manager`, `plugin`, or `integration` |
+| `description` | ✅ | Shown in the catalog table |
+| `languages` | ✅ | `Python`, `TypeScript`, or omit for both |
+| `project` | Recommended | PyPI/npm link, GitHub repo, maintainer |
+| `service` | Optional | External service metadata |
 
 ## Update navigation.yml
 
@@ -107,8 +126,12 @@ Add your page to `src/config/navigation.yml` under the Community section:
 
 ## Examples to Follow
 
-- **Model Provider**: [fireworksai.md](https://github.com/strands-agents/docs/blob/main/docs/community/model-providers/fireworksai.md)
-- **Tool**: [strands-deepgram.md](https://github.com/strands-agents/docs/blob/main/docs/community/tools/strands-deepgram.md)
+Look at existing community pages for reference:
+
+- **Tool**: [strands-deepgram.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/tools/strands-deepgram.mdx)
+- **Model Provider**: [nvidia-nim.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/model-providers/nvidia-nim.mdx)
+- **Session Manager**: [agentcore-memory.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/session-managers/agentcore-memory.mdx)
+- **Integration**: [ag-ui.mdx](https://github.com/strands-agents/docs/blob/main/src/content/docs/community/integrations/ag-ui.mdx)
 
 ## Questions?
 


### PR DESCRIPTION
The `get-featured.mdx` guide was missing the frontmatter fields required for pages to appear in the [community catalog](https://strandsagents.com/docs/community/community-packages/) (`community`, `integrationType`, `description`, `languages`). This caused [#751](https://github.com/strands-agents/docs/pull/751) to be invisible in the catalog.

Changes:
- Extends the existing "For Tools" frontmatter section with the required catalog fields
- Adds a quick field reference table
- Adds Plugins to the package types list
- Fixes `.md` → `.mdx` file extensions in examples
- Updates example links to point to correct paths

cc @mkmeral