### PR TITLE
fix: update sdk-typescript GitHub links for monorepo structure

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -329,7 +329,7 @@ See the [SlidingWindowConversationManager](https://github.com/strands-agents/sdk
 </Tab>
 <Tab label="TypeScript">
 
-To create a custom conversation manager, extend the abstract [`ConversationManager`](https://github.com/strands-agents/sdk-typescript/blob/main/src/conversation-manager/conversation-manager.ts) base class and implement the `reduce` method:
+To create a custom conversation manager, extend the abstract [`ConversationManager`](@api/typescript/ConversationManager) base class and implement the `reduce` method:
 
 1. **`reduce(options: ReduceOptions): boolean`**: Called automatically when a `ContextWindowOverflowError` occurs. Mutate `agent.messages` in place to reduce history, then return `true` if any reduction was made. Return `false` to let the error propagate out of the agent loop uncaught.
 
@@ -349,6 +349,6 @@ For proactive management alongside overflow recovery, override `initAgent`:
 --8<-- "user-guide/concepts/agents/conversation-management.ts:custom_conversation_manager_proactive"
 ```
 
-See the [SlidingWindowConversationManager](https://github.com/strands-agents/sdk-typescript/blob/main/src/conversation-manager/sliding-window-conversation-manager.ts) implementation as a reference example.
+See the [SlidingWindowConversationManager](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts) implementation as a reference example.
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -344,7 +344,7 @@ The [Teacher's Assistant](../../../../examples/python/multi_agent_example/multi_
 </Tab>
 <Tab label="TypeScript">
 
-The [Agents as Tools](https://github.com/strands-agents/sdk-typescript/tree/main/examples/agents-as-tools) example demonstrates an orchestrator agent that routes student queries to specialized tool agents for math, English, computer science, and general knowledge.
+The [Agents as Tools](https://github.com/strands-agents/sdk-typescript/tree/main/strands-ts/examples/agents-as-tools) example demonstrates an orchestrator agent that routes student queries to specialized tool agents for math, English, computer science, and general knowledge.
 
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
+++ b/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 :::note[Python-Only Package]
 The Community Tools Package (`strands-agents-tools`) is currently Python-only. 
-TypeScript users should use [vended tools](https://github.com/strands-agents/sdk-typescript/blob/main/src/vended-tools)
+TypeScript users should use [vended tools](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools)
 included in the TypeScript SDK or create custom tools using the `tool()` function.
 :::
 

--- a/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
+++ b/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 :::note[Python-Only Package]
 The Community Tools Package (`strands-agents-tools`) is currently Python-only. 
-TypeScript users should use [vended tools](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools)
+TypeScript users should use [vended tools](vended-tools)
 included in the TypeScript SDK or create custom tools using the `tool()` function.
 :::
 

--- a/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -410,11 +410,16 @@ For a complete list of available tools, see [Community Tools Package](community-
 
 **Vended Tools**
 
-TypeScript vended tools are included in the SDK at [`vended-tools/`](vended-tools).
-The Community Tools Package (`strands-agents-tools`) is Python-only.
+TypeScript [vended tools](vended-tools) are included directly in the SDK. The Community Tools Package (`strands-agents-tools`) is Python-only.
 
 ```typescript
---8<-- "user-guide/concepts/tools/tools.ts:vended-tools"
+import { Agent } from '@strands-agents/sdk'
+import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
+import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
+
+const agent = new Agent({
+  tools: [notebook, fileEditor],
+})
 ```
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -410,7 +410,7 @@ For a complete list of available tools, see [Community Tools Package](community-
 
 **Vended Tools**
 
-TypeScript vended tools are included in the SDK at [`vended-tools/`](https://github.com/strands-agents/sdk-typescript/blob/main/src/vended-tools).
+TypeScript vended tools are included in the SDK at [`vended-tools/`](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools).
 The Community Tools Package (`strands-agents-tools`) is Python-only.
 
 ```typescript

--- a/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -410,7 +410,7 @@ For a complete list of available tools, see [Community Tools Package](community-
 
 **Vended Tools**
 
-TypeScript vended tools are included in the SDK at [`vended-tools/`](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools).
+TypeScript vended tools are included in the SDK at [`vended-tools/`](vended-tools).
 The Community Tools Package (`strands-agents-tools`) is Python-only.
 
 ```typescript

--- a/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -46,7 +46,7 @@ This tool reads and writes files with the full permissions of the Node.js proces
 --8<-- "user-guide/concepts/tools/vended-tools.ts:file_editor_example"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/src/vended-tools/file-editor/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/file-editor/README.md)
 
 ---
 
@@ -63,7 +63,7 @@ _Supported in: Node.js 20+, modern browsers._
 --8<-- "user-guide/concepts/tools/vended-tools.ts:http_request_example"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/src/vended-tools/http-request/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/http-request/README.md)
 
 ---
 
@@ -87,7 +87,7 @@ _Supported in: Node.js, browsers._
 --8<-- "user-guide/concepts/tools/vended-tools.ts:notebook_state_persistence"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/src/vended-tools/notebook/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/notebook/README.md)
 
 ---
 
@@ -115,7 +115,7 @@ This tool executes arbitrary bash commands without sandboxing. Commands run with
 --8<-- "user-guide/concepts/tools/vended-tools.ts:bash_session"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/src/vended-tools/bash/README.md)
+📖 [Full API Reference](https://github.com/strands-agents/sdk-typescript/blob/main/strands-ts/src/vended-tools/bash/README.md)
 
 ---
 

--- a/src/content/docs/user-guide/quickstart/typescript.mdx
+++ b/src/content/docs/user-guide/quickstart/typescript.mdx
@@ -191,7 +191,7 @@ See the [Async Iterators](../concepts/streaming/async-iterators.md) documentatio
 
 Ready to learn more? Check out these resources:
 
-- [Examples](https://github.com/strands-agents/sdk-typescript/tree/main/examples) - Examples for many use cases
+- [Examples](https://github.com/strands-agents/sdk-typescript/tree/main/strands-ts/examples) - Examples for many use cases
 - [TypeScript SDK Repository](https://github.com/strands-agents/sdk-typescript/blob/main) - Explore the TypeScript SDK source code and contribute
 - [Agent Loop](../concepts/agents/agent-loop.md) - Learn how Strands agents work under the hood
 - [State](../concepts/agents/state.md) - Understand how agents maintain context and state across a conversation


### PR DESCRIPTION
## Description

The TypeScript SDK moved from a flat repo structure to a monorepo with `strands-ts/` as the workspace package. This PR updates 11 GitHub links across 6 documentation files that still referenced the old paths (`examples/`, `src/`) instead of the new paths under `strands-ts/`.

Changes:
- `examples/` → `strands-ts/examples/` (2 links)
- `src/` → `strands-ts/src/` (8 links)
- `ConversationManager` base class link replaced with `@api/typescript/ConversationManager` API reference (1 link)

## Related Issues

N/A

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.