### PR TITLE
fix: remove node modules from ts sdk build to resolve ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run typecheck
 
       - name: Build TypeScript SDK
-        run: npm install --ignore-scripts && npm run build
+        run: npm install --ignore-scripts && npm run build && rm -rf node_modules
         working-directory: .build/sdk-typescript
 
       - name: Re-link SDK types


### PR DESCRIPTION


## Description

Fixes the `typecheck:snippets` CI failure caused by duplicate `@aws-sdk/client-s3` type declarations. The SDK build step (`npm install` in `.build/sdk-typescript`) creates its own `node_modules` with a separate copy of `@aws-sdk/client-s3`. When `session-manager.ts` passes an `S3Client` from the root installation to `S3Storage` from the SDK's copy, TypeScript rejects it because the private `handlers` property comes from two separate declarations.

The fix removes `.build/sdk-typescript/node_modules` after the SDK is compiled. The built `.d.ts` files are already generated and the subsequent `npm install` at root re-links the SDK, so the SDK's `node_modules` are no longer needed. This ensures only one copy of `@aws-sdk/client-s3` exists during typechecking.


See CI failure in https://github.com/strands-agents/docs/pull/772 for example:
```
Error: ../src/content/docs/user-guide/concepts/agents/session-manager.ts(70,9): error TS2322: Type 'import("/home/runner/work/docs/docs/node_modules/@aws-sdk/client-s3/dist-types/S3Client").S3Client' is not assignable to type 'import("/home/runner/work/docs/docs/.build/sdk-typescript/node_modules/@aws-sdk/client-s3/dist-types/S3Client").S3Client'.
```

## Related Issues

N/A — pre-existing CI failure introduced when the TypeScript SDK was restructured into a monorepo.

## Type of Change

- Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.