### PR TITLE
docs: fix model names and IDs in quickstart and bedrock pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "unist-util-visit": "^5.1.0",
     "vitest": "^4.0.18"
   },
+  "overrides": {
+    "zod": "4.3.6"
+  },
   "prettier": {
     "semi": false,
     "singleQuote": true,

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -188,7 +188,7 @@ response = agent("Tell me about Amazon Bedrock.")
 </Tab>
 <Tab label="TypeScript">
 
-The [`BedrockModel`](@api/typescript/BedrockModel) provider is used by default when creating a basic Agent, and uses the [Claude Sonnet 4.5](https://aws.amazon.com/blogs/aws/introducing-claude-sonnet-4-5-in-amazon-bedrock-anthropics-most-intelligent-model-best-for-coding-and-complex-agents/) model by default. This basic example creates an agent using this default setup:
+The [`BedrockModel`](@api/typescript/BedrockModel) provider is used by default when creating a basic Agent, and uses the [Claude Sonnet 4.6](https://www.anthropic.com/claude/sonnet) model by default. This basic example creates an agent using this default setup:
 
 ```typescript
 --8<-- "user-guide/concepts/model-providers/amazon-bedrock_imports.ts:basic_default_imports"

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -188,7 +188,7 @@ response = agent("Tell me about Amazon Bedrock.")
 </Tab>
 <Tab label="TypeScript">
 
-The [`BedrockModel`](@api/typescript/BedrockModel) provider is used by default when creating a basic Agent, and uses the [Claude Sonnet 4.6](https://www.anthropic.com/claude/sonnet) model by default. This basic example creates an agent using this default setup:
+The [`BedrockModel`](@api/typescript/BedrockModel) provider is used by default when creating a basic Agent, and uses [Claude Sonnet 4.6](https://www.anthropic.com/claude/sonnet) by default. This basic example creates an agent using this default setup:
 
 ```typescript
 --8<-- "user-guide/concepts/model-providers/amazon-bedrock_imports.ts:basic_default_imports"

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -301,7 +301,7 @@ async function toolCachingFull() {
 async function automaticCacheStrategy() {
   // --8<-- [start:automatic_cache_strategy]
   const bedrockModel = new BedrockModel({
-    modelId: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    modelId: 'us.anthropic.claude-sonnet-4-6',
     cacheConfig: { strategy: 'auto' },
   })
 

--- a/src/content/docs/user-guide/quickstart/python.mdx
+++ b/src/content/docs/user-guide/quickstart/python.mdx
@@ -68,16 +68,16 @@ See the [MCP server documentation](https://github.com/strands-agents/mcp-server)
 
 ## Configuring Credentials
 
-Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with the Claude Sonnet 4 model. To modify the default model, refer to [the Model Providers section](#model-providers)
+Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with Claude Sonnet 4. To modify the default model, refer to [the Model Providers section](#model-providers)
 
-To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke the Claude Sonnet 4 model. You can set up your credentials in several ways:
+To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke Claude Sonnet 4. You can set up your credentials in several ways:
 
 1. **Environment variables**: Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`
 2. **AWS credentials file**: Configure credentials using `aws configure` CLI command
 3. **IAM roles**: If running on AWS services like EC2, ECS, or Lambda, use IAM roles
 4. **Bedrock API keys**: Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable
 
-Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke the Claude Sonnet 4 model.
+Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke Claude Sonnet 4.
 
 ## Project Setup
 

--- a/src/content/docs/user-guide/quickstart/python.mdx
+++ b/src/content/docs/user-guide/quickstart/python.mdx
@@ -68,16 +68,16 @@ See the [MCP server documentation](https://github.com/strands-agents/mcp-server)
 
 ## Configuring Credentials
 
-Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with the Claude 4 model. To modify the default model, refer to [the Model Providers section](#model-providers)
+Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with the Claude Sonnet 4 model. To modify the default model, refer to [the Model Providers section](#model-providers)
 
-To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke the Claude 4 model. You can set up your credentials in several ways:
+To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke the Claude Sonnet 4 model. You can set up your credentials in several ways:
 
 1. **Environment variables**: Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`
 2. **AWS credentials file**: Configure credentials using `aws configure` CLI command
 3. **IAM roles**: If running on AWS services like EC2, ECS, or Lambda, use IAM roles
 4. **Bedrock API keys**: Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable
 
-Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke the Claude 4 model.
+Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke the Claude Sonnet 4 model.
 
 ## Project Setup
 
@@ -387,7 +387,7 @@ See the [Logs documentation](../observability-evaluation/logs.md) for more infor
 
 ### Identifying a configured model
 
-Strands defaults to the Bedrock model provider using Claude 4 Sonnet. The model your agent is using can be retrieved by accessing [`model.config`](@api/python/strands.models.model#Model.get_config):
+Strands defaults to the Bedrock model provider using Claude Sonnet 4. The model your agent is using can be retrieved by accessing [`model.config`](@api/python/strands.models.model#Model.get_config):
 
 ```python
 from strands import Agent

--- a/src/content/docs/user-guide/quickstart/typescript.mdx
+++ b/src/content/docs/user-guide/quickstart/typescript.mdx
@@ -39,16 +39,16 @@ import { bash } from '@strands-agents/sdk/vended-tools/bash'
 
 ## Configuring Credentials
 
-Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with the Claude Sonnet 4.6 model.
+Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with Claude Sonnet 4.6.
 
-To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke the Claude Sonnet 4.6 model. You can set up your credentials in several ways:
+To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke Claude Sonnet 4.6. You can set up your credentials in several ways:
 
 1. **Environment variables**: Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`
 2. **AWS credentials file**: Configure credentials using `aws configure` CLI command
 3. **IAM roles**: If running on AWS services like EC2, ECS, or Lambda, use IAM roles
 4. **Bedrock API keys**: Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable
 
-Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke the Claude Sonnet 4.6 model.
+Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke Claude Sonnet 4.6.
 
 ## Project Setup
 

--- a/src/content/docs/user-guide/quickstart/typescript.mdx
+++ b/src/content/docs/user-guide/quickstart/typescript.mdx
@@ -39,20 +39,20 @@ import { bash } from '@strands-agents/sdk/vended-tools/bash'
 
 ## Configuring Credentials
 
-Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with the Claude 4 model.
+Strands supports many different model providers. By default, agents use the Amazon Bedrock model provider with the Claude Sonnet 4.6 model.
 
-To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke the Claude 4 model. You can set up your credentials in several ways:
+To use the examples in this guide, you'll need to configure your environment with AWS credentials that have permissions to invoke the Claude Sonnet 4.6 model. You can set up your credentials in several ways:
 
 1. **Environment variables**: Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`
 2. **AWS credentials file**: Configure credentials using `aws configure` CLI command
 3. **IAM roles**: If running on AWS services like EC2, ECS, or Lambda, use IAM roles
 4. **Bedrock API keys**: Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable
 
-Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke the Claude 4 model.
+Make sure your AWS credentials have the necessary permissions to access Amazon Bedrock and invoke the Claude Sonnet 4.6 model.
 
 ## Project Setup
 
-Now we'll continuing building out the nodejs project by adding TypeScript to the project where our agent will reside. We'll use this directory structure:
+Now we'll continue building out the nodejs project by adding TypeScript to the project where our agent will reside. We'll use this directory structure:
 
 ```
 my-agent/
@@ -138,7 +138,7 @@ Agents display their reasoning and responses in real-time to the console by defa
 
 ### Identifying a configured model
 
-Strands defaults to the Bedrock model provider using Claude 4 Sonnet. The model your agent is using can be retrieved by accessing `model.config`:
+Strands defaults to the Bedrock model provider using Claude Sonnet 4.6. The model your agent is using can be retrieved by accessing `model.config`:
 
 
 ```typescript

--- a/src/content/docs/user-guide/quickstart/typescript.ts
+++ b/src/content/docs/user-guide/quickstart/typescript.ts
@@ -64,13 +64,13 @@ const quietAgent = new Agent({
 // Check the model configuration
 const myAgent = new Agent()
 console.log(myAgent['model'].getConfig().modelId)
-// Output: { modelId: 'global.anthropic.claude-sonnet-4-5-20250929-v1:0' }
+// Output: { modelId: 'global.anthropic.claude-sonnet-4-6' }
 // --8<-- [end:model-config]
 
 // --8<-- [start:model-string]
 // Create an agent with a specific model by passing the model ID string
 const specificAgent = new Agent({
-  model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+  model: 'global.anthropic.claude-opus-4-6-v1',
 })
 // --8<-- [end:model-string]
 
@@ -79,7 +79,7 @@ import { BedrockModel } from '@strands-agents/sdk'
 
 // Create a BedrockModel with custom configuration
 const bedrockModel = new BedrockModel({
-  modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+  modelId: 'global.anthropic.claude-opus-4-6-v1',
   region: 'us-west-2',
   temperature: 0.3,
 })


### PR DESCRIPTION
## Description

The quickstart guides and Amazon Bedrock model provider page referenced incorrect or outdated model names and IDs. This PR updates them to match the current SDK defaults.

**Quickstart pages (Python and TypeScript):**
- "Claude 4" and "Claude 4 Sonnet" are not real model names. Updated to "Claude Sonnet 4" (Python, matching its `claude-sonnet-4-20250514` default) and "Claude Sonnet 4.6" (TypeScript, matching its `claude-sonnet-4-6` default).
- Updated the TypeScript model-config comment to show the current default ID (`global.anthropic.claude-sonnet-4-6`).
- Changed the custom model ID examples from Claude Sonnet 4 to Claude Opus 4.6 (`global.anthropic.claude-opus-4-6-v1`) so they clearly demonstrate switching to a different model rather than restating the default. Model ID verified against Bedrock.
- Fixed grammar: "we'll continuing building out" to "we'll continue building out".

**Amazon Bedrock model provider page:**
- Updated the TypeScript tab description from "Claude Sonnet 4.5" to "Claude Sonnet 4.6".
- Updated the automatic cache strategy example model ID from `us.anthropic.claude-sonnet-4-5-20250929-v1:0` to `us.anthropic.claude-sonnet-4-6`.

**CI fix: pin Zod to 4.3.6**

Zod 4.4.0 (published 2026-04-29) introduced a regression where `z.preprocess` no longer preserves `.optional()` on the wrapped schema. This breaks Starlight's `social` config validation, which uses that pattern, causing all doc builds to fail with `social: Required`. This affects all branches, not just this PR.

Pinning Zod to 4.3.6 via `overrides` in `package.json` restores the working behavior. Verified locally: Zod 4.4.0 reproduces the error, Zod 4.3.6 builds successfully.

## Related Issues

N/A

## Type of Change

- Content update/revision
- Typo/formatting fix
- Build fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.