### PR TITLE
fix: default homepage code snippets to typescript

### DIFF
--- a/src/components/LanguageToggle.astro
+++ b/src/components/LanguageToggle.astro
@@ -216,6 +216,7 @@
 
     // Restore on page load
     var current = getPreference();
+    setPreference(current);
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', function () { syncAll(current); });
     } else {

--- a/src/components/landing/LangCodeBlock.astro
+++ b/src/components/landing/LangCodeBlock.astro
@@ -39,12 +39,12 @@ const hasTs = !!tsCode
     width: 100%;
   }
 
-  /* Default: show Python, hide TypeScript */
-  [data-lang-code="TypeScript"] {
+  /* Default: show TypeScript, hide Python (matches LanguageToggle default) */
+  [data-has-ts="true"] > [data-lang-code="Python"] {
     display: none;
   }
 
-  [data-lang-code="Python"] {
+  [data-has-ts="true"] > [data-lang-code="TypeScript"] {
     display: block;
   }
 
@@ -70,9 +70,9 @@ const hasTs = !!tsCode
 
   function getPreference(): string {
     try {
-      return localStorage.getItem(STORAGE_KEY) || 'Python'
+      return localStorage.getItem(STORAGE_KEY) || 'TypeScript'
     } catch {
-      return 'Python'
+      return 'TypeScript'
     }
   }
 


### PR DESCRIPTION
## Description

Fixes a first-visit bug where the homepage language toggle (LanguageToggle) defaults to TypeScript but the code snippets (LangCodeBlock) default to Python, causing them to disagree when localStorage is empty.

Three changes:
- **Align JS fallback** in LangCodeBlock from `'Python'` to `'TypeScript'` to match LanguageToggle
- **Flip CSS defaults** in LangCodeBlock to show TypeScript and hide Python before JS runs (scoped to paired blocks so Python-only examples like steering/guardrails remain visible)
- **Write default to localStorage on init** in LanguageToggle so the preference is available to all consumers immediately, not just after a click

## Related Issues

N/A

## Type of Change

- Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.