### PR TITLE
fix: add interrupt to tool context to fix ci

### DIFF
--- a/src/content/docs/user-guide/concepts/tools/tools.ts
+++ b/src/content/docs/user-guide/concepts/tools/tools.ts
@@ -302,6 +302,9 @@ async function directInvocationExample() {
       },
       agent: agent,
       invocationState: {},
+      interrupt: () => {
+        throw new Error('not supported')
+      },
     }
   )
 


### PR DESCRIPTION
## Description

Adds missing `interrupt` property to the `ToolContext` object in the direct tool invocation docs example. The `interrupt` field became required on `ToolContext` after the SDK's interrupts PR (#784), which caused the `typecheck:snippets` CI check to fail.


## Related Issues
https://github.com/strands-agents/sdk-typescript/pull/784

## Type of Change

- Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.