### PR TITLE
docs: add GPT-OSS stop token workaround to OpenAI provider troubleshooting

### DIFF
--- a/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -135,12 +135,53 @@ The model configuration sets parameters for inference:
 **Module Not Found**
 
 If you encounter the error `ModuleNotFoundError: No module named 'openai'`, this means you haven't installed the `openai` dependency in your environment. To fix, run `pip install 'strands-agents[openai]'`.
+
+**GPT-OSS Tool Calling Fails on Non-Managed Endpoints**
+
+If you are running GPT-OSS on an endpoint that isn't a managed inference provider and you see errors like `Unexpected token ... while expecting start token ...` during tool calling, your endpoint likely doesn't have the correct stop tokens configured.
+
+As an immediate workaround, pass the GPT-OSS stop sequences explicitly via `params`:
+
+```python
+model = OpenAIModel(
+    client_args={
+        "api_key": "<KEY>",
+        "base_url": "http://localhost:8000/v1",
+    },
+    model_id="<MODEL_ID>",
+    params={"stop": ["<|call|>", "<|return|>", "<|end|>"]}
+)
+```
+
+See the [OpenAI Harmony message format](https://cookbook.openai.com/articles/openai-harmony#message-format) for details on GPT-OSS stop tokens.
 </Tab>
 <Tab label="TypeScript">
 
 **Authentication Errors**
 
 If you encounter authentication errors, ensure your OpenAI API key is properly configured. Set the `OPENAI_API_KEY` environment variable or pass it via the `apiKey` parameter in the model configuration.
+
+**GPT-OSS Tool Calling Fails on Non-Managed Endpoints**
+
+If you are running GPT-OSS on an endpoint that isn't a managed inference provider and you see errors like `Unexpected token ... while expecting start token ...` during tool calling, your endpoint likely doesn't have the correct stop tokens configured.
+
+As an immediate workaround, pass the GPT-OSS stop sequences explicitly via `params`:
+
+```typescript
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+
+const model = new OpenAIModel({
+  api: 'chat',
+  apiKey: '<KEY>',
+  clientConfig: {
+    baseURL: 'http://localhost:8000/v1',
+  },
+  modelId: '<MODEL_ID>',
+  params: { stop: ['<|call|>', '<|return|>', '<|end|>'] },
+})
+```
+
+See the [OpenAI Harmony message format](https://cookbook.openai.com/articles/openai-harmony#message-format) for details on GPT-OSS stop tokens.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Description

 Adds a troubleshooting entry to the OpenAI provider docs for GPT-OSS tool calling failures on non-managed endpoints. When the endpoint doesn't have the correct stop tokens configured, tool calling fails with `Unexpected token ... while expecting start token ...`. The workaround is to pass the stop sequences explicitly via `params`.

## Related Issues

Addresses https://github.com/strands-agents/sdk-python/issues/1949

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
