### PR TITLE
docs: sync model provider pages with TypeScript SDK

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -118,7 +118,7 @@ sidebar:
           - docs/user-guide/concepts/model-providers/amazon-bedrock
           - docs/user-guide/concepts/model-providers/amazon-nova
           - docs/user-guide/concepts/model-providers/anthropic
-          - docs/user-guide/concepts/model-providers/gemini
+          - docs/user-guide/concepts/model-providers/google
           - docs/user-guide/concepts/model-providers/litellm
           - docs/user-guide/concepts/model-providers/llamacpp
           - docs/user-guide/concepts/model-providers/llamaapi

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -275,6 +275,7 @@ Common configuration parameters include:
 - `stream` - Enable/disable streaming mode
 - `cacheConfig` - Enable prompt caching with `{ strategy: 'auto' }` or `{ strategy: 'anthropic' }`
 - `region` - AWS region to use
+- `apiKey` - Bedrock API key for bearer token authentication (alternative to SigV4 signing)
 - `clientConfig` - AWS SDK client configuration
 - `additionalArgs` - Additional model-specific parameters
 </Tab>

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -137,5 +137,4 @@ You can pass a pre-configured Anthropic client directly to `AnthropicModel`. You
 ## References
 
 - [Python API](@api/python/strands.models.model)
