### PR TITLE
docs(context): update offloader for TS availability

### DIFF
--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -67,14 +67,9 @@ agent = Agent(plugins=[
 <Tab label="TypeScript">
 
 ```typescript
-const agent = new Agent({
-  plugins: [
-    new ContextOffloader({
-      storage: new FileStorage('./artifacts'),
-      includeRetrievalTool: false,
-    }),
-  ],
-})
+--8<-- "user-guide/concepts/plugins/context-offloader_imports.ts:disable_retrieval_tool"
+
+--8<-- "user-guide/concepts/plugins/context-offloader.ts:disable_retrieval_tool"
 ```
 </Tab>
 </Tabs>
@@ -101,12 +96,9 @@ agent = Agent(plugins=[
 <Tab label="TypeScript">
 
 ```typescript
-import { Agent } from '@strands-agents/sdk'
-import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+--8<-- "user-guide/concepts/plugins/context-offloader_imports.ts:getting_started"
 
-const agent = new Agent({
-  plugins: [new ContextOffloader({ storage: new InMemoryStorage() })],
-})
+--8<-- "user-guide/concepts/plugins/context-offloader.ts:getting_started"
 ```
 </Tab>
 </Tabs>
@@ -129,15 +121,9 @@ agent = Agent(plugins=[
 <Tab label="TypeScript">
 
 ```typescript
-const agent = new Agent({
-  plugins: [
-    new ContextOffloader({
-      storage: new InMemoryStorage(),
-      maxResultTokens: 5_000,
-      previewTokens: 2_000,
-    }),
-  ],
-})
+--8<-- "user-guide/concepts/plugins/context-offloader_imports.ts:custom_thresholds"
+
+--8<-- "user-guide/concepts/plugins/context-offloader.ts:custom_thresholds"
 ```
 </Tab>
 </Tabs>
@@ -175,15 +161,9 @@ agent = Agent(plugins=[
 <Tab label="TypeScript">
 
 ```typescript
-import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+--8<-- "user-guide/concepts/plugins/context-offloader_imports.ts:in_memory_storage"
 
-const agent = new Agent({
-  plugins: [
-    new ContextOffloader({
-      storage: new InMemoryStorage(),
-    }),
-  ],
-})
+--8<-- "user-guide/concepts/plugins/context-offloader.ts:in_memory_storage"
 ```
 </Tab>
 </Tabs>
@@ -209,15 +189,9 @@ agent = Agent(plugins=[
 <Tab label="TypeScript">
 
 ```typescript
-import { ContextOffloader, FileStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+--8<-- "user-guide/concepts/plugins/context-offloader_imports.ts:file_storage"
 
-const agent = new Agent({
-  plugins: [
-    new ContextOffloader({
-      storage: new FileStorage('./artifacts'),
-    }),
-  ],
-})
+--8<-- "user-guide/concepts/plugins/context-offloader.ts:file_storage"
 ```
 </Tab>
 </Tabs>
@@ -246,17 +220,9 @@ agent = Agent(plugins=[
 <Tab label="TypeScript">
 
 ```typescript
-import { ContextOffloader, S3Storage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+--8<-- "user-guide/concepts/plugins/context-offloader_imports.ts:s3_storage"
 
-const agent = new Agent({
-  plugins: [
-    new ContextOffloader({
-      storage: new S3Storage('my-agent-artifacts', {
-        prefix: 'tool-results/',
-      }),
-    }),
-  ],
-})
+--8<-- "user-guide/concepts/plugins/context-offloader.ts:s3_storage"
 ```
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -1,6 +1,5 @@
 ---
 title: Context Offloader
-languages: [python]
 sidebar:
   badge:
     text: New
@@ -19,12 +18,12 @@ The default [`SlidingWindowConversationManager`](../agents/conversation-manageme
 
 ## How It Works
 
-After each tool call, the plugin estimates the result's token count using the agent's `model.count_tokens()` method and compares it against the `max_result_tokens` threshold (default: 2,500 tokens). If the result exceeds it, the plugin:
+After each tool call, the plugin estimates the result's token count and compares it against the `max_result_tokens` threshold (default: 2,500 tokens). If the result exceeds it, the plugin:
 
 1. Stores each content block individually in the configured storage backend, preserving its content type
 2. Replaces the in-context result with the first `preview_tokens` tokens (default: 1,000) plus per-block storage references
 
-Token estimation uses tiktoken when available for accurate counts, falling back to a chars/4 heuristic. Preview slicing also uses tiktoken for exact token-level cuts when available.
+Token estimation uses `model.count_tokens()`, which delegates to the model provider's counting API if available, falls back to tiktoken if installed, and otherwise uses a chars/4 heuristic.
 
 Results under the threshold pass through unchanged.
 
@@ -51,7 +50,10 @@ For non-text content, the plugin replaces the result with a descriptive placehol
 
 The plugin includes a `retrieve_offloaded_content` tool that lets the agent fetch offloaded content by reference, returning it in its native format — text as a string, JSON as a JSON block, images as image blocks, and documents as document blocks. This tool is registered by default.
 
-The inline guidance in offloaded results tells the agent to use its available tools to selectively access the data it needs, and mentions `retrieve_offloaded_content` as a fallback. If the agent already has tools that can access the storage backend directly (file readers, shell, etc.), you can disable it with `include_retrieval_tool=False`:
+The inline guidance in offloaded results tells the agent to use its available tools to selectively access the data it needs, and mentions `retrieve_offloaded_content` as a fallback. If the agent already has tools that can access the storage backend directly (file readers, shell, etc.), you can disable it:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 agent = Agent(plugins=[
@@ -61,10 +63,28 @@ agent = Agent(plugins=[
     )
 ])
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+const agent = new Agent({
+  plugins: [
+    new ContextOffloader({
+      storage: new FileStorage('./artifacts'),
+      includeRetrievalTool: false,
+    }),
+  ],
+})
+```
+</Tab>
+</Tabs>
 
 ## Getting Started
 
 Pass a `ContextOffloader` instance to your agent's `plugins` list with your choice of storage backend:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands import Agent
@@ -77,8 +97,24 @@ agent = Agent(plugins=[
     ContextOffloader(storage=InMemoryStorage())
 ])
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+
+const agent = new Agent({
+  plugins: [new ContextOffloader({ storage: new InMemoryStorage() })],
+})
+```
+</Tab>
+</Tabs>
 
 To customize the token thresholds:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 agent = Agent(plugins=[
@@ -89,6 +125,22 @@ agent = Agent(plugins=[
     )
 ])
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+const agent = new Agent({
+  plugins: [
+    new ContextOffloader({
+      storage: new InMemoryStorage(),
+      maxResultTokens: 5_000,
+      previewTokens: 2_000,
+    }),
+  ],
+})
+```
+</Tab>
+</Tabs>
 
 ### Storage Backends
 
@@ -100,9 +152,46 @@ Choose a storage backend based on your needs:
 | `FileStorage` | Disk | Local development, debugging, inspecting stored artifacts |
 | `S3Storage` | Amazon S3 | Production workloads, shared or durable artifact retention |
 
-All backends implement the `OffloadStorage` protocol and preserve content type metadata, so you can also build your own.
+All backends implement the `Storage` protocol and preserve content type metadata, so you can also build your own.
+
+**In-memory storage** — stores content in process memory, useful for development and testing:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.vended_plugins.context_offloader import (
+    ContextOffloader,
+    InMemoryStorage,
+)
+
+agent = Agent(plugins=[
+    ContextOffloader(
+        storage=InMemoryStorage(),
+    )
+])
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+
+const agent = new Agent({
+  plugins: [
+    new ContextOffloader({
+      storage: new InMemoryStorage(),
+    }),
+  ],
+})
+```
+</Tab>
+</Tabs>
 
 **File storage** — persists to a local directory with `.metadata.json` sidecars for content type tracking:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands.vended_plugins.context_offloader import (
@@ -116,8 +205,27 @@ agent = Agent(plugins=[
     )
 ])
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+import { ContextOffloader, FileStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+
+const agent = new Agent({
+  plugins: [
+    new ContextOffloader({
+      storage: new FileStorage('./artifacts'),
+    }),
+  ],
+})
+```
+</Tab>
+</Tabs>
 
 **S3 storage** — persists to an Amazon S3 bucket with content type preserved via S3 object metadata:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands.vended_plugins.context_offloader import (
@@ -134,8 +242,29 @@ agent = Agent(plugins=[
     )
 ])
 ```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+import { ContextOffloader, S3Storage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+
+const agent = new Agent({
+  plugins: [
+    new ContextOffloader({
+      storage: new S3Storage('my-agent-artifacts', {
+        prefix: 'tool-results/',
+      }),
+    }),
+  ],
+})
+```
+</Tab>
+</Tabs>
 
 ## Configuration
+
+<Tabs>
+<Tab label="Python">
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -143,6 +272,19 @@ agent = Agent(plugins=[
 | `max_result_tokens` | `2_500` | Results whose estimated token count exceeds this are offloaded |
 | `preview_tokens` | `1_000` | Number of tokens to keep as an in-context preview |
 | `include_retrieval_tool` | `True` | Registers a `retrieve_offloaded_content` tool the agent can use to fetch full content by reference. Enabled by default; set to `False` to disable |
+
+</Tab>
+<Tab label="TypeScript">
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `storage` | *(required)* | Storage backend instance |
+| `maxResultTokens` | `2_500` | Results whose estimated token count exceeds this are offloaded |
+| `previewTokens` | `1_000` | Number of tokens to keep as an in-context preview |
+| `includeRetrievalTool` | `true` | Registers a `retrieve_offloaded_content` tool the agent can use to fetch full content by reference. Enabled by default; set to `false` to disable |
+
+</Tab>
+</Tabs>
 
 ## Tradeoffs
 

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -23,7 +23,7 @@ After each tool call, the plugin estimates the result's token count and compares
 1. Stores each content block individually in the configured storage backend, preserving its content type
 2. Replaces the in-context result with the first `preview_tokens` tokens (default: 1,000) plus per-block storage references
 
-Token estimation uses `model.count_tokens()`, which delegates to the model provider's counting API if available, falls back to tiktoken if installed, and otherwise uses a chars/4 heuristic.
+Token estimation uses `model.count_tokens()`, which delegates to the model provider's counting API if available, otherwise falling back to a chars/4 heuristic. In Python, tiktoken is used as an intermediate fallback when installed.
 
 Results under the threshold pass through unchanged.
 

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.ts
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.ts
@@ -1,0 +1,118 @@
+import { Agent } from '@strands-agents/sdk'
+import {
+  ContextOffloader,
+  InMemoryStorage,
+  FileStorage,
+  S3Storage,
+} from '@strands-agents/sdk/vended-plugins/context-offloader'
+
+declare const model: any
+
+// =====================
+// Disable Retrieval Tool
+// =====================
+
+{
+  // --8<-- [start:disable_retrieval_tool]
+  const agent = new Agent({
+    plugins: [
+      new ContextOffloader({
+        storage: new FileStorage('./artifacts'),
+        includeRetrievalTool: false,
+      }),
+    ],
+  })
+  // --8<-- [end:disable_retrieval_tool]
+
+  void agent
+}
+
+// =====================
+// Getting Started
+// =====================
+
+{
+  // --8<-- [start:getting_started]
+  const agent = new Agent({
+    plugins: [new ContextOffloader({ storage: new InMemoryStorage() })],
+  })
+  // --8<-- [end:getting_started]
+
+  void agent
+}
+
+// =====================
+// Custom Thresholds
+// =====================
+
+{
+  // --8<-- [start:custom_thresholds]
+  const agent = new Agent({
+    plugins: [
+      new ContextOffloader({
+        storage: new InMemoryStorage(),
+        maxResultTokens: 5_000,
+        previewTokens: 2_000,
+      }),
+    ],
+  })
+  // --8<-- [end:custom_thresholds]
+
+  void agent
+}
+
+// =====================
+// In-Memory Storage
+// =====================
+
+{
+  // --8<-- [start:in_memory_storage]
+  const agent = new Agent({
+    plugins: [
+      new ContextOffloader({
+        storage: new InMemoryStorage(),
+      }),
+    ],
+  })
+  // --8<-- [end:in_memory_storage]
+
+  void agent
+}
+
+// =====================
+// File Storage
+// =====================
+
+{
+  // --8<-- [start:file_storage]
+  const agent = new Agent({
+    plugins: [
+      new ContextOffloader({
+        storage: new FileStorage('./artifacts'),
+      }),
+    ],
+  })
+  // --8<-- [end:file_storage]
+
+  void agent
+}
+
+// =====================
+// S3 Storage
+// =====================
+
+{
+  // --8<-- [start:s3_storage]
+  const agent = new Agent({
+    plugins: [
+      new ContextOffloader({
+        storage: new S3Storage('my-agent-artifacts', {
+          prefix: 'tool-results/',
+        }),
+      }),
+    ],
+  })
+  // --8<-- [end:s3_storage]
+
+  void agent
+}

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.ts
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.ts
@@ -6,7 +6,6 @@ import {
   S3Storage,
 } from '@strands-agents/sdk/vended-plugins/context-offloader'
 
-declare const model: any
 
 // =====================
 // Disable Retrieval Tool

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader_imports.ts
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader_imports.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+// Import snippets — intentionally repeat imports across blocks so each
+// rendered doc example is self-contained.
+
+// --8<-- [start:disable_retrieval_tool]
+import { Agent } from '@strands-agents/sdk'
+import { ContextOffloader, FileStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+// --8<-- [end:disable_retrieval_tool]
+
+// --8<-- [start:getting_started]
+import { Agent } from '@strands-agents/sdk'
+import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+// --8<-- [end:getting_started]
+
+// --8<-- [start:custom_thresholds]
+import { Agent } from '@strands-agents/sdk'
+import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+// --8<-- [end:custom_thresholds]
+
+// --8<-- [start:in_memory_storage]
+import { Agent } from '@strands-agents/sdk'
+import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+// --8<-- [end:in_memory_storage]
+
+// --8<-- [start:file_storage]
+import { Agent } from '@strands-agents/sdk'
+import { ContextOffloader, FileStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+// --8<-- [end:file_storage]
+
+// --8<-- [start:s3_storage]
+import { Agent } from '@strands-agents/sdk'
+import { ContextOffloader, S3Storage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+// --8<-- [end:s3_storage]


### PR DESCRIPTION
## Description

Adds TS support availability for context offloader

## Related Issues

strands-agents/sdk-typescript#974

## Type of Change

- Content update/revision

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working