### PR TITLE
docs: Update method name for structured output in Ollama docs

### DIFF
--- a/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -197,7 +197,7 @@ factual_agent = Agent(model=factual_model)
 
 ### Structured Output
 
-Ollama supports structured output for models that have tool calling capabilities. When you use [`Agent.structured_output()`](@api/python/strands.agent.agent#Agent.structured_output), the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.
+Ollama supports structured output for models that have tool calling capabilities. When you use [`Agent.structured_output_model()`](@api/python/strands.agent.agent#Agent.structured_output_model), the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.
 
 ```python
 from pydantic import BaseModel, Field
@@ -219,7 +219,7 @@ ollama_model = OllamaModel(
 
 agent = Agent(model=ollama_model)
 
-result = agent.structured_output(
+result = agent.structured_output_model(
     BookAnalysis,
     """
     Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.

--- a/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -204,7 +204,6 @@ from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.ollama import OllamaModel
 
-# 1) Define the Pydantic model
 class BookAnalysis(BaseModel):
     """Analyze a book's key information."""
     title: str = Field(description="The book's title")
@@ -213,28 +212,25 @@ class BookAnalysis(BaseModel):
     summary: str = Field(description="Brief summary of the book")
     rating: int = Field(description="Rating from 1-10", ge=1, le=10)
 
-# 2) Define Ollama Model and Prompt
 ollama_model = OllamaModel(
     host="http://localhost:11434",
     model_id="llama3.1",
 )
 
-prompt = """
-    Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
-    It's a science fiction comedy about Arthur Dent's adventures through space
-    after Earth is destroyed. It's widely considered a classic of humorous sci-fi with good ratings.
-    """
-
-# 3) Pass the model to the agent
 agent = Agent(model=ollama_model)
-result = agent(prompt, structured_output_model=BookAnalysis)
 
-# 4) Access the `structured_output` from the result
-result_info: BookAnalysis = result.structured_output
-print(f"Title: {result_info.title}")
-print(f"Author: {result_info.author}")
-print(f"Genre: {result_info.genre}")
-print(f"Rating: {result_info.rating}")
+result = agent(
+    """Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
+    It's a science fiction comedy about Arthur Dent's adventures through space
+    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.""",
+    structured_output_model=BookAnalysis,
+)
+
+book_analysis: BookAnalysis = result.structured_output
+print(f"Title: {book_analysis.title}")
+print(f"Author: {book_analysis.author}")
+print(f"Genre: {book_analysis.genre}")
+print(f"Rating: {book_analysis.rating}")
 ```
 
 ## Tool Support

--- a/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -197,7 +197,7 @@ factual_agent = Agent(model=factual_model)
 
 ### Structured Output
 
-Ollama supports structured output for models that have tool calling capabilities. When you use [`Agent.structured_output()`](@api/python/strands.agent.agent#Agent.structured_output) and pass `structured_output_model` parameter to the agent invocation, the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.
+Ollama supports structured output for models that have tool calling capabilities. When you pass `structured_output_model` parameter to the [agent invocation](@api/python/strands.agent.agent#Agent.__call__), the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.
 
 ```python
 from pydantic import BaseModel, Field

--- a/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -197,13 +197,14 @@ factual_agent = Agent(model=factual_model)
 
 ### Structured Output
 
-Ollama supports structured output for models that have tool calling capabilities. When you use [`Agent.structured_output_model()`](@api/python/strands.agent.agent#Agent.structured_output_model), the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.
+Ollama supports structured output for models that have tool calling capabilities. When you use [`Agent.structured_output()`](@api/python/strands.agent.agent#Agent.structured_output) and pass `structured_output_model` parameter to the agent invocation, the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.
 
 ```python
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models.ollama import OllamaModel
 
+# 1) Define the Pydantic model
 class BookAnalysis(BaseModel):
     """Analyze a book's key information."""
     title: str = Field(description="The book's title")
@@ -212,26 +213,28 @@ class BookAnalysis(BaseModel):
     summary: str = Field(description="Brief summary of the book")
     rating: int = Field(description="Rating from 1-10", ge=1, le=10)
 
+# 2) Define Ollama Model and Prompt
 ollama_model = OllamaModel(
     host="http://localhost:11434",
     model_id="llama3.1",
 )
 
-agent = Agent(model=ollama_model)
-
-result = agent.structured_output_model(
-    BookAnalysis,
-    """
+prompt = """
     Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
     It's a science fiction comedy about Arthur Dent's adventures through space
-    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.
+    after Earth is destroyed. It's widely considered a classic of humorous sci-fi with good ratings.
     """
-)
 
-print(f"Title: {result.title}")
-print(f"Author: {result.author}")
-print(f"Genre: {result.genre}")
-print(f"Rating: {result.rating}")
+# 3) Pass the model to the agent
+agent = Agent(model=ollama_model)
+result = agent(prompt, structured_output_model=BookAnalysis)
+
+# 4) Access the `structured_output` from the result
+result_info: BookAnalysis = result.structured_output
+print(f"Title: {result_info.title}")
+print(f"Author: {result_info.author}")
+print(f"Genre: {result_info.genre}")
+print(f"Rating: {result_info.rating}")
 ```
 
 ## Tool Support


### PR DESCRIPTION
## Description

When executing the example provided in the below documentation page: 
https://strandsagents.com/docs/user-guide/concepts/model-providers/ollama/#structured-output

A deprecation warning is displayed as below:
```
DeprecationWarning: Agent.structured_output method is deprecated. You should pass in `structured_output_model` directly into the agent invocation. see: https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/structured-output/
```

## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change

- Content update/revision
- Typo/formatting fix

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.