### PR TITLE
docs(traces): add Future AGI to OTel-compatible visualization tools

### DIFF
--- a/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -292,6 +292,7 @@ Common visualization options include:
 3. **AWS X-Ray**: For AWS-based applications
 4. **Zipkin**: Lightweight distributed tracing
 5. **Opik**: For evaluating and optimizing multi-agent systems
+6. **[Future AGI](https://futureagi.com)**: For agent traces, online and offline evaluations, and self-improvement loops
 
 ## Local Development Setup
 


### PR DESCRIPTION
## Summary

Adds [Future AGI](https://futureagi.com) to the bulleted list of OpenTelemetry-compatible visualization options in `src/content/docs/user-guide/observability-evaluation/traces.mdx`, alongside Jaeger, Langfuse, AWS X-Ray, Zipkin, and Opik.

Future AGI is an open-source e2e agent engineering and optimization platform that helps you ship self-improving AI agents. It accepts standard OTLP/HTTP at `https://api.futureagi.com/tracer/v1/traces`, so an existing Strands `StrandsTelemetry().setup_otlp_exporter()` configuration works unchanged when pointed at the Future AGI endpoint via `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS`.

## What changed

- One new bullet in the "Common visualization options include:" list.
- No code, config, or other docs touched.

## Smoke test

Verified the Future AGI tracer endpoint accepts OTLP/HTTP from a vanilla Python OTel SDK:

- `POST https://api.futureagi.com/tracer/v1/traces` with `x-api-key` + `x-secret-key` headers → `HTTP 200 OK`.
- A test span with `project_name` resource attribute landed in the Future AGI dashboard under the named project.

## Test plan

- [ ] Astro / mkdocs build passes
- [ ] Maintainer happy with the one-line addition (also open to writing a fuller community integration page under `src/content/docs/community/integrations/` if preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)