### PR TITLE
docs(plugin): add tool result offload plugin

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -72,6 +72,7 @@ sidebar:
               - docs/user-guide/concepts/plugins
               - docs/user-guide/concepts/plugins/skills
               - docs/user-guide/concepts/plugins/steering
+              - docs/user-guide/concepts/plugins/context-offloader
           - label: Model Providers
             items:
               - docs/user-guide/concepts/model-providers

--- a/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -94,7 +94,7 @@ Key features of the `SlidingWindowConversationManager`:
 - **Maintains Window Size**: Automatically removes messages from the window if the number of messages exceeds the limit.
 - **Dangling Message Cleanup**: Removes incomplete message sequences to maintain valid conversation state.
 - **Overflow Trimming**: In the case of a context window overflow, it will trim the oldest messages from history until the request fits in the models context window.
-- **Configurable Tool Result Truncation**: Enable / disable truncation of tool results when the message exceeds context window limits. When `should_truncate_results=True` (default), large results are truncated with a placeholder message. When `False`, full results are preserved but more historical messages may be removed.
+- **Configurable Tool Result Truncation**: Enable / disable truncation of tool results when the message exceeds context window limits. When `should_truncate_results=True` (default), large results are truncated with a placeholder message. When `False`, full results are preserved but more historical messages may be removed. For a proactive alternative that preserves full content externally, see the [Context Offloader](../plugins/context-offloader) plugin.
 - **Per-Turn Management**: Optionally apply context management proactively during the agent loop execution, not just at the end.
 
 **Per-Turn Management**:

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -19,10 +19,12 @@ The default [`SlidingWindowConversationManager`](../agents/conversation-manageme
 
 ## How It Works
 
-After each tool call, the plugin checks the result size against the `max_result_chars` threshold (default: 10,000 characters). If the result exceeds it, the plugin:
+After each tool call, the plugin estimates the result's token count using the agent's `model.count_tokens()` method and compares it against the `max_result_tokens` threshold (default: 2,500 tokens). If the result exceeds it, the plugin:
 
 1. Stores each content block individually in the configured storage backend, preserving its content type
-2. Replaces the in-context result with the first `preview_chars` characters (default: 4,000) plus per-block storage references
+2. Replaces the in-context result with the first `preview_tokens` tokens (default: 1,000) plus per-block storage references
+
+Token estimation uses tiktoken when available for accurate counts, falling back to a chars/4 heuristic. Preview slicing also uses tiktoken for exact token-level cuts when available.
 
 Results under the threshold pass through unchanged.
 
@@ -32,7 +34,7 @@ For a tool that returns 150KB of JSON, the agent would see something like:
 
 ```
 {"users": [{"id": 1, "name": "Alice", ...}, {"id": 2, "name": "Bob", ...},
-... (first 4,000 characters of the result) ...
+... (first ~1,000 tokens of the result) ...
 
 [Full content offloaded to storage - reference: a1b2c3d4]
 ```
@@ -41,7 +43,7 @@ For non-text content, the plugin replaces the result with a descriptive placehol
 
 | Content Type | What the agent sees |
 |-------------|----------|
-| Text / JSON | First `preview_chars` characters + storage reference |
+| Text / JSON | First `preview_tokens` tokens + storage reference |
 | Image | `[image: format, N bytes]` placeholder + storage reference |
 | Document | `[document: format, name, N bytes]` placeholder + storage reference |
 
@@ -67,14 +69,14 @@ agent = Agent(plugins=[
 ])
 ```
 
-To customize the size thresholds:
+To customize the token thresholds:
 
 ```python
 agent = Agent(plugins=[
     ContextOffloader(
         storage=InMemoryStorage(),
-        max_result_chars=20_000,
-        preview_chars=8_000,
+        max_result_tokens=5_000,
+        preview_tokens=2_000,
     )
 ])
 ```
@@ -129,11 +131,11 @@ agent = Agent(plugins=[
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `storage` | *(required)* | Storage backend instance |
-| `max_result_chars` | `10_000` | Results exceeding this character count are offloaded |
-| `preview_chars` | `4_000` | Number of characters to keep as an in-context preview |
+| `max_result_tokens` | `2_500` | Results whose estimated token count exceeds this are offloaded |
+| `preview_tokens` | `1_000` | Number of tokens to keep as an in-context preview |
 
 ## Tradeoffs
 
-- **Preview vs. full content**: The agent reasons over the preview, not the full result. If the answer is buried deep in a large result, the agent may miss it. Tune `preview_chars` to balance context usage against information loss for your use case. The built-in retrieval tool lets the agent fetch the full content when needed, but each retrieval is an extra tool call.
+- **Preview vs. full content**: The agent reasons over the preview, not the full result. If the answer is buried deep in a large result, the agent may miss it. Tune `preview_tokens` to balance context usage against information loss for your use case. The built-in retrieval tool lets the agent fetch the full content when needed, but each retrieval is an extra tool call.
 - **Storage costs**: `S3Storage` incurs S3 PUT/GET and storage charges. `FileStorage` writes to disk on every large result.
 - **Not a replacement for conversation management**: This plugin handles individual large results. You still need a conversation manager like `SlidingWindowConversationManager` to handle overall context growth across many turns.

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -1,0 +1,139 @@
+---
+title: Context Offloader
+languages: [python]
+sidebar:
+  badge:
+    text: New
+    variant: tip
+---
+
+The `ContextOffloader` plugin prevents large tool results from consuming your agent's context window. When a tool returns a result that exceeds a configurable size threshold, the plugin stores each content block individually in an external storage backend and replaces it in the conversation with a truncated preview plus per-block references. The agent keeps working with a useful summary, and can retrieve the full content on demand using the built-in `retrieve_offloaded_content` tool.
+
+## The Problem
+
+Tools like file readers, API clients, and database queries can return results that are tens or hundreds of thousands of characters long. When these large results enter the conversation, they crowd out other context and can exceed the model's token limits.
+
+The default [`SlidingWindowConversationManager`](../agents/conversation-management) handles this reactively — after the context overflows, it truncates tool results to the first and last 200 characters. This works as a safety net, but the truncation is lossy (the middle content is gone permanently) and happens after a failed API call has already been wasted.
+
+`ContextOffloader` takes a proactive approach: it intercepts results at tool execution time, **before** they enter the conversation, so the overflow never happens in the first place.
+
+## How It Works
+
+After each tool call, the plugin checks the result size against the `max_result_chars` threshold (default: 10,000 characters). If the result exceeds it, the plugin:
+
+1. Stores each content block individually in the configured storage backend, preserving its content type
+2. Replaces the in-context result with the first `preview_chars` characters (default: 4,000) plus per-block storage references
+
+Results under the threshold pass through unchanged.
+
+### What the agent sees
+
+For a tool that returns 150KB of JSON, the agent would see something like:
+
+```
+{"users": [{"id": 1, "name": "Alice", ...}, {"id": 2, "name": "Bob", ...},
+... (first 4,000 characters of the result) ...
+
+[Full content offloaded to storage - reference: a1b2c3d4]
+```
+
+For non-text content, the plugin replaces the result with a descriptive placeholder plus a reference:
+
+| Content Type | What the agent sees |
+|-------------|----------|
+| Text / JSON | First `preview_chars` characters + storage reference |
+| Image | `[image: format, N bytes]` placeholder + storage reference |
+| Document | `[document: format, name, N bytes]` placeholder + storage reference |
+
+### Built-in retrieval
+
+The plugin automatically provides a `retrieve_offloaded_content` tool and injects system prompt guidance telling the agent to prefer the preview when possible, and only retrieve the full content when the preview is insufficient. When the agent does retrieve, content is returned in its native format — text as a string, JSON as a JSON block, images as image blocks, and documents as document blocks.
+
+No additional configuration is needed. The retrieval tool, system prompt guidance, and storage are all handled by the plugin.
+
+## Getting Started
+
+Pass a `ContextOffloader` instance to your agent's `plugins` list with your choice of storage backend:
+
+```python
+from strands import Agent
+from strands.vended_plugins.context_offloader import (
+    ContextOffloader,
+    InMemoryStorage,
+)
+
+agent = Agent(plugins=[
+    ContextOffloader(storage=InMemoryStorage())
+])
+```
+
+To customize the size thresholds:
+
+```python
+agent = Agent(plugins=[
+    ContextOffloader(
+        storage=InMemoryStorage(),
+        max_result_chars=20_000,
+        preview_chars=8_000,
+    )
+])
+```
+
+### Storage Backends
+
+Choose a storage backend based on your needs:
+
+| Backend | Persistence | Best for |
+|---------|-------------|----------|
+| `InMemoryStorage` | Process lifetime only | Development, testing, reducing context without side effects |
+| `FileStorage` | Disk | Local development, debugging, inspecting stored artifacts |
+| `S3Storage` | Amazon S3 | Production workloads, shared or durable artifact retention |
+
+All backends implement the `OffloadStorage` protocol and preserve content type metadata, so you can also build your own.
+
+**File storage** — persists to a local directory with `.metadata.json` sidecars for content type tracking:
+
+```python
+from strands.vended_plugins.context_offloader import (
+    ContextOffloader,
+    FileStorage,
+)
+
+agent = Agent(plugins=[
+    ContextOffloader(
+        storage=FileStorage("./artifacts"),
+    )
+])
+```
+
+**S3 storage** — persists to an Amazon S3 bucket with content type preserved via S3 object metadata:
+
+```python
+from strands.vended_plugins.context_offloader import (
+    ContextOffloader,
+    S3Storage,
+)
+
+agent = Agent(plugins=[
+    ContextOffloader(
+        storage=S3Storage(
+            bucket="my-agent-artifacts",
+            prefix="tool-results/",
+        ),
+    )
+])
+```
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `storage` | *(required)* | Storage backend instance |
+| `max_result_chars` | `10_000` | Results exceeding this character count are offloaded |
+| `preview_chars` | `4_000` | Number of characters to keep as an in-context preview |
+
+## Tradeoffs
+
+- **Preview vs. full content**: The agent reasons over the preview, not the full result. If the answer is buried deep in a large result, the agent may miss it. Tune `preview_chars` to balance context usage against information loss for your use case. The built-in retrieval tool lets the agent fetch the full content when needed, but each retrieval is an extra tool call.
+- **Storage costs**: `S3Storage` incurs S3 PUT/GET and storage charges. `FileStorage` writes to disk on every large result.
+- **Not a replacement for conversation management**: This plugin handles individual large results. You still need a conversation manager like `SlidingWindowConversationManager` to handle overall context growth across many turns.

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -85,7 +85,7 @@ Choose a storage backend based on your needs:
 
 | Backend | Persistence | Best for |
 |---------|-------------|----------|
-| `InMemoryStorage` | Process lifetime only | Development, testing, reducing context without side effects |
+| `InMemoryStorage` | Process lifetime only (call `clear()` to free manually) | Development, testing, reducing context without side effects |
 | `FileStorage` | Disk | Local development, debugging, inspecting stored artifacts |
 | `S3Storage` | Amazon S3 | Production workloads, shared or durable artifact retention |
 

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -7,7 +7,7 @@ sidebar:
     variant: tip
 ---
 
-The `ContextOffloader` plugin prevents large tool results from consuming your agent's context window. When a tool returns a result that exceeds a configurable size threshold, the plugin stores each content block individually in an external storage backend and replaces it in the conversation with a truncated preview plus per-block references. The agent keeps working with a useful summary, and can retrieve the full content on demand using the built-in `retrieve_offloaded_content` tool.
+The `ContextOffloader` plugin prevents large tool results from consuming your agent's context window. When a tool returns a result that exceeds a configurable token threshold, the plugin stores each content block individually in an external storage backend and replaces it in the conversation with a truncated preview plus per-block references. Each offloaded result includes inline guidance telling the agent to use its available tools to selectively access the data it needs.
 
 ## The Problem
 
@@ -47,11 +47,20 @@ For non-text content, the plugin replaces the result with a descriptive placehol
 | Image | `[image: format, N bytes]` placeholder + storage reference |
 | Document | `[document: format, name, N bytes]` placeholder + storage reference |
 
-### Built-in retrieval
+### Retrieval tool (opt-in)
 
-The plugin automatically provides a `retrieve_offloaded_content` tool and injects system prompt guidance telling the agent to prefer the preview when possible, and only retrieve the full content when the preview is insufficient. When the agent does retrieve, content is returned in its native format — text as a string, JSON as a JSON block, images as image blocks, and documents as document blocks.
+The plugin includes an optional `retrieve_offloaded_content` tool that lets the agent fetch offloaded content by reference, returning it in its native format — text as a string, JSON as a JSON block, images as image blocks, and documents as document blocks. Enable it with `include_retrieval_tool=True`:
 
-No additional configuration is needed. The retrieval tool, system prompt guidance, and storage are all handled by the plugin.
+```python
+agent = Agent(plugins=[
+    ContextOffloader(
+        storage=InMemoryStorage(),
+        include_retrieval_tool=True,
+    )
+])
+```
+
+The retrieval tool is disabled by default. The inline guidance in offloaded results always tells the agent to use its available tools to selectively access the data it needs. When the retrieval tool is enabled, the guidance additionally mentions `retrieve_offloaded_content`.
 
 ## Getting Started
 
@@ -122,6 +131,7 @@ agent = Agent(plugins=[
             bucket="my-agent-artifacts",
             prefix="tool-results/",
         ),
+        include_retrieval_tool=True,
     )
 ])
 ```
@@ -133,9 +143,10 @@ agent = Agent(plugins=[
 | `storage` | *(required)* | Storage backend instance |
 | `max_result_tokens` | `2_500` | Results whose estimated token count exceeds this are offloaded |
 | `preview_tokens` | `1_000` | Number of tokens to keep as an in-context preview |
+| `include_retrieval_tool` | `False` | When `True`, registers a `retrieve_offloaded_content` tool the agent can use to fetch full content by reference |
 
 ## Tradeoffs
 
-- **Preview vs. full content**: The agent reasons over the preview, not the full result. If the answer is buried deep in a large result, the agent may miss it. Tune `preview_tokens` to balance context usage against information loss for your use case. The built-in retrieval tool lets the agent fetch the full content when needed, but each retrieval is an extra tool call.
+- **Preview vs. full content**: The agent reasons over the preview, not the full result. If the answer is buried deep in a large result, the agent may miss it. Tune `preview_tokens` to balance context usage against information loss for your use case. Enable `include_retrieval_tool=True` if the agent needs to fetch full offloaded content and doesn't have other tools (file readers, shell, etc.) that can access the storage backend directly.
 - **Storage costs**: `S3Storage` incurs S3 PUT/GET and storage charges. `FileStorage` writes to disk on every large result.
 - **Not a replacement for conversation management**: This plugin handles individual large results. You still need a conversation manager like `SlidingWindowConversationManager` to handle overall context growth across many turns.

--- a/src/content/docs/user-guide/concepts/plugins/index.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/index.mdx
@@ -9,6 +9,7 @@ The Strands SDK provides built-in plugins that you can use out of the box:
 
 - **[Skills](./skills.mdx)** - On-demand, modular instructions that agents discover and activate at runtime following the [Agent Skills specification](https://agentskills.io/specification)
 - **[Steering](./steering)** - Modular prompting for complex agent tasks through context-aware guidance
+- **[Context Offloader](./context-offloader)** - Proactively offloads oversized tool results to storage, replacing them with previews and providing a built-in retrieval tool
 
 You can also build and distribute your own plugins to extend agent functionality. See [Get Featured](/docs/community/get-featured) to share your plugins with the community.
 
@@ -299,4 +300,5 @@ class AsyncConfigPlugin(Plugin):
 
 - [Hooks](../agents/hooks.mdx) - Learn about the underlying hook system
 - [Steering](./steering) - Explore the built-in steering plugin
+- [Context Offloader](./context-offloader) - Manage large tool results proactively
 - [Get Featured](/docs/community/get-featured) - Share your plugins with the community


### PR DESCRIPTION


## Description

Adds documentation for the new `ToolResultExternalizer` plugin (from [strands-agents/sdk-python#2162](https://github.com/strands-agents/sdk-python/pull/2162)).

This plugin proactively intercepts oversized tool results at execution time, stores the full content in a pluggable storage backend, and replaces the in-context result with a configurable truncated preview — preventing context window overflow without permanently losing data.

**Changes:**
- New page: `docs/user-guide/concepts/plugins/result-externalizer.mdx` covering the problem, how the plugin works, getting started with all three storage backends (InMemory, File, S3), configuration, and tradeoffs
- Added sidebar entry in `navigation.yml`
- Added plugin to the built-in plugins list and Next Steps on the Plugins index page
- Added cross-reference from the Conversation Management page's tool result truncation section

## Related Issues

strands-agents/sdk-python#2162
strands-agents/sdk-python#1296

## Type of Change

- New content

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.