### PR TITLE
docs: add streaming direct tool calls documentation

### DIFF
--- a/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -185,6 +185,44 @@ Find the tool in the `agent.tools` array and call its `invoke()` method. You nee
 </Tab>
 </Tabs>
 
+#### Streaming Direct Tool Calls
+
+<Tabs>
+<Tab label="Python">
+
+Direct tool calls support streaming, allowing you to observe execution events in real-time without recording to message history:
+
+```python
+from strands import Agent, tool
+
+@tool
+def analyze_data(query: str) -> str:
+    """Analyze data based on a query."""
+    return f"Analysis complete for: {query}"
+
+agent = Agent(tools=[analyze_data])
+
+# Async streaming
+async for event in agent.tool.analyze_data.stream_async(query="sales trends"):
+    if "data" in event:
+        print(event["data"], end="")
+
+# Sync streaming
+for event in agent.tool.analyze_data.stream(query="sales trends"):
+    if "data" in event:
+        print(event["data"], end="")
+```
+
+Streaming methods yield the same [tool events](../streaming/index.md#tool-events) as agent-level streaming.
+</Tab>
+<Tab label="TypeScript">
+
+```ts
+// Not supported in TypeScript
+```
+</Tab>
+</Tabs>
+
 
 ## Tool Executors
 

--- a/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -186,6 +186,37 @@ Find the tool in the `agent.tools` array and call its `invoke()` method. You nee
 </Tab>
 </Tabs>
 
+#### Streaming Direct Tool Calls
+
+Direct tool calls support streaming, allowing you to observe execution events in real-time without recording to message history:
+
+```python
+from strands import Agent, tool
+
+@tool
+def analyze_data(query: str) -> str:
+    """Analyze data based on a query."""
+    return f"Analysis complete for: {query}"
+
+agent = Agent(tools=[analyze_data])
+
+# Async streaming
+async for event in agent.tool.analyze_data.stream_async(query="sales trends"):
+    if "data" in event:
+        print(event["data"], end="")
+
+# Sync streaming
+for event in agent.tool.analyze_data.stream(query="sales trends"):
+    if "data" in event:
+        print(event["data"], end="")
+```
+
+Streaming methods yield the same [tool events](../streaming/index.md#tool-events) as agent-level streaming.
+
+:::note
+In Python, `agent.tool.my_tool(...)` is equivalent to TypeScript's `agent.tool.my_tool.invoke(...)`. Python uses `__call__` as the synchronous entry point, while TypeScript uses an explicit `.invoke()` method.
+:::
+
 
 ## Tool Executors
 


### PR DESCRIPTION
## Description

Document the new `stream()` and `stream_async()` methods for direct tool calls (`agent.tool.my_tool.stream_async()`), added in strands-agents/sdk-python#1955.

## Related Issues

strands-agents/sdk-python#1436

## Type of Change

- New content

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.