### PR TITLE
docs: add OpenSearch as trace provider and export destination

### DIFF
--- a/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
+++ b/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
@@ -175,7 +175,7 @@ for report in reports:
     print(f"{report.overall_score:.2f} - {report.reasons}")
 ```
 
-The same pattern works with `LangfuseProvider` — just swap the provider initialization.
+The same pattern works with `LangfuseProvider` or `OpenSearchProvider` — just swap the provider initialization.
 
 ## Error Handling
 

--- a/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
+++ b/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
@@ -98,10 +98,6 @@ provider = LangfuseProvider(
 
 The `OpenSearchProvider` retrieves agent traces from OpenSearch using [opensearch-genai-observability-sdk-py](https://github.com/opensearch-project/genai-observability-sdk-py). It works with both self-hosted OpenSearch clusters and Amazon OpenSearch Service.
 
-:::note[Sending traces to OpenSearch]
-[OpenSearch](https://opensearch.org/) can store and visualize OpenTelemetry traces sent via OTLP. For setup instructions covering self-managed and managed deployments, see the [OpenSearch Observability — Send Data](https://observability.opensearch.org/docs/send-data/) guide or jump straight to [Ingest Your First Traces](https://observability.opensearch.org/docs/get-started/quickstart/first-traces/).
-:::
-
 ### Setup
 
 ```python
@@ -125,6 +121,10 @@ provider = OpenSearchProvider(
     auth=auth,
 )
 ```
+
+:::note[Sending traces to OpenSearch]
+[OpenSearch](https://opensearch.org/) can store and visualize OpenTelemetry traces sent via OTLP. For setup instructions covering self-managed and managed deployments, see the [OpenSearch Observability — Send Data](https://observability.opensearch.org/docs/send-data/) guide or jump straight to [Ingest Your First Traces](https://observability.opensearch.org/docs/get-started/quickstart/first-traces/).
+:::
 
 ### Configuration
 

--- a/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
+++ b/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
@@ -10,6 +10,7 @@ Trace providers fetch agent execution data from observability backends and conve
 |----------|---------|------|
 | `CloudWatchProvider` | AWS CloudWatch Logs (Bedrock AgentCore runtime logs) | AWS credentials (boto3) |
 | `LangfuseProvider` | Langfuse | API keys |
+| `OpenSearchProvider` | OpenSearch (self-hosted or Amazon OpenSearch Service) | Basic auth or SigV4 |
 
 ## Installation
 
@@ -23,6 +24,12 @@ For the Langfuse provider, install the optional `langfuse` extra:
 
 ```bash
 pip install strands-agents-evals[langfuse]
+```
+
+For the OpenSearch provider, install the optional `opensearch` extra:
+
+```bash
+pip install strands-agents-evals[opensearch]
 ```
 
 ## CloudWatch Provider
@@ -86,6 +93,43 @@ provider = LangfuseProvider(
 | `secret_key` | `LANGFUSE_SECRET_KEY` env var | Langfuse secret API key |
 | `host` | `LANGFUSE_HOST` env var or `https://us.cloud.langfuse.com` | Langfuse API host URL |
 | `timeout` | `120` | Request timeout in seconds |
