### PR TITLE
docs(context): update offloader for default tool enabled

### DIFF
--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -47,20 +47,20 @@ For non-text content, the plugin replaces the result with a descriptive placehol
 | Image | `[image: format, N bytes]` placeholder + storage reference |
 | Document | `[document: format, name, N bytes]` placeholder + storage reference |
 
-### Retrieval tool (opt-in)
+### Retrieval tool
 
-The plugin includes an optional `retrieve_offloaded_content` tool that lets the agent fetch offloaded content by reference, returning it in its native format — text as a string, JSON as a JSON block, images as image blocks, and documents as document blocks. Enable it with `include_retrieval_tool=True`:
+The plugin includes a `retrieve_offloaded_content` tool that lets the agent fetch offloaded content by reference, returning it in its native format — text as a string, JSON as a JSON block, images as image blocks, and documents as document blocks. This tool is registered by default.
+
+The inline guidance in offloaded results tells the agent to use its available tools to selectively access the data it needs, and mentions `retrieve_offloaded_content` as a fallback. If the agent already has tools that can access the storage backend directly (file readers, shell, etc.), you can disable it with `include_retrieval_tool=False`:
 
 ```python
 agent = Agent(plugins=[
     ContextOffloader(
-        storage=InMemoryStorage(),
-        include_retrieval_tool=True,
+        storage=FileStorage("./artifacts"),
+        include_retrieval_tool=False,
     )
 ])
 ```
-
-The retrieval tool is disabled by default. The inline guidance in offloaded results always tells the agent to use its available tools to selectively access the data it needs. When the retrieval tool is enabled, the guidance additionally mentions `retrieve_offloaded_content`.
 
 ## Getting Started
 
@@ -131,7 +131,6 @@ agent = Agent(plugins=[
             bucket="my-agent-artifacts",
             prefix="tool-results/",
         ),
-        include_retrieval_tool=True,
     )
 ])
 ```
@@ -143,10 +142,10 @@ agent = Agent(plugins=[
 | `storage` | *(required)* | Storage backend instance |
 | `max_result_tokens` | `2_500` | Results whose estimated token count exceeds this are offloaded |
 | `preview_tokens` | `1_000` | Number of tokens to keep as an in-context preview |
-| `include_retrieval_tool` | `False` | When `True`, registers a `retrieve_offloaded_content` tool the agent can use to fetch full content by reference |
+| `include_retrieval_tool` | `True` | Registers a `retrieve_offloaded_content` tool the agent can use to fetch full content by reference. Enabled by default; set to `False` to disable |
 
 ## Tradeoffs
 
-- **Preview vs. full content**: The agent reasons over the preview, not the full result. If the answer is buried deep in a large result, the agent may miss it. Tune `preview_tokens` to balance context usage against information loss for your use case. Enable `include_retrieval_tool=True` if the agent needs to fetch full offloaded content and doesn't have other tools (file readers, shell, etc.) that can access the storage backend directly.
+- **Preview vs. full content**: The agent reasons over the preview, not the full result. If the answer is buried deep in a large result, the agent may miss it. Tune `preview_tokens` to balance context usage against information loss for your use case. The `retrieve_offloaded_content` tool is enabled by default so the agent can fetch full offloaded content as a fallback. If the agent already has tools that can access the storage backend directly (file readers, shell, etc.), you can disable it with `include_retrieval_tool=False`.
 - **Storage costs**: `S3Storage` incurs S3 PUT/GET and storage charges. `FileStorage` writes to disk on every large result.
 - **Not a replacement for conversation management**: This plugin handles individual large results. You still need a conversation manager like `SlidingWindowConversationManager` to handle overall context growth across many turns.


### PR DESCRIPTION


## Description

Update the Context Offloader plugin documentation to reflect [strands-agents/sdk-python#2222](https://github.com/strands-agents/sdk-python/pull/2222), which changes `include_retrieval_tool` from defaulting to `False` to `True`.

- Updated the "Retrieval tool" section heading (removed "opt-in") and rewrote to describe the tool as registered by default
- Flipped the code example to show how to disable the tool (`include_retrieval_tool=False`) instead of how to enable it
- Updated the configuration table default from `False` to `True`
- Removed redundant `include_retrieval_tool=True` from the S3 storage example
- Updated the tradeoffs section to reflect the new default

## Related Issues

strands-agents/sdk-python#2222

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.