### PR TITLE
docs: update AgentSkills page to include TS

### DIFF
--- a/src/content/docs/user-guide/concepts/plugins/skills.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/skills.mdx
@@ -61,11 +61,11 @@ The injected system prompt metadata looks like this:
 </available_skills>
 ```
 
-This XML block is refreshed before each invocation, so changes to available skills (through `set_available_skills`) take effect immediately. Activated skills are tracked in [agent state](../agents/state.mdx) for session persistence.
+This XML block is refreshed before each invocation, so changes to available skills (through `set_available_skills` / `setAvailableSkills`) take effect immediately. Activated skills are tracked in [agent state](../agents/state.mdx) for session persistence.
 
 ## Usage
 
-The `AgentSkills` plugin accepts skill sources in several forms — filesystem paths, parent directories, or programmatic `Skill` instances. You can pass a single source or a list.
+The `AgentSkills` plugin accepts skill sources in several forms — filesystem paths, parent directories, HTTPS URLs, or programmatic `Skill` instances. In Python you can pass a single source or a list; in TypeScript the `skills` parameter is always an array.
 
 <Tabs>
 <Tab label="Python">
@@ -95,8 +95,10 @@ agent = Agent(plugins=[plugin])
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Skills are not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/plugins/skills_imports.ts:usage"
+
+--8<-- "user-guide/concepts/plugins/skills.ts:usage"
 ```
 </Tab>
 </Tabs>
@@ -107,10 +109,10 @@ The `AgentSkills` plugin handles only skill discovery and activation. It does no
 
 When a skill is activated, the tool response includes a listing of available resource files (from `scripts/`, `references/`, and `assets/` subdirectories), but to actually read those files or run scripts, you provide your own tools. This gives you full control over what the agent can access.
 
-For filesystem-based skills, `file_read` and `shell` from `strands-agents-tools` are the easiest way to get started:
-
 <Tabs>
 <Tab label="Python">
+
+For filesystem-based skills, `file_read` and `shell` from `strands-agents-tools` are the easiest way to get started:
 
 ```python
 from strands import Agent, AgentSkills
@@ -126,17 +128,21 @@ agent = Agent(
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Skills are not yet available in TypeScript SDK
+For filesystem-based skills, the vended `bash` and `fileEditor` tools are the easiest way to get started:
+
+```typescript
+--8<-- "user-guide/concepts/plugins/skills_imports.ts:tools"
+
+--8<-- "user-guide/concepts/plugins/skills.ts:tools"
 ```
 </Tab>
 </Tabs>
 
-You can also use other tools depending on your environment. For example, `http_request` for skills with remote resources, or the AgentCore code interpreter tool for executing scripts in a sandboxed environment. Choose tools that match your skill's resource access patterns and your security requirements.
+You can also use other tools depending on your environment. For example, an HTTP request tool for skills with remote resources, or a code interpreter tool for executing scripts in a sandboxed environment. Choose tools that match your skill's resource access patterns and your security requirements.
 
 ### Programmatic skill creation
 
-Use the `Skill` dataclass to create skills in code without filesystem directories:
+Use the `Skill` class to create skills in code without filesystem directories:
 
 <Tabs>
 <Tab label="Python">
@@ -168,8 +174,10 @@ skills = Skill.from_directory("./skills/")
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Skills are not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/plugins/skills_imports.ts:programmatic"
+
+--8<-- "user-guide/concepts/plugins/skills.ts:programmatic"
 ```
 </Tab>
 </Tabs>
