### PR TITLE
feat: add before invocation and before model calls cancellation

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -357,6 +357,12 @@ Most event properties are read-only to prevent unintended modifications. However
 </Tab>
 <Tab label="TypeScript">
 
+- `BeforeInvocationEvent`
+    - `cancel` - Cancel the agent invocation with a message.
+
+- `BeforeModelCallEvent`
+    - `cancel` - Cancel the model call with a message.
+
 - `BeforeToolsEvent`
     - `cancel` - Cancel all tool calls in a batch with a message. See [Limit Tool Counts](#limit-tool-counts).
 

--- a/src/content/docs/user-guide/concepts/streaming/index.mdx
+++ b/src/content/docs/user-guide/concepts/streaming/index.mdx
@@ -36,10 +36,12 @@ All streaming methods yield the same set of events:
 Each event emitted from the TypeScript agent is a class with a `type` attribute that has a unique value. When determining an event, you can use `instanceof` on the class, or an equality check on the `event.type` value. All events extend `HookableEvent`, making them both streamable and subscribable via hook callbacks.
 
 - **`BeforeInvocationEvent`**: Start of agent loop (before any iterations)
+    - **`cancel`**: Set by hook callbacks to cancel the invocation (`boolean | string`)
 - **`AfterInvocationEvent`**: End of agent loop (after all iterations complete)
     - **`error?`**: Optional error if loop terminated due to exception
 - **`BeforeModelCallEvent`**: Before model invocation
     - **`messages`**: Array of messages being sent to model
+    - **`cancel`**: Set by hook callbacks to cancel the model call (`boolean | string`)
 - **`AfterModelCallEvent`**: After model invocation
     - **`message`**: Assistant message returned by model
     - **`stopReason`**: Why generation stopped


### PR DESCRIPTION
Adds `cancel` property documentation for `BeforeInvocationEvent` and `BeforeModelCallEvent` in the TypeScript SDK. These events now support cancellation via hooks, following the existing pattern on `BeforeToolCallEvent`, `BeforeToolsEvent`, and `BeforeNodeCallEvent`.

- **Event Properties table** (`hooks.mdx`): Added `cancel` entries for both events in the TypeScript tab.
- **Streaming event reference** (`streaming/index.mdx`): Added `cancel` property lines under both events.
- **Agent loop cancellation section** (`agent-loop.mdx`): Added a "Hook-based cancellation" paragraph in the TypeScript tab, noting that hooks can cancel at the invocation and model-call lifecycle stages via `BeforeInvocationEvent.cancel` and `BeforeModelCallEvent.cancel`, with a cross-reference to the Hooks Event Properties section.

## Related Issues

strands-agents/sdk-typescript#889

## Type of Change

- [x] Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working