### PR TITLE
fix: remove headings inside tabs that created broken table of content links

### DIFF
--- a/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
+++ b/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
@@ -169,7 +169,7 @@ result = swarm(content_blocks)
 <Tabs>
 <Tab label="Python">
 
-### Handoff Tool
+**Handoff Tool**
 
 When you create a Swarm in Python, each agent is automatically equipped with special tools for coordination. Agents can transfer control to another agent when they need specialized help:
 
@@ -182,7 +182,7 @@ handoff_to_agent(
 )
 ```
 
-### Shared Context
+**Shared Context**
 
 The Swarm maintains a shared context that all agents can access. This includes:
 
@@ -214,7 +214,7 @@ You have access to swarm coordination tools if you need help from other agents.
 </Tab>
 <Tab label="TypeScript">
 
-### Structured Output Routing
+**Structured Output Routing**
 
 Agents use structured output to decide the next step. Each agent's response includes:
 


### PR DESCRIPTION
## Description

Remove table of content headings from sections that only appear in Typescript / Python to fix broken TOC link that leads nowhere.

ie. see https://strandsagents.com/docs/user-guide/concepts/multi-agent/swarm/#structured-output-routing

## Related Issues
https://github.com/strands-agents/docs/issues/750


## Type of Change
- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
