### PR TITLE
docs(hooks): add hooks order priority

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -392,11 +392,13 @@ After event callbacks run in reverse registration order for cleanup symmetry:
 
 By default, After event callbacks run in reverse registration order for cleanup symmetry. You can override this with explicit priority using the `order` option — lower values run first.
 
-The SDK exports named constants for common priorities:
+The SDK exports convenience constants for common priorities:
 
-- `HookOrder.FIRST` (-100) — runs before all other hooks
+- `HookOrder.FIRST` (-100) — convenience preset for early hooks
 - `HookOrder.DEFAULT` (0) — implicit when no order is specified
-- `HookOrder.LAST` (100) — runs after all other hooks
+- `HookOrder.LAST` (100) — convenience preset for late hooks
+
+These are not enforced bounds — any numeric value works. For guaranteed absolute ordering, use `-Infinity` or `Infinity`.
 
 ```typescript
 --8<-- "user-guide/concepts/agents/hooks.ts:hook_ordering"

--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -392,13 +392,13 @@ After event callbacks run in reverse registration order for cleanup symmetry:
 
 By default, After event callbacks run in reverse registration order for cleanup symmetry. You can override this with explicit priority using the `order` option — lower values run first.
 
-The SDK exports convenience constants for common priorities:
+The SDK exports convenience presets that mark where the SDK's own hooks run, so you can position yours relative to them:
 
-- `HookOrder.FIRST` (-100) — convenience preset for early hooks
+- `HookOrder.SDK_FIRST` (-100) — where the SDK's earliest hooks run
 - `HookOrder.DEFAULT` (0) — implicit when no order is specified
-- `HookOrder.LAST` (100) — convenience preset for late hooks
+- `HookOrder.SDK_LAST` (100) — where the SDK's latest hooks run
 
-These are not enforced bounds — any numeric value works. For guaranteed absolute ordering, use `-Infinity` or `Infinity`.
+These are not enforced bounds — any numeric value works. Use values beyond them (e.g. `SDK_FIRST - 1`) to run before or after the SDK's hooks, or `-Infinity`/`Infinity` for guaranteed absolute ordering.
 
 ```typescript
 --8<-- "user-guide/concepts/agents/hooks.ts:hook_ordering"

--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -379,7 +379,33 @@ Most event properties are read-only to prevent unintended modifications. However
 
 ### Callback Ordering
 
-Some events come in pairs, such as Before/After events. The After event callbacks are always called in reverse order from the Before event callbacks to ensure proper cleanup semantics.
+<Tabs>
+<Tab label="Python">
+
+After event callbacks run in reverse registration order for cleanup symmetry:
+
+- **Before**: A, B, C (registration order)
+- **After**: C, B, A (reverse registration order)
+
+</Tab>
+<Tab label="TypeScript">
+
+By default, After event callbacks run in reverse registration order for cleanup symmetry. You can override this with explicit priority using the `order` option — lower values run first.
+
+The SDK exports named constants for common priorities:
+
+- `HookOrder.FIRST` (-100) — runs before all other hooks
+- `HookOrder.DEFAULT` (0) — implicit when no order is specified
+- `HookOrder.LAST` (100) — runs after all other hooks
+
+```typescript
+--8<-- "user-guide/concepts/agents/hooks.ts:hook_ordering"
+```
+
+Within the same order group, Before events preserve registration order and After events reverse it.
+
+</Tab>
+</Tabs>
 
 ## Advanced Usage
 