-- [TypeScript API](@api/typescript/AnthropicModel)
 - [Anthropic](https://platform.claude.com/docs/en/home)

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -1,6 +1,5 @@
 ---
 title: Anthropic
-languages: Python
 integrationType: model-provider
 ---
 
@@ -8,15 +7,29 @@ integrationType: model-provider
 
 ## Installation
 
-Anthropic is configured as an optional dependency in Strands. To install, run:
+Anthropic is configured as an optional dependency in Strands Agents. To install, run:
+
+<Tabs>
+<Tab label="Python">
 
 ```bash
 pip install 'strands-agents[anthropic]' strands-agents-tools
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```bash
+npm install @strands-agents/sdk @anthropic-ai/sdk
+```
+</Tab>
+</Tabs>
 
 ## Usage
 
-After installing `anthropic`, you can import and initialize Strands' Anthropic provider as follows:
+After installing dependencies, you can import and initialize the Strands Agents' Anthropic provider as follows:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands import Agent
@@ -29,7 +42,7 @@ model = AnthropicModel(
     },
     # **model_config
     max_tokens=1028,
-    model_id="claude-sonnet-4-20250514",
+    model_id="claude-sonnet-4-6",
     params={
         "temperature": 0.7,
     }
@@ -39,78 +52,90 @@ agent = Agent(model=model, tools=[calculator])
 response = agent("What is 2+2")
 print(response)
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/anthropic_imports.ts:basic_usage_imports"
+
+--8<-- "user-guide/concepts/model-providers/anthropic.ts:basic_usage"
+```
+</Tab>
+</Tabs>
 
 ## Configuration
 
 ### Client Configuration
 
-The `client_args` configure the underlying Anthropic client. For a complete list of available arguments, please refer to the Anthropic [docs](https://docs.anthropic.com/en/api/client-sdks).
+<Tabs>
+<Tab label="Python">
+
+The `client_args` configure the underlying Anthropic client. For a complete list of available arguments, please refer to the [Anthropic Python SDK docs](https://platform.claude.com/docs/en/api/sdks/python).
+</Tab>
+<Tab label="TypeScript">
+
+The `clientConfig` configures the underlying Anthropic client. You can also pass a pre-configured `client` instance directly (see [Custom Client](#custom-client)). For a complete list of available options, please refer to the [Anthropic TypeScript SDK docs](https://platform.claude.com/docs/en/api/sdks/typescript).
+</Tab>
+</Tabs>
 
 ### Model Configuration
+
+<Tabs>
+<Tab label="Python">
 
 The `model_config` configures the underlying model selected for inference. The supported configurations are:
 
 |  Parameter | Description | Example | Options |
 |------------|-------------|---------|---------|
-| `max_tokens` | Maximum number of tokens to generate before stopping | `1028` | [reference](https://docs.anthropic.com/en/api/messages#body-max-tokens)
-| `model_id` | ID of a model to use | `claude-sonnet-4-20250514` | [reference](https://docs.anthropic.com/en/api/messages#body-model)
-| `params` | Model specific parameters | `{"max_tokens": 1000, "temperature": 0.7}` | [reference](https://docs.anthropic.com/en/api/messages)
+| `max_tokens` | Maximum number of tokens to generate before stopping | `1028` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.max_tokens)
+| `model_id` | ID of a model to use | `claude-sonnet-4-6` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.model)
+| `params` | Additional pass-through parameters | `{"metadata": {"user_id": "user-123"}}` | [reference](https://platform.claude.com/docs/en/api/messages/create)
+</Tab>
+<Tab label="TypeScript">
+
+|  Parameter | Description | Example | Options |
+|------------|-------------|---------|---------|
+| `modelId` | ID of a model to use | `'claude-sonnet-4-6'` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.model) |
+| `maxTokens` | Maximum tokens to generate | `1028` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.max_tokens) |
+| `stopSequences` | Sequences that stop generation | `['END']` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.stop_sequences) |
+| `params` | Additional pass-through parameters | `{ metadata: { user_id: 'user-123' } }` | [reference](https://platform.claude.com/docs/en/api/messages/create) |
+</Tab>
+</Tabs>
 
 ## Troubleshooting
+
+<Tabs>
+<Tab label="Python">
 
 ### Module Not Found
 
 If you encounter the error `ModuleNotFoundError: No module named 'anthropic'`, this means you haven't installed the `anthropic` dependency in your environment. To fix, run `pip install 'strands-agents[anthropic]'`.
+</Tab>
+<Tab label="TypeScript">
+
+### Import Errors
+
+If you encounter import errors for `@anthropic-ai/sdk`, ensure the package is installed: `npm install @anthropic-ai/sdk`.
+</Tab>
+</Tabs>
 
 ## Advanced Features
 
-### Structured Output
+### Custom Client
 
-Anthropic's Claude models support structured output through their tool calling capabilities. When you use [`Agent.structured_output()`](@api/python/strands.agent.agent#Agent.structured_output), the Strands SDK converts your Pydantic models to Anthropic's tool specification format.
+You can pass a pre-configured Anthropic client directly to `AnthropicModel`. You are responsible for managing the client's lifecycle.
 
-```python
-from pydantic import BaseModel, Field
-from strands import Agent
-from strands.models.anthropic import AnthropicModel
+<Tabs>
+<Tab label="TypeScript">
 
-class BookAnalysis(BaseModel):
-    """Analyze a book's key information."""
-    title: str = Field(description="The book's title")
-    author: str = Field(description="The book's author")
-    genre: str = Field(description="Primary genre or category")
-    summary: str = Field(description="Brief summary of the book")
-    rating: int = Field(description="Rating from 1-10", ge=1, le=10)
-
-model = AnthropicModel(
-    client_args={
-        "api_key": "<KEY>",
-    },
-    max_tokens=1028,
-    model_id="claude-sonnet-4-20250514",
-    params={
-        "temperature": 0.7,
-    }
-)
-
-agent = Agent(model=model)
-
-result = agent.structured_output(
-    BookAnalysis,
-    """
-    Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
-    It's a science fiction comedy about Arthur Dent's adventures through space
-    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.
-    """
-)
-
-print(f"Title: {result.title}")
-print(f"Author: {result.author}")
-print(f"Genre: {result.genre}")
-print(f"Rating: {result.rating}")
+```typescript
+--8<-- "user-guide/concepts/model-providers/anthropic.ts:custom_client"
 ```
+</Tab>
+</Tabs>
 
 ## References
 
 - [Python API](@api/python/strands.models.model)
-- [Anthropic](https://docs.anthropic.com/en/home)
-
+- [TypeScript API](@api/typescript/AnthropicModel)
+- [Anthropic](https://platform.claude.com/docs/en/home)

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -89,7 +89,7 @@ The `model_config` configures the underlying model selected for inference. The s
 |------------|-------------|---------|---------|
 | `max_tokens` | Maximum number of tokens to generate before stopping | `1028` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.max_tokens)
 | `model_id` | ID of a model to use | `claude-sonnet-4-6` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.model)
-| `params` | Additional pass-through parameters | `{"metadata": {"user_id": "user-123"}}` | [reference](https://platform.claude.com/docs/en/api/messages/create)
+| `params` | Additional pass-through parameters | `{"metadata": {"user_id": "u1"}}` | [reference](https://platform.claude.com/docs/en/api/messages/create)
 </Tab>
 <Tab label="TypeScript">
 
@@ -98,7 +98,7 @@ The `model_config` configures the underlying model selected for inference. The s
 | `modelId` | ID of a model to use | `'claude-sonnet-4-6'` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.model) |
 | `maxTokens` | Maximum tokens to generate | `1028` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.max_tokens) |
 | `stopSequences` | Sequences that stop generation | `['END']` | [reference](https://platform.claude.com/docs/en/api/messages/create#create.stop_sequences) |
-| `params` | Additional pass-through parameters | `{ metadata: { user_id: 'user-123' } }` | [reference](https://platform.claude.com/docs/en/api/messages/create) |
+| `params` | Additional pass-through parameters | `{ metadata: { user_id: 'u1' } }` | [reference](https://platform.claude.com/docs/en/api/messages/create) |
 </Tab>
 </Tabs>
 
@@ -126,9 +126,15 @@ If you encounter import errors for `@anthropic-ai/sdk`, ensure the package is in
 You can pass a pre-configured Anthropic client directly to `AnthropicModel`. You are responsible for managing the client's lifecycle.
 
 <Tabs>
+<Tab label="Python">
+
+The Python SDK does not currently support passing a pre-configured client. Use `client_args` to configure the client at initialization.
+</Tab>
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/model-providers/anthropic_imports.ts:custom_client_imports"
+
 --8<-- "user-guide/concepts/model-providers/anthropic.ts:custom_client"
 ```
 </Tab>

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic.ts
@@ -1,0 +1,47 @@
+/**
+ * TypeScript examples for Anthropic model provider documentation.
+ * These examples demonstrate common usage patterns for the AnthropicModel.
+ */
+// @ts-nocheck
+
+import { Agent } from '@strands-agents/sdk'
+import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
+
+// Basic usage
+async function basicUsage() {
+  // --8<-- [start:basic_usage]
+  const model = new AnthropicModel({
+    apiKey: process.env.ANTHROPIC_API_KEY || '<KEY>',
+    modelId: 'claude-sonnet-4-6',
+    maxTokens: 1028,
+    params: {
+      temperature: 0.7,
+    },
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2')
+  console.log(response)
+  // --8<-- [end:basic_usage]
+}
+
+// Custom client
+async function customClient() {
+  // --8<-- [start:custom_client]
+  import Anthropic from '@anthropic-ai/sdk'
+  import { Agent } from '@strands-agents/sdk'
+  import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
+
+  const client = new Anthropic({ apiKey: '<KEY>' })
+
+  const model = new AnthropicModel({
+    client,
+    modelId: 'claude-sonnet-4-6',
+    maxTokens: 1028,
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2')
+  console.log(response)
+  // --8<-- [end:custom_client]
+}

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic.ts
@@ -2,8 +2,8 @@
  * TypeScript examples for Anthropic model provider documentation.
  * These examples demonstrate common usage patterns for the AnthropicModel.
  */
-// @ts-nocheck
 
+import Anthropic from '@anthropic-ai/sdk'
 import { Agent } from '@strands-agents/sdk'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 
@@ -28,10 +28,6 @@ async function basicUsage() {
 // Custom client
 async function customClient() {
   // --8<-- [start:custom_client]
-  import Anthropic from '@anthropic-ai/sdk'
-  import { Agent } from '@strands-agents/sdk'
-  import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
-
   const client = new Anthropic({ apiKey: '<KEY>' })
 
   const model = new AnthropicModel({

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic_imports.ts
@@ -4,3 +4,9 @@
 import { Agent } from '@strands-agents/sdk'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 // --8<-- [end:basic_usage_imports]
+
+// --8<-- [start:custom_client_imports]
+import Anthropic from '@anthropic-ai/sdk'
+import { Agent } from '@strands-agents/sdk'
+import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
+// --8<-- [end:custom_client_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/anthropic_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/anthropic_imports.ts
@@ -1,0 +1,6 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_usage_imports]
+import { Agent } from '@strands-agents/sdk'
+import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
+// --8<-- [end:basic_usage_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
@@ -32,37 +32,6 @@ response = agent("Hello, how can you help me today?")
 
 This invokes the underlying model provided to the agent.
 
-### Structured Output
-A specialized mode that returns type-safe, validated responses using validated data models instead of raw text. This enables reliable data extraction and processing:
-
-<Tabs>
-<Tab label="Python">
-
-```python
-from pydantic import BaseModel
-
-class PersonInfo(BaseModel):
-    name: str
-    age: int
-    occupation: str
-
-result = agent.structured_output(
-    PersonInfo,
-    "Extract info: John Smith is a 30-year-old software engineer"
-)
-# Returns a validated PersonInfo object
-```
-</Tab>
-<Tab label="TypeScript">
-
-```ts
-// Structured output is not available for custom model providers in TypeScript
-```
-</Tab>
-</Tabs>
-
-Both modes work through the same underlying model provider interface, with structured output using tool calling capabilities to ensure schema compliance.
-
 ## Model Provider Architecture
 
 Strands Agents uses an abstract `Model` class that defines the standard interface all model providers must implement:
@@ -499,78 +468,7 @@ const metadata: ModelMetadataEventData = {
 </Tab>
 </Tabs>
 
-### 4. Structured Output Support
-
-<Tabs>
-<Tab label="Python">
-
-To support structured output in your custom model provider, you need to implement a `structured_output()` method that invokes your model and yields a JSON output. This method leverages the unified `stream` interface with tool specifications.
-
-```python
-T = TypeVar('T', bound=BaseModel)
-
-@override
-async def structured_output(
-    self,
-    output_model: Type[T],
-    prompt: Messages,
-    system_prompt: Optional[str] = None,
-    **kwargs: Any
-) -> Generator[dict[str, Union[T, Any]], None, None]:
-    """Get structured output using tool calling.
-
-    Args:
-        output_model: The output model to use for the agent.
-        prompt: The prompt messages to use for the agent.
-        system_prompt: The system prompt to use for the agent.
-        **kwargs: Additional keyword arguments for future extensibility.
-    """
-
-    # Convert Pydantic model to tool specification
-    tool_spec = convert_pydantic_to_tool_spec(output_model)
-
-    # Use the stream method with tool specification
-    response = await self.stream(messages=prompt, tool_specs=[tool_spec], system_prompt=system_prompt, **kwargs)
-
-    # Process streaming response
-    async for event in process_stream(response, prompt):
-        yield event  # Passed to callback handler configured in Agent instance
-
-    stop_reason, messages, _, _ = event["stop"]
-
-    # Validate tool use response
-    if stop_reason != "tool_use":
-        raise ValueError("No valid tool use found in the model response.")
-
-    # Extract tool use output
-    content = messages["content"]
-    for block in content:
-        if block.get("toolUse") and block["toolUse"]["name"] == tool_spec["name"]:
-            yield {"output": output_model(**block["toolUse"]["input"])}
-            return
-
-    raise ValueError("No valid tool use input found in the response.")
-```
-
-**Implementation Suggestions:**
-
-1. **Tool Integration**: Use the `stream()` method with tool specifications to invoke your model
-2. **Response Validation**: Use `output_model(**data)` to validate the response
-3. **Error Handling**: Provide clear error messages for parsing and validation failures
-
-For detailed structured output usage patterns, see the [Structured Output documentation](../agents/structured-output.md).
-
-> Note, similar to the `stream` method, `structured_output` must be implemented async. If your client does not support async invocation, you may consider wrapping the relevant calls in a thread so as not to block the async event loop. Again, for an example on how to achieve this, you can check out the [BedrockModel](https://github.com/strands-agents/sdk-python/blob/main/src/strands/models/bedrock.py) provider implementation.
-</Tab>
-<Tab label="TypeScript">
-
-```ts
-// Structured output is not available for custom model providers in TypeScript
-```
-</Tab>
-</Tabs>
-
-### 5. Use Your Custom Model Provider
+### 4. Use Your Custom Model Provider
 
 Once implemented, you can use your custom model provider in your applications for regular agent invocation:
 
@@ -602,40 +500,6 @@ response = agent("Hello, how are you today?")
 
 ```typescript
 --8<-- "user-guide/concepts/model-providers/custom_model_provider.ts:usage_example"
-```
-</Tab>
-</Tabs>
-
-Or you can use the `structured_output` feature to generate structured output:
-
-<Tabs>
-<Tab label="Python">
-
-```python
-from strands import Agent
-from your_org.models.custom_model import CustomModel
-from pydantic import BaseModel, Field
-
-class PersonInfo(BaseModel):
-    name: str = Field(description="Full name")
-    age: int = Field(description="Age in years")
-    occupation: str = Field(description="Job title")
-
-model = CustomModel(api_key="key", model_id="model")
-
-agent = Agent(model=model)
-
-result = agent.structured_output(PersonInfo, "John Smith is a 30-year-old engineer.")
-
-print(f"Name: {result.name}")
-print(f"Age: {result.age}")
-print(f"Occupation: {result.occupation}")
-```
-</Tab>
-<Tab label="TypeScript">
-
-```ts
-// Structured output is not available for custom model providers in TypeScript
 ```
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -185,6 +185,56 @@ For a complete list of supported models, see the [Gemini API documentation](http
 - `gemini-2.0-flash` - Next-gen features with improved speed
 - `gemini-2.0-flash-lite` - Cost-optimized version of 2.0
 
+### Built-in Tools
+
+<Tabs>
+<Tab label="Python">
+
+Google's built-in tools (Google Search, Code Execution, URL Context) can be passed via the `gemini_tools` config option. These are appended alongside any function tools registered on the agent.
+
+```python
+from google import genai
+from strands import Agent
+from strands.models.gemini import GeminiModel
+
+model = GeminiModel(
+    client_args={"api_key": "<KEY>"},
+    model_id="gemini-2.5-flash",
+    gemini_tools=[
+        genai.types.Tool(google_search=genai.types.GoogleSearch()),
+    ],
+)
+
+agent = Agent(model=model)
+response = agent("What are the latest AI news today?")
+print(response)
+```
+</Tab>
+<Tab label="TypeScript">
+
+Google's built-in tools (Google Search, Code Execution, URL Context) can be passed via the `builtInTools` config option. These are appended alongside any function tools registered on the agent.
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { GoogleModel } from '@strands-agents/sdk/models/google'
+
+const model = new GoogleModel({
+  apiKey: '<KEY>',
+  modelId: 'gemini-2.5-flash',
+  builtInTools: [{ googleSearch: {} }],
+})
+
+const agent = new Agent({ model })
+const response = await agent.invoke(
+  'What are the latest AI news today?'
+)
+console.log(response)
+```
+</Tab>
+</Tabs>
+
+For available built-in tools, see the [Gemini tools documentation](https://ai.google.dev/gemini-api/docs/tools).
+
 ## Troubleshooting
 
 ### Module Not Found
@@ -496,3 +546,4 @@ const result = await agent.invoke([
 - [Google Gemini](https://ai.google.dev/api)
 - [Google GenAI SDK documentation](https://googleapis.github.io/python-genai/)
 - [Google AI Studio](https://aistudio.google.com/)
+- [@google/genai TypeScript SDK](https://github.com/googleapis/js-genai)

--- a/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -63,23 +63,9 @@ print(response)
 <Tab label="TypeScript">
 
 ```typescript
-import { Agent } from '@strands-agents/sdk'
-import { GoogleModel } from '@strands-agents/sdk/models/google'
+--8<-- "user-guide/concepts/model-providers/google_imports.ts:basic_usage_imports"
 
-const model = new GoogleModel({
-  apiKey: '<KEY>',
-  modelId: 'gemini-2.5-flash',
-  params: {
-    temperature: 0.7,
-    maxOutputTokens: 2048,
-    topP: 0.9,
-    topK: 40,
-  },
-})
-
-const agent = new Agent({ model })
-const response = await agent.invoke('What is 2+2')
-console.log(response)
+--8<-- "user-guide/concepts/model-providers/google.ts:basic_usage"
 ```
 </Tab>
 </Tabs>
@@ -163,14 +149,7 @@ params = {
 **Example:**
 
 ```typescript
-const params = {
-  temperature: 0.8,
-  maxOutputTokens: 4096,
-  topP: 0.95,
-  topK: 40,
-  candidateCount: 1,
-  stopSequences: ['STOP!'],
-}
+--8<-- "user-guide/concepts/model-providers/google.ts:params_example"
 ```
 </Tab>
 </Tabs>
@@ -217,20 +196,7 @@ print(response)
 Google's built-in tools (Google Search, Code Execution, URL Context) can be passed via the `builtInTools` config option. These are appended alongside any function tools registered on the agent.
 
 ```typescript
-import { Agent } from '@strands-agents/sdk'
-import { GoogleModel } from '@strands-agents/sdk/models/google'
-
-const model = new GoogleModel({
-  apiKey: '<KEY>',
-  modelId: 'gemini-2.5-flash',
-  builtInTools: [{ googleSearch: {} }],
-})
-
-const agent = new Agent({ model })
-const response = await agent.invoke(
-  'What are the latest AI news today?'
-)
-console.log(response)
+--8<-- "user-guide/concepts/model-providers/google.ts:builtin_tools"
 ```
 </Tab>
 </Tabs>
@@ -280,12 +246,7 @@ except ModelThrottledException as e:
 <Tab label="TypeScript">
 
 ```typescript
-try {
-  const response = await agent.invoke('Your query here')
-} catch (error) {
-  console.error('Error:', error)
-  // Implement backoff strategy
-}
+--8<-- "user-guide/concepts/model-providers/google.ts:error_handling"
 ```
 </Tab>
 </Tabs>
@@ -383,26 +344,9 @@ print(response)
 <Tab label="TypeScript">
 
 ```typescript
-import { GoogleGenAI } from '@google/genai'
-import { Agent } from '@strands-agents/sdk'
-import { GoogleModel } from '@strands-agents/sdk/models/google'
+--8<-- "user-guide/concepts/model-providers/google_imports.ts:custom_client_imports"
 
-const client = new GoogleGenAI({ apiKey: '<KEY>' })
-
-const model = new GoogleModel({
-  client,
-  modelId: 'gemini-2.5-flash',
-  params: {
-    temperature: 0.7,
-    maxOutputTokens: 2048,
-    topP: 0.9,
-    topK: 40,
-  },
-})
-
-const agent = new Agent({ model })
-const response = await agent.invoke('What is 2+2')
-console.log(response)
+--8<-- "user-guide/concepts/model-providers/google.ts:custom_client"
 ```
 </Tab>
 </Tabs>
@@ -447,24 +391,9 @@ response = agent([
 <Tab label="TypeScript">
 
 ```typescript
-import { Agent, ImageBlock, TextBlock } from '@strands-agents/sdk'
-import { GoogleModel } from '@strands-agents/sdk/models/google'
+--8<-- "user-guide/concepts/model-providers/google_imports.ts:image_imports"
 
-const model = new GoogleModel({
-  apiKey: '<KEY>',
-  modelId: 'gemini-2.5-flash',
-})
-
-const agent = new Agent({ model })
-
-// Process image with text
-const result = await agent.invoke([
-  new TextBlock('What do you see in this image?'),
-  new ImageBlock({
-    format: 'png',
-    source: { bytes: imageBytes },
-  }),
-])
+--8<-- "user-guide/concepts/model-providers/google.ts:image_input"
 ```
 </Tab>
 </Tabs>
@@ -489,16 +418,9 @@ response = agent([
 <Tab label="TypeScript">
 
 ```typescript
-import { DocumentBlock, TextBlock } from '@strands-agents/sdk'
+--8<-- "user-guide/concepts/model-providers/google_imports.ts:document_imports"
 
-const result = await agent.invoke([
-  new TextBlock('Summarize this document'),
-  new DocumentBlock({
-    name: 'my-document',
-    format: 'pdf',
-    source: { bytes: pdfBytes },
-  }),
-])
+--8<-- "user-guide/concepts/model-providers/google.ts:document_input"
 ```
 </Tab>
 </Tabs>
@@ -523,15 +445,9 @@ response = agent([
 <Tab label="TypeScript">
 
 ```typescript
-import { VideoBlock, TextBlock } from '@strands-agents/sdk'
+--8<-- "user-guide/concepts/model-providers/google_imports.ts:video_imports"
 
-const result = await agent.invoke([
-  new TextBlock('Describe what happens in this video'),
-  new VideoBlock({
-    format: 'mp4',
-    source: { bytes: videoBytes },
-  }),
-])
+--8<-- "user-guide/concepts/model-providers/google.ts:video_input"
 ```
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -1,6 +1,8 @@
 ---
 title: Google
 integrationType: model-provider
+redirectFrom:
+  - docs/user-guide/concepts/model-providers/gemini
 ---
 
 [Google Gemini](https://ai.google.dev/api) is Google's family of multimodal large language models designed for advanced reasoning, code generation, and creative tasks. The Strands Agents SDK implements a Google/Gemini provider, allowing you to run agents against the Gemini models available through Google's AI API.

--- a/src/content/docs/user-guide/concepts/model-providers/google.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/google.ts
@@ -66,6 +66,7 @@ async function builtInTools() {
 
 // Error handling
 async function errorHandling() {
+  const agent = new Agent({ model: new GoogleModel({ apiKey: '<KEY>' }) })
   // --8<-- [start:error_handling]
   try {
     const response = await agent.invoke('Your query here')
@@ -122,6 +123,7 @@ async function imageInput() {
 
 // Document input
 async function documentInput() {
+  const agent = new Agent({ model: new GoogleModel({ apiKey: '<KEY>' }) })
   const pdfBytes = new Uint8Array()
   // --8<-- [start:document_input]
   const result = await agent.invoke([
@@ -137,6 +139,7 @@ async function documentInput() {
 
 // Video input
 async function videoInput() {
+  const agent = new Agent({ model: new GoogleModel({ apiKey: '<KEY>' }) })
   const videoBytes = new Uint8Array()
   // --8<-- [start:video_input]
   const result = await agent.invoke([

--- a/src/content/docs/user-guide/concepts/model-providers/google.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/google.ts
@@ -1,0 +1,150 @@
+/**
+ * TypeScript examples for Google model provider documentation.
+ * These examples demonstrate common usage patterns for the GoogleModel.
+ */
+
+import { GoogleGenAI } from '@google/genai'
+import {
+  Agent,
+  DocumentBlock,
+  ImageBlock,
+  TextBlock,
+  VideoBlock,
+} from '@strands-agents/sdk'
+import { GoogleModel } from '@strands-agents/sdk/models/google'
+
+// Basic usage
+async function basicUsage() {
+  // --8<-- [start:basic_usage]
+  const model = new GoogleModel({
+    apiKey: '<KEY>',
+    modelId: 'gemini-2.5-flash',
+    params: {
+      temperature: 0.7,
+      maxOutputTokens: 2048,
+      topP: 0.9,
+      topK: 40,
+    },
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2')
+  console.log(response)
+  // --8<-- [end:basic_usage]
+}
+
+// Model parameters example
+async function paramsExample() {
+  // --8<-- [start:params_example]
+  const params = {
+    temperature: 0.8,
+    maxOutputTokens: 4096,
+    topP: 0.95,
+    topK: 40,
+    candidateCount: 1,
+    stopSequences: ['STOP!'],
+  }
+  // --8<-- [end:params_example]
+}
+
+// Built-in tools
+async function builtInTools() {
+  // --8<-- [start:builtin_tools]
+  const model = new GoogleModel({
+    apiKey: '<KEY>',
+    modelId: 'gemini-2.5-flash',
+    builtInTools: [{ googleSearch: {} }],
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke(
+    'What are the latest AI news today?'
+  )
+  console.log(response)
+  // --8<-- [end:builtin_tools]
+}
+
+// Error handling
+async function errorHandling() {
+  // --8<-- [start:error_handling]
+  try {
+    const response = await agent.invoke('Your query here')
+  } catch (error) {
+    console.error('Error:', error)
+    // Implement backoff strategy
+  }
+  // --8<-- [end:error_handling]
+}
+
+// Custom client
+async function customClient() {
+  // --8<-- [start:custom_client]
+  const client = new GoogleGenAI({ apiKey: '<KEY>' })
+
+  const model = new GoogleModel({
+    client,
+    modelId: 'gemini-2.5-flash',
+    params: {
+      temperature: 0.7,
+      maxOutputTokens: 2048,
+      topP: 0.9,
+      topK: 40,
+    },
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2')
+  console.log(response)
+  // --8<-- [end:custom_client]
+}
+
+// Image input
+async function imageInput() {
+  const imageBytes = new Uint8Array()
+  // --8<-- [start:image_input]
+  const model = new GoogleModel({
+    apiKey: '<KEY>',
+    modelId: 'gemini-2.5-flash',
+  })
+
+  const agent = new Agent({ model })
+
+  // Process image with text
+  const result = await agent.invoke([
+    new TextBlock('What do you see in this image?'),
+    new ImageBlock({
+      format: 'png',
+      source: { bytes: imageBytes },
+    }),
+  ])
+  // --8<-- [end:image_input]
+}
+
+// Document input
+async function documentInput() {
+  const pdfBytes = new Uint8Array()
+  // --8<-- [start:document_input]
+  const result = await agent.invoke([
+    new TextBlock('Summarize this document'),
+    new DocumentBlock({
+      name: 'my-document',
+      format: 'pdf',
+      source: { bytes: pdfBytes },
+    }),
+  ])
+  // --8<-- [end:document_input]
+}
+
+// Video input
+async function videoInput() {
+  const videoBytes = new Uint8Array()
+  // --8<-- [start:video_input]
+  const result = await agent.invoke([
+    new TextBlock('Describe what happens in this video'),
+    new VideoBlock({
+      format: 'mp4',
+      source: { bytes: videoBytes },
+    }),
+  ])
+  // --8<-- [end:video_input]
+}

--- a/src/content/docs/user-guide/concepts/model-providers/google_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/google_imports.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_usage_imports]
+import { Agent } from '@strands-agents/sdk'
+import { GoogleModel } from '@strands-agents/sdk/models/google'
+// --8<-- [end:basic_usage_imports]
+
+// --8<-- [start:custom_client_imports]
+import { GoogleGenAI } from '@google/genai'
+import { Agent } from '@strands-agents/sdk'
+import { GoogleModel } from '@strands-agents/sdk/models/google'
+// --8<-- [end:custom_client_imports]
+
+// --8<-- [start:image_imports]
+import { Agent, ImageBlock, TextBlock } from '@strands-agents/sdk'
+import { GoogleModel } from '@strands-agents/sdk/models/google'
+// --8<-- [end:image_imports]
+
+// --8<-- [start:document_imports]
+import { DocumentBlock, TextBlock } from '@strands-agents/sdk'
+// --8<-- [end:document_imports]
+
+// --8<-- [start:video_imports]
+import { VideoBlock, TextBlock } from '@strands-agents/sdk'
+// --8<-- [end:video_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/index.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/index.mdx
@@ -125,4 +125,4 @@ response = agent("What can you help me with?")
 - **[OpenAI](openai.md)** - GPT models with streaming support
 - **[Google](google.md)** - Google's Gemini models with tool calling support
 - **[Custom Providers](custom_model_provider.md)** - Build your own model integration
-- **[Anthropic](anthropic.md)** - Direct Claude API access (Python only)
+- **[Anthropic](anthropic.md)** - Direct Claude API access

--- a/test/known-routes.json
+++ b/test/known-routes.json
@@ -154,6 +154,7 @@
   "/latest/documentation/docs/user-guide/versioning-and-support/",
   "/docs/user-guide/concepts/model-providers/clova-studio/",
   "/docs/user-guide/concepts/model-providers/cohere/",
+  "/docs/user-guide/concepts/model-providers/gemini/",
   "/docs/user-guide/concepts/model-providers/nebius-token-factory/",
   "/docs/user-guide/concepts/model-providers/fireworksai/",
   "/docs/user-guide/concepts/model-providers/xai/",


### PR DESCRIPTION
## Description

Syncs the model provider documentation with the current TypeScript SDK implementation. Several provider pages were missing TypeScript examples or had outdated information.

**Anthropic** (most significant change): The page was marked Python-only but the TS SDK has a full `AnthropicModel` with streaming, tool calling, reasoning, and caching support. Added TypeScript tabs throughout (installation, usage, configuration, troubleshooting, custom client). Updated model ID from the deprecated `claude-sonnet-4-20250514` to `claude-sonnet-4-6`. Migrated all Anthropic doc links to `platform.claude.com`.

**Google**: Added a new Built-in Tools section documenting `gemini_tools` (Python) and `builtInTools` (TypeScript) for Google Search, Code Execution, and URL Context. Fixed a pre-existing bug where the sidebar navigation entry pointed to `gemini` but the file is `google.mdx`, causing Google to be missing from the left sidebar. Added a redirect from the old `gemini` URL. Added `@google/genai` TypeScript SDK link to references.

**Amazon Bedrock**: Documented the `apiKey` option on `BedrockModelOptions` for bearer token authentication (TypeScript-only feature).

**Custom Model Provider**: Removed deprecated structured output sections (three instances).

**Index (Overview)**: Removed the outdated "Python only" label from the Anthropic link in the Next Steps section.

### Testing

All code samples were verified with one-off scripts run against live APIs:
- **Anthropic basic usage (TS)**: Tested `AnthropicModel` with `claude-sonnet-4-6` via `npm install @strands-agents/sdk @anthropic-ai/sdk`, confirmed correct response.
- **Anthropic custom client (TS)**: Tested passing a pre-configured `Anthropic` client instance to `AnthropicModel`.
- **Google built-in tools (Python)**: Tested `gemini_tools` with `GoogleSearch`, confirmed grounded real-time results (current weather, time).
- **Google built-in tools (TS)**: Tested `builtInTools` with `{ googleSearch: {} }`, confirmed matching real-time results.
- Verified Python SDK does not support a `client` parameter for Anthropic (only `client_args`), so the custom client section is TypeScript-only.

## Related Issues

N/A

## Type of Change

- Content update/revision
- Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