@@ -211,8 +219,10 @@ print(f"Activated skills: {activated}")
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Skills are not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/plugins/skills_imports.ts:runtime"
+
+--8<-- "user-guide/concepts/plugins/skills.ts:runtime"
 ```
 </Tab>
 </Tabs>
@@ -252,7 +262,7 @@ The `allowed-tools` field is currently informational. When a skill is activated,
 :::
 
 :::note[Name validation]
-Skill names must match the parent directory name. By default, validation issues produce warnings rather than errors. Pass `strict=True` to raise exceptions instead.
+Skill names must match the parent directory name. By default, validation issues produce warnings rather than errors. Pass `strict=True` (Python) or `strict: true` (TypeScript) to raise exceptions instead.
 :::
 
 ### Resource directories
@@ -276,14 +286,30 @@ When the agent activates a skill, the tool response includes a listing of all re
 
 The `AgentSkills` constructor accepts the following parameters.
 
+<Tabs>
+<Tab label="Python">
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `skills` | `SkillSources` | Required | One or more skill sources (paths, `Skill` instances, or a mix). |
+| `skills` | `SkillSources` | Required | One or more skill sources (paths, HTTPS URLs, `Skill` instances, or a mix). Accepts a single value or a list. |
 | `state_key` | `str` | `"agent_skills"` | Key for storing plugin state in `agent.state`. |
 | `max_resource_files` | `int` | `20` | Maximum number of resource files listed in skill activation responses. |
 | `strict` | `bool` | `False` | If `True`, raise exceptions on validation issues instead of logging warnings. |
 
-Activated skills are tracked in [agent state](../agents/state.mdx) under the configured `state_key`. This means activated skills persist across invocations within the same session and can be serialized for [session management](../agents/session-management.mdx).
+</Tab>
+<Tab label="TypeScript">
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `skills` | `SkillSource[]` | Required | Array of skill sources (paths, `Skill` instances, or HTTPS URLs). |
+| `stateKey` | `string` | `'agent_skills'` | Key for storing plugin state in `agent.appState`. |
+| `maxResourceFiles` | `number` | `20` | Maximum number of resource files listed in skill activation responses. |
+| `strict` | `boolean` | `false` | If `true`, throw on validation issues instead of logging warnings. |
+
+</Tab>
+</Tabs>
+
+Activated skills are tracked in [agent state](../agents/state.mdx) under the configured state key. This means activated skills persist across invocations within the same session and can be serialized for [session management](../agents/session-management.mdx).
 
 ## Comparison with other approaches
 

--- a/src/content/docs/user-guide/concepts/plugins/skills.ts
+++ b/src/content/docs/user-guide/concepts/plugins/skills.ts
@@ -1,0 +1,138 @@
+import { Agent } from '@strands-agents/sdk'
+import { AgentSkills, Skill } from '@strands-agents/sdk/vended-plugins/skills'
+import { bash } from '@strands-agents/sdk/vended-tools/bash'
+import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+
+declare const model: any
+
+// =====================
+// Usage Example
+// =====================
+
+{
+  // --8<-- [start:usage]
+  // Single skill directory
+  const plugin = new AgentSkills({
+    skills: ['./skills/pdf-processing'],
+  })
+
+  // Parent directory — loads all child directories
+  // containing SKILL.md
+  const pluginFromDir = new AgentSkills({
+    skills: ['./skills/'],
+  })
+
+  // Mixed sources
+  const pluginMixed = new AgentSkills({
+    skills: [
+      './skills/pdf-processing',
+      './skills/',
+      new Skill({
+        name: 'custom-greeting',
+        description: 'Generate custom greetings',
+        instructions: 'Always greet the user by name with enthusiasm.',
+      }),
+    ],
+  })
+
+  const agent = new Agent({
+    model,
+    plugins: [pluginMixed],
+  })
+  // --8<-- [end:usage]
+
+  void plugin
+  void pluginFromDir
+  void agent
+}
+
+// =====================
+// Tools for Resource Access
+// =====================
+
+{
+  // --8<-- [start:tools]
+  const plugin = new AgentSkills({
+    skills: ['./skills/'],
+  })
+
+  const agent = new Agent({
+    model,
+    plugins: [plugin],
+    tools: [bash, fileEditor],
+  })
+  // --8<-- [end:tools]
+
+  void agent
+}
+
+// =====================
+// Programmatic Skill Creation
+// =====================
+
+{
+  // --8<-- [start:programmatic]
+  // Create directly
+  const skill = new Skill({
+    name: 'code-review',
+    description: 'Review code for best practices and bugs',
+    instructions: 'Review the provided code. Check for...',
+  })
+
+  // Parse from SKILL.md content
+  const parsed = Skill.fromContent(
+    '---\n' +
+      'name: code-review\n' +
+      'description: Review code for best practices\n' +
+      '---\n' +
+      'Review the provided code. Check for...\n'
+  )
+
+  // Load from a specific directory
+  const loaded = Skill.fromFile('./skills/code-review')
+
+  // Load all skills from a parent directory
+  const skills = Skill.fromDirectory('./skills/')
+  // --8<-- [end:programmatic]
+
+  void skill
+  void parsed
+  void loaded
+  void skills
+}
+
+// =====================
+// Managing Skills at Runtime
+// =====================
+
+async function runtimeExample() {
+  // --8<-- [start:runtime]
+  const plugin = new AgentSkills({
+    skills: ['./skills/pdf-processing'],
+  })
+  const agent = new Agent({ model, plugins: [plugin] })
+
+  // View available skills
+  const available = await plugin.getAvailableSkills()
+  for (const skill of available) {
+    console.log(`${skill.name}: ${skill.description}`)
+  }
+
+  // Add a new skill at runtime
+  const newSkill = new Skill({
+    name: 'summarize',
+    description: 'Summarize long documents',
+    instructions: 'Read the document and produce a concise summary...',
+  })
+  plugin.setAvailableSkills([...available, newSkill])
+
+  // Replace all skills
+  plugin.setAvailableSkills(['./skills/new-set/'])
+
+  // Check which skills the agent has activated
+  const activated = plugin.getActivatedSkills(agent)
+  console.log(`Activated skills: ${activated}`)
+  // --8<-- [end:runtime]
+}
+
+void runtimeExample

--- a/src/content/docs/user-guide/concepts/plugins/skills_imports.ts
+++ b/src/content/docs/user-guide/concepts/plugins/skills_imports.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+// Import snippets — intentionally repeat imports across blocks so each
+// rendered doc example is self-contained.
+
+// --8<-- [start:usage]
+import { Agent } from '@strands-agents/sdk'
+import { AgentSkills, Skill } from '@strands-agents/sdk/vended-plugins/skills'
+// --8<-- [end:usage]
+
+// --8<-- [start:tools]
+import { Agent } from '@strands-agents/sdk'
+import { AgentSkills } from '@strands-agents/sdk/vended-plugins/skills'
+import { bash } from '@strands-agents/sdk/vended-tools/bash'
+import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+// --8<-- [end:tools]
+
+// --8<-- [start:programmatic]
+import { Skill } from '@strands-agents/sdk/vended-plugins/skills'
+// --8<-- [end:programmatic]
+
+// --8<-- [start:runtime]
+import { Agent } from '@strands-agents/sdk'
+import { AgentSkills, Skill } from '@strands-agents/sdk/vended-plugins/skills'
+// --8<-- [end:runtime]

--- a/src/content/docs/user-guide/concepts/streaming/overview.ts
+++ b/src/content/docs/user-guide/concepts/streaming/overview.ts
@@ -136,7 +136,9 @@ async function eventSerializationExample() {
           event.event.type === 'modelContentBlockDeltaEvent' &&
           event.event.delta.type === 'textDelta'
         ) {
-          console.log(`data: ${JSON.stringify({ type: 'text', text: event.event.delta.text })}`)
+          console.log(
+            `data: ${JSON.stringify({ type: 'text', text: event.event.delta.text })}`
+          )
         }
         break
 


### PR DESCRIPTION
## Description

Add `AgentSkills` for TS

## Related Issues

https://github.com/strands-agents/sdk-typescript/issues/774

## Type of Change

- New content

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
