### PR TITLE
docs(community): add Future AGI integration page

### DIFF
--- a/src/content/docs/community/integrations/future-agi.mdx
+++ b/src/content/docs/community/integrations/future-agi.mdx
@@ -1,0 +1,95 @@
+---
+title: Trace and evaluate Strands agents with Future AGI
+community: true
+description: Future AGI integration
+integrationType: integration
+languages: Python
+sidebar:
+  label: "Future AGI"
+---
+
+
+[Future AGI](https://futureagi.com) is an open-source e2e agent engineering and optimization platform that helps you ship self-improving AI agents. Strands traces export over OpenTelemetry, so they can be sent to the Future AGI tracer endpoint without any code changes to your agent.
+
+This page walks through two setup paths:
+
+1. The recommended `traceai-strands` package, which wires up the project resource attributes Future AGI uses to bucket spans into a named project.
+2. A manual setup using only Strands' built-in OpenTelemetry support and OTLP environment variables.
+
+## Prerequisites
+
+Sign up at [app.futureagi.com](https://app.futureagi.com) and copy your `FI_API_KEY` and `FI_SECRET_KEY` from the dashboard.
+
+```bash
+export FI_API_KEY="your-fi-api-key"
+export FI_SECRET_KEY="your-fi-secret-key"
+```
+
+## Option 1: Recommended setup with `traceai-strands`
+
+Install Strands with OpenTelemetry support and the Future AGI integration package:
+
+```bash
+pip install 'strands-agents[otel]' traceai-strands
+```
+
+Register the tracer once at startup, then attach it to Strands. The `register()` call sets all the resource attributes Future AGI needs to surface the project in the dashboard.
+
+```python
+from fi_instrumentation import register
+from fi_instrumentation.fi_types import ProjectType
+from traceai_strands import configure_strands_tracing
+
+trace_provider = register(
+    project_type=ProjectType.OBSERVE,
+    project_name="my-strands-agent",
+)
+configure_strands_tracing(tracer_provider=trace_provider)
+
+from strands import Agent
+
+agent = Agent(
+    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+    system_prompt="You are a helpful assistant.",
+)
+
+response = agent("Hello!")
+```
+
+Open your project in the [Future AGI dashboard](https://app.futureagi.com) to inspect the run tree, prompts, completions, model parameters, token usage, and tool execution details.
+
+## Option 2: Manual setup with `StrandsTelemetry`
+
+If you would rather not add another package, you can configure Strands' built-in OTLP exporter directly. Future AGI's tracer endpoint accepts standard OTLP/HTTP at `https://api.futureagi.com/tracer/v1/traces`.
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.futureagi.com/tracer/v1/traces"
+export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=${FI_API_KEY},x-secret-key=${FI_SECRET_KEY}"
+export OTEL_RESOURCE_ATTRIBUTES="project_name=my-strands-agent,project_type=observe,project_version_name=DEFAULT"
+```
+
+```python
+from strands.telemetry import StrandsTelemetry
+
+StrandsTelemetry().setup_otlp_exporter()
+
+from strands import Agent
+
+agent = Agent(
+    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+    system_prompt="You are a helpful assistant.",
+)
+
+response = agent("Hello!")
+```
+
+The `project_name`, `project_type`, and `project_version_name` resource attributes are required for Future AGI to bucket spans into a named project — without them, traces are accepted but not surfaced in the dashboard. Option 1 sets these automatically.
+
+## What gets traced
+
+Once configured, every agent invocation, model call, tool execution, and event-loop cycle is captured as an OpenTelemetry span and forwarded to Future AGI. See the [Strands traces page](/docs/user-guide/observability-evaluation/traces) for the full attribute schema.
+
+## Resources
+
+- [`traceai-strands` on PyPI](https://pypi.org/project/traceai-strands/)
+- [Future AGI Strands integration guide](https://docs.futureagi.com)


### PR DESCRIPTION
## Summary

Adds a community integration page at `src/content/docs/community/integrations/future-agi.mdx` documenting how to send Strands agent traces to [Future AGI](https://futureagi.com) — an open-source e2e agent engineering and optimization platform that helps you ship self-improving AI agents.

The page mirrors the structure of the existing `ag-ui.mdx` community integration page (frontmatter, tone, length).

## What changed

- New file: `src/content/docs/community/integrations/future-agi.mdx`
- Two setup paths covered:
  1. Recommended: `traceai-strands` + `fi_instrumentation.register()` + `configure_strands_tracing()` — handles the project resource attributes Future AGI uses for dashboard bucketing.
  2. Manual: Strands' built-in `StrandsTelemetry().setup_otlp_exporter()` plus `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` / `OTEL_RESOURCE_ATTRIBUTES` env vars.

## Smoke test

Verified end-to-end against the Future AGI tracer endpoint:

- `POST https://api.futureagi.com/tracer/v1/traces` with `x-api-key` + `x-secret-key` → `HTTP 200 OK`.
- A test span carrying `project_name`, `project_type=observe`, `project_version_name=DEFAULT`, and `project_version_id` resource attributes surfaced in the Future AGI dashboard under the named project. Spans without those attributes are accepted but land in the unnamed bucket — this is why the page leads with the `traceai-strands` path.

## Relationship to #809

This is a separate, additive PR. #809 adds a single bullet to the visualization-options list in `traces.mdx`. This PR adds the fuller community-integration page. Either or both can be merged independently.

## Test plan

- [ ] Astro / mkdocs build passes
- [ ] Maintainer happy with placement under `community/integrations/` (matches `ag-ui.mdx`)
- [ ] Confirm wording on the resource-attribute caveat is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)