### PR TITLE
fix: add missing invocationState to ToolContext in direct invocation example

### DIFF
--- a/src/content/docs/user-guide/concepts/tools/tools.ts
+++ b/src/content/docs/user-guide/concepts/tools/tools.ts
@@ -303,6 +303,7 @@ async function directInvocationExample() {
         input: { mode: 'read', name: 'default' },
       },
       agent: agent,
+      invocationState: {},
     }
   )
 


### PR DESCRIPTION
## Summary
- The `ToolContext` interface now requires `invocationState` property, seems related to https://github.com/strands-agents/docs/pull/785/changes/3456102b221f2694e96c31f6d003c4572249f02f?
- The direct invocation code example in the tools concept page was missing this property, causing CI typecheck failures ([example](https://github.com/strands-agents/docs/actions/runs/25078831568/job/73478598031?pr=793))