+
+## OpenSearch Provider
+
+The `OpenSearchProvider` retrieves agent traces from OpenSearch using [opensearch-genai-observability-sdk-py](https://github.com/opensearch-project/genai-observability-sdk-py). It works with both self-hosted OpenSearch clusters and Amazon OpenSearch Service.
+
+### Setup
+
+```python
+from strands_evals.providers import OpenSearchProvider
+
+# Basic auth (self-hosted)
+provider = OpenSearchProvider(
+    host="https://localhost:9200",
+    auth=("admin", "password"),
+    verify_certs=False,
+)
+
+# SigV4 auth (Amazon OpenSearch Service)
+from opensearchpy import RequestsAWSV4SignerAuth
+import boto3
+
+credentials = boto3.Session().get_credentials()
+auth = RequestsAWSV4SignerAuth(credentials, "us-east-1", "es")
+provider = OpenSearchProvider(
+    host="https://my-domain.us-east-1.es.amazonaws.com",
+    auth=auth,
+)
+```
+
+### Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `host` | `https://localhost:9200` | OpenSearch endpoint URL |
+| `index` | `otel-v1-apm-span-*` | Index pattern for span documents |
+| `auth` | `None` | `(username, password)` tuple for basic auth, or `RequestsAWSV4SignerAuth` for SigV4 |
+| `verify_certs` | `True` | Whether to verify TLS certificates |
 
 ## Running Evaluations on Remote Traces
 

--- a/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
+++ b/src/content/docs/user-guide/evals-sdk/how-to/trace_providers.mdx
@@ -98,6 +98,10 @@ provider = LangfuseProvider(
 
 The `OpenSearchProvider` retrieves agent traces from OpenSearch using [opensearch-genai-observability-sdk-py](https://github.com/opensearch-project/genai-observability-sdk-py). It works with both self-hosted OpenSearch clusters and Amazon OpenSearch Service.
 
+:::note[Sending traces to OpenSearch]
+[OpenSearch](https://opensearch.org/) can store and visualize OpenTelemetry traces sent via OTLP. For setup instructions covering self-managed and managed deployments, see the [OpenSearch Observability — Send Data](https://observability.opensearch.org/docs/send-data/) guide or jump straight to [Ingest Your First Traces](https://observability.opensearch.org/docs/get-started/quickstart/first-traces/).
+:::
+
 ### Setup
 
 ```python

--- a/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -529,3 +529,9 @@ There are several ways to send traces, metrics, and logs to CloudWatch. Please v
 1. [AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter)
 2. [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html)
   - Please ensure Transaction Search is enabled in CloudWatch.
+
+## Sending traces to OpenSearch
+
+[OpenSearch](https://opensearch.org/) can store and visualize OpenTelemetry traces sent via OTLP. For setup instructions covering self-managed and managed deployments, see the [OpenSearch Observability — Send Data](https://observability.opensearch.org/docs/send-data/) guide or jump straight to [Ingest Your First Traces](https://observability.opensearch.org/docs/get-started/quickstart/first-traces/).
+
+Once traces are stored, you can retrieve them for evaluation using the `OpenSearchProvider`. See [Evaluating Remote Traces — OpenSearch Provider](../evals-sdk/how-to/trace_providers/#opensearch-provider) for setup and configuration.

--- a/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -529,9 +529,3 @@ There are several ways to send traces, metrics, and logs to CloudWatch. Please v
 1. [AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter)
 2. [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html)
   - Please ensure Transaction Search is enabled in CloudWatch.
-
-## Sending traces to OpenSearch
-
-[OpenSearch](https://opensearch.org/) can store and visualize OpenTelemetry traces sent via OTLP. For setup instructions covering self-managed and managed deployments, see the [OpenSearch Observability — Send Data](https://observability.opensearch.org/docs/send-data/) guide or jump straight to [Ingest Your First Traces](https://observability.opensearch.org/docs/get-started/quickstart/first-traces/).
-
-Once traces are stored, you can retrieve them for evaluation using the `OpenSearchProvider`. See [Evaluating Remote Traces — OpenSearch Provider](../evals-sdk/how-to/trace_providers/#opensearch-provider) for setup and configuration.


### PR DESCRIPTION
## What

Adds `OpenSearchProvider` documentation to the trace providers page and adds a "Sending traces to OpenSearch" section to the traces page.

## Why

`OpenSearchProvider` was merged into strands-agents/evals ([#192](https://github.com/strands-agents/evals/pull/192)) but the docs site only listed CloudWatch and Langfuse as available providers. Users had no way to discover OpenSearch support from the docs.

Similarly, the traces page documented sending traces to CloudWatch X-Ray but had no equivalent section for OpenSearch.

## Changes

**trace_providers.mdx:**
- Add `OpenSearchProvider` to the available providers table
- Add `pip install strands-agents-evals[opensearch]` install instructions
- Add OpenSearch Provider section with setup examples (basic auth + SigV4) and configuration table

**traces.mdx:**
- Add "Sending traces to OpenSearch" section after the existing CloudWatch X-Ray section
- Links to [observability.opensearch.org/docs/send-data/](https://observability.opensearch.org/docs/send-data/) for ingestion setup rather than prescribing a specific pipeline

## Testing

Built and verified locally with `npm run dev`. Both pages render correctly, links resolve, and the table of contents picks up the new sections.