### PR TITLE
docs: add Ollama example to Vercel TS provider page

### DIFF
--- a/src/content/docs/user-guide/concepts/model-providers/vercel.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/vercel.mdx
@@ -28,6 +28,12 @@ npm install @strands-agents/sdk @ai-sdk/google
 
 The `@ai-sdk/provider` package (which defines the `LanguageModelV3` interface) is listed as an optional peer dependency of `@strands-agents/sdk` and will be installed automatically with any `@ai-sdk/*` provider.
 
+For community providers like Ollama, install the community package directly:
+
+```bash
+npm install @strands-agents/sdk ai-sdk-ollama
+```
+
 ## Usage
 
 Create a `LanguageModelV3` instance from any Vercel provider and wrap it with `VercelModel`:
@@ -55,6 +61,18 @@ Create a `LanguageModelV3` instance from any Vercel provider and wrap it with `V
 ```typescript
 --8<-- "user-guide/concepts/model-providers/vercel.ts:basic_usage_google"
 ```
+
+### Ollama
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/vercel.ts:basic_usage_ollama"
+```
+
+:::note
+Ollama must be [installed](https://ollama.com/download) and running locally with your desired model pulled (e.g., `ollama pull llama3.1`).
+
+The [Vercel AI SDK recommends two community Ollama providers](https://ai-sdk.dev/providers/community-providers/ollama): `ollama-ai-provider-v2` as a basic option for simple text generation, and `ai-sdk-ollama` as a more advanced option with reliable tool calling and guaranteed complete responses. We choose `ai-sdk-ollama` to ensure Strands agents can fully leverage tool calling and operate without limitations.
+:::
 
 ## Configuration
 
@@ -98,7 +116,9 @@ The `VercelModel` adapter handles:
 
 ## Compatible providers
 
-Any package that implements the `LanguageModelV3` interface works with `VercelModel`. This includes all [official Vercel AI SDK providers](https://sdk.vercel.ai/docs/foundations/providers-and-models) and community providers:
+Any package that implements the `LanguageModelV3` interface works with `VercelModel`. This includes both official Vercel AI SDK providers and community providers.
+
+### [Official providers](https://sdk.vercel.ai/docs/foundations/providers-and-models)
 
 | Provider | Package |
 |----------|---------|
@@ -114,7 +134,11 @@ Any package that implements the `LanguageModelV3` interface works with `VercelMo
 | DeepSeek | `@ai-sdk/deepseek` |
 | Groq | `@ai-sdk/groq` |
 
-See the [Vercel AI SDK providers page](https://sdk.vercel.ai/docs/foundations/providers-and-models) for the full list.
+### [Community providers](https://ai-sdk.dev/providers/community-providers)
+
+| Provider | Package |
+|----------|---------|
+| Ollama | `ai-sdk-ollama` |
 
 ## Troubleshooting
 

--- a/src/content/docs/user-guide/concepts/model-providers/vercel.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/vercel.ts
@@ -9,6 +9,7 @@ import { bedrock } from '@ai-sdk/amazon-bedrock'
 import { openai } from '@ai-sdk/openai'
 import { anthropic } from '@ai-sdk/anthropic'
 import { google } from '@ai-sdk/google'
+import { ollama } from 'ai-sdk-ollama'
 
 // Basic usage with OpenAI
 async function basicUsageOpenAI() {
@@ -74,6 +75,22 @@ async function basicUsageGoogle() {
   const result = await agent.invoke('Hello!')
   console.log(result)
   // --8<-- [end:basic_usage_google]
+}
+
+// Basic usage with Ollama
+async function basicUsageOllama() {
+  // --8<-- [start:basic_usage_ollama]
+  import { Agent } from '@strands-agents/sdk'
+  import { VercelModel } from '@strands-agents/sdk/models/vercel'
+  import { ollama } from 'ai-sdk-ollama'
+
+  const agent = new Agent({
+    model: new VercelModel({ provider: ollama('llama3.1') }),
+  })
+
+  const result = await agent.invoke('Hello!')
+  console.log(result)
+  // --8<-- [end:basic_usage_ollama]
 }
 
 // Configuration example


### PR DESCRIPTION
## Description

Document how to use Ollama with VercelModel via the ai-sdk-ollama community provider package. Adds install command, usage example, prerequisite note, and compatible providers table entry.

## Related Issues

Addresses https://github.com/strands-agents/sdk-typescript/issues/780

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
