### PR TITLE
feat: add /discord vanity redirect to Discord invite

### DIFF
--- a/src/util/redirect.ts
+++ b/src/util/redirect.ts
@@ -34,6 +34,12 @@ const SLUG_RULES: SlugRule[] = [
     to: 'docs/examples/python/multi_agent_example/multi_agent_example',
   },
 
+  // Vanity URLs for community links
+  {
+    match: exactly('discord'),
+    to: 'https://discord.gg/strands',
+  },
+
   // CDK and deployment examples now live on GitHub
   {
     match: exactly('docs/examples/cdk/deploy_to_apprunner'),

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -5,6 +5,8 @@ const redirectCases: Array<{ description: string; input: string; expected: strin
   // Renamed pages
   { description: 'python-tools renamed to custom-tools',   input: 'docs/user-guide/concepts/tools/python-tools',         expected: 'docs/user-guide/concepts/tools/custom-tools' },
   { description: 'multi_agent_example index -> main page', input: 'docs/examples/python/multi_agent_example',             expected: 'docs/examples/python/multi_agent_example/multi_agent_example' },
+  // Vanity URLs → external
+  { description: '/discord redirects to Discord invite', input: 'discord', expected: 'https://discord.gg/strands' },
   // No redirect
   { description: 'current page returns null',              input: 'docs/user-guide/concepts/agents/agent-loop',           expected: null },
   { description: 'unknown path returns null',              input: 'docs/some/unknown/path',                               expected: null },


### PR DESCRIPTION
## Description

Adds a `/discord` vanity URL that redirects to the Discord invite (`https://discord.gg/strands`). Uses the existing client-side redirect infrastructure in `Redirect404.astro` + `redirect.ts` — same pattern as the CDK/deployment example redirects to GitHub.

## Test plan

- [x] `vitest run test/redirect.test.ts` — 28/28 passing
- [x] Local dev server + browser verification — `/discord` lands on `discord.com/invite/strands`


## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