--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -401,6 +401,8 @@ The SDK exports convenience presets that mark where the SDK's own hooks run, so 
 These are not enforced bounds — any numeric value works. Use values beyond them (e.g. `SDK_FIRST - 1`) to run before or after the SDK's hooks, or `-Infinity`/`Infinity` for guaranteed absolute ordering.
 
 ```typescript
+--8<-- "user-guide/concepts/agents/hooks_imports.ts:hook_ordering_imports"
+
 --8<-- "user-guide/concepts/agents/hooks.ts:hook_ordering"
 ```
 

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -79,26 +79,19 @@ async function hookOrderingExample() {
   const agent = new Agent()
 
   agent.addHook(BeforeToolCallEvent, (event) => {
-    console.log('[security] Checking permissions')
-  }, { order: HookOrder.SDK_FIRST })  // -100
-
-  // Arbitrary numbers for fine-grained control
-  agent.addHook(BeforeToolCallEvent, (event) => {
-    console.log('[validation] Validating input')
-  }, { order: -50 })
-
-  agent.addHook(BeforeToolCallEvent, (event) => {
     console.log('[logging] Tool called:', event.toolUse.name)
   })  // HookOrder.DEFAULT (0)
-
-  agent.addHook(BeforeToolCallEvent, (event) => {
-    console.log('[metrics] Recording call')
-  }, { order: HookOrder.SDK_LAST })  // 100
 
   // Run before the SDK's earliest hooks
   agent.addHook(BeforeToolCallEvent, (event) => {
     console.log('[guardrail] Runs before SDK hooks')
   }, { order: HookOrder.SDK_FIRST - 1 })
+
+
+  // Arbitrary numbers for fine-grained control
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    console.log('[validation] Validating input')
+  }, { order: -50 })
 
   // Use -Infinity/Infinity for guaranteed absolute first/last
   agent.addHook(BeforeToolCallEvent, (event) => {

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -94,6 +94,11 @@ async function hookOrderingExample() {
   agent.addHook(BeforeToolCallEvent, (event) => {
     console.log('[metrics] Recording call')
   }, { order: HookOrder.LAST })  // 100
+
+  // Use -Infinity/Infinity for guaranteed absolute first/last
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    console.log('[guardrail] Always runs first, no matter what')
+  }, { order: -Infinity })
   // --8<-- [end:hook_ordering]
 }
 

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -1,4 +1,4 @@
-import { Agent, FunctionTool } from '@strands-agents/sdk'
+import { Agent, FunctionTool, HookOrder } from '@strands-agents/sdk'
 import type { LocalAgent, Plugin } from '@strands-agents/sdk'
 import {
   BeforeInvocationEvent,
@@ -72,6 +72,29 @@ async function individualCallbackExample() {
 
   agent.addHook(BeforeInvocationEvent, myCallback)
   // --8<-- [end:individual_callback]
+}
+
+async function hookOrderingExample() {
+  // --8<-- [start:hook_ordering]
+  const agent = new Agent()
+
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    console.log('[security] Checking permissions')
+  }, { order: HookOrder.FIRST })  // -100
+
+  // Arbitrary numbers for fine-grained control
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    console.log('[validation] Validating input')
+  }, { order: -50 })
+
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    console.log('[logging] Tool called:', event.toolUse.name)
+  })  // HookOrder.DEFAULT (0)
+
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    console.log('[metrics] Recording call')
+  }, { order: HookOrder.LAST })  // 100
+  // --8<-- [end:hook_ordering]
 }
 
 // =====================
@@ -445,6 +468,7 @@ async function layeredHooksExample() {
 
 // Suppress unused function warnings
 void invocationStateInHooksExample
+void hookOrderingExample
 void limitToolCountsExample
 void orchestratorCallbackExample
 void conditionalNodeExecutionExample

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -80,7 +80,7 @@ async function hookOrderingExample() {
 
   agent.addHook(BeforeToolCallEvent, (event) => {
     console.log('[security] Checking permissions')
-  }, { order: HookOrder.FIRST })  // -100
+  }, { order: HookOrder.SDK_FIRST })  // -100
 
   // Arbitrary numbers for fine-grained control
   agent.addHook(BeforeToolCallEvent, (event) => {
@@ -93,11 +93,16 @@ async function hookOrderingExample() {
 
   agent.addHook(BeforeToolCallEvent, (event) => {
     console.log('[metrics] Recording call')
-  }, { order: HookOrder.LAST })  // 100
+  }, { order: HookOrder.SDK_LAST })  // 100
+
+  // Run before the SDK's earliest hooks
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    console.log('[guardrail] Runs before SDK hooks')
+  }, { order: HookOrder.SDK_FIRST - 1 })
 
   // Use -Infinity/Infinity for guaranteed absolute first/last
   agent.addHook(BeforeToolCallEvent, (event) => {
-    console.log('[guardrail] Always runs first, no matter what')
+    console.log('[absolute] Always runs first, no matter what')
   }, { order: -Infinity })
   // --8<-- [end:hook_ordering]
 }

--- a/src/content/docs/user-guide/concepts/agents/hooks_imports.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks_imports.ts
@@ -1,0 +1,5 @@
+// @ts-nocheck
+
+// --8<-- [start:hook_ordering_imports]
+import { Agent, HookOrder, BeforeToolCallEvent } from '@strands-agents/sdk'
+// --8<-- [end:hook_ordering_imports]


### PR DESCRIPTION
## Description

Documents the new hook ordering feature added in [strands-agents/sdk-typescript#1005](https://github.com/strands-agents/sdk-typescript/pull/1005) and the rename from [strands-agents/sdk-typescript#1024](https://github.com/strands-agents/sdk-typescript/pull/1024). Expands the "Callback Ordering" section in the hooks page with:

- TypeScript tab documenting the `order` option for `addHook` and `HookOrder` presets (`SDK_FIRST`, `DEFAULT`, `SDK_LAST`)
- Python tab explaining existing reverse-ordering behavior
- Code example showing priority-based hook registration, relative positioning, and absolute ordering with `-Infinity`

## Related Issues

https://github.com/strands-agents/sdk-typescript/pull/1005
https://github.com/strands-agents/sdk-typescript/pull/1024

## Type of Change

- New content

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.