### PR TITLE
docs(blogs): added strands-evals blogs

### DIFF
--- a/src/content/authors.yaml
+++ b/src/content/authors.yaml
@@ -87,3 +87,48 @@
   name: Patrick Gray
   role: "Software Engineer, AWS Agentic AI"
   bio: Patrick is a Software Engineer at AWS Agentic AI working on the Strands Agents SDK.
+
+- id: ishan-singh
+  name: Ishan Singh
+  role: "Sr. Applied Scientist, AWS"
+  bio: Ishan Singh is a Sr. Applied Scientist at Amazon Web Services, helping customers build generative AI solutions with expertise in building innovative and responsible AI products.
+
+- id: abhishek-kumar
+  name: Abhishek Kumar
+  role: "Applied Scientist, AWS"
+  bio: Abhishek Kumar is an Applied Scientist at AWS focusing on agent observability, simulation, and evaluation.
+
+- id: jonathan-buck
+  name: Jonathan Buck
+  role: "Senior Software Engineer, AWS"
+  bio: Jonathan Buck is a Senior Software Engineer at Amazon Web Services focused on building agent environments, evaluation infrastructure, and systems to support productization of agentic AI.
+
+- id: vinayak-arannil
+  name: Vinayak Arannil
+  role: "Sr. Applied Scientist, AWS"
+  bio: Vinayak Arannil is a Sr. Applied Scientist at Amazon Web Services helping build capabilities on AgentCore and Strands to enable customers to evaluate agentic applications.
+
+- id: akarsha-sehwag
+  name: Akarsha Sehwag
+  role: "Generative AI Data Scientist, AWS"
+  bio: Akarsha Sehwag is a Generative AI Data Scientist for the Amazon Bedrock AgentCore team with over 6 years of experience in production AI/ML solutions across enterprise sectors.
+
+- id: po-shin-chen
+  name: Po-Shin Chen
+  role: "Software Developer, AWS"
+  bio: Po-Shin Chen is a Software Developer focusing on agentic AI development and evaluations at Amazon Web Services, responsible for core capabilities in agent frameworks and evaluation.
+
+- id: smeet-dhakecha
+  name: Smeet Dhakecha
+  role: "Research Engineer, Amazon"
+  bio: Smeet Dhakecha is a Research Engineer at Amazon within the Agentic AI Science team, working on agent simulation, evaluation systems, and data transformation pipeline infrastructure.
+
+- id: darren-wang
+  name: Darren Wang
+  role: "Research Engineer, AWS"
+  bio: Darren Wang is a Research Engineer at Amazon Web Services who bridges AI research and production systems, specializing in agent simulation and evaluation frameworks.
+
+- id: xuan-qi
+  name: Xuan Qi
+  role: "Applied Scientist, AWS"
+  bio: Xuan Qi is an Applied Scientist at Amazon Web Services focusing on ML modeling and simulation, translating scientific concepts into practical AI applications.

--- a/src/content/blog/evaluating-ai-agents-practical-guide-strands-evals.mdx
+++ b/src/content/blog/evaluating-ai-agents-practical-guide-strands-evals.mdx
@@ -1,0 +1,323 @@
+---
+title: "Evaluating AI agents for production: A practical guide to Strands Evals"
+date: 2026-03-18
+description: "Learn how to systematically evaluate AI agents using Strands Evals, covering core concepts like cases, experiments, evaluators, multi-turn simulation capabilities, and practical integration patterns for production deployment."
+authors:
+  - ishan-singh
+  - akarsha-sehwag
+  - jonathan-buck
+  - po-shin-chen
+  - smeet-dhakecha
+tags:
+  - Evaluation
+  - Best Practices
+canonicalUrl: "https://aws.amazon.com/blogs/machine-learning/evaluating-ai-agents-for-production-a-practical-guide-to-strands-evals/"
+draft: false
+---
+
+Moving AI agents from prototypes to production surfaces a challenge that traditional testing is unable to address. Agents are flexible, adaptive, and context-aware by design, but the same qualities that make them powerful also make them difficult to evaluate systematically.
+
+Traditional software testing relies on deterministic outputs: same input, same expected output, every time. AI agents break this assumption. They generate natural language, make context-dependent decisions, and produce varied outputs even from identical inputs. How do you systematically evaluate something that is not deterministic?
+
+In this post, we show how to evaluate AI agents systematically using [Strands Evals](https://github.com/strands-agents/evals). We walk through the core concepts, built-in evaluators, multi-turn simulation capabilities and practical approaches and patterns for integration. Strands Evals provides a structured framework for evaluating AI agents built with the Strands Agents SDK, offering evaluators, simulation tools, and reporting capabilities. Whether you need to verify that your agent uses the right tools, produces helpful responses, or guides users toward their goals, the framework provides infrastructure to measure and track these qualities systematically.
+
+## Why evaluating AI agents is different
+
+When you ask an agent "What is the weather like in Tokyo?", many valid responses exist, and no single answer is definitively correct. The agent might report temperature in Celsius or Fahrenheit, include humidity and wind, or only focus on temperature. These variations could be correct and helpful, which is exactly why traditional assertion-based testing falls short. Beyond text generation, agents also take action. A well-designed agent calls tools, retrieves information, and makes decisions throughout a conversation. Evaluating the final response alone misses whether the agent took appropriate steps to reach that response.
+
+Even correct responses can fall short. A response might be factually accurate but unhelpful, or helpful but unfaithful to source materials. No single metric captures these different quality dimensions. Conversations add another layer of complexity because they unfold over time. In multi-turn interactions, earlier responses affect later ones. An agent might handle individual queries well but fail to maintain a coherent context across a conversation. Testing single turns in isolation misses these interaction patterns.
+
+These characteristics demand evaluation that requires judgment rather than keyword comparison. Large language model (LLM)-based evaluation addresses this need. By using language models as evaluators, we can assess qualities like helpfulness, coherence, and faithfulness that resist mechanical checking. Strands Evals embraces this flexibility while still offering rigorous, repeatable quality assessments.
+
+## Core concepts of Strands Evals
+
+Strands Evals follows a pattern that should feel familiar to anyone who has written unit tests but adapts it for the judgment-based evaluation that AI agents require. The framework introduces three foundational concepts that work together: Cases, Experiments, and Evaluators.
+
+![Figure: High-Level Architecture](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/06/image001-1024x496.png)
+
+A Case represents a single test scenario. It contains the input that you want to test, perhaps a user's query like "What is the weather in Paris?", along with optional expected outputs, expected tool sequences known as trajectories, and metadata. Cases are the atomic unit of evaluation. Each one defines one scenario that you want your agent to handle correctly.
+
+```python
+from strands_evals import Case
+
+case = Case(
+    name="Weather Query",
+    input="What is the weather like in Tokyo?",
+    expected_output="Should include temperature and conditions",
+    expected_trajectory=["weather_api"]
+)
+```
+
+An Experiment bundles multiple Cases together with one or more evaluators. Think of it as a test suite in traditional testing. The Experiment orchestrates the evaluation process. It takes each Case, runs your agent on it, and applies the configured evaluators to score the results.
+
+Evaluators are the judges. They examine what your agent produced (the actual output and trajectory) and compare it against what was expected. Unlike simple assertion checks, evaluators in Strands Evals are primarily LLM-based. They use language models to make nuanced judgments about quality, relevance, helpfulness, and other qualities that cannot be reduced to string comparison.
+
+Separating these concerns helps keep the framework flexible. You can define what to test with Cases, how to test it with evaluators, and the framework handles orchestration and reporting through Experiments. Each piece can be configured independently so that you can build evaluation suites that are tailored to your specific needs.
+
+## The task function: connecting agents to evaluation
+
+Cases define your scenarios, and evaluators provide judgment. But how does your agent actually connect to this evaluation system? That is where the Task Function comes in.
+
+A Task Function is a callable that you provide to the Experiment. It receives a Case and returns the results of running that case through your system. This interface enables two fundamentally different evaluation patterns.
+
+![Figure: Task Function Patterns](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/06/image002-908x1024.png)
+
+Online evaluation involves invoking your agent live during the evaluation run. Your Task Function creates an agent, sends it the case input, captures the response and execution trace, and returns them for evaluation. This pattern is recommended during development when you want to test changes immediately, or in continuous integration and delivery (CI/CD) pipelines where you need to verify agent behavior before deployment.
+
+```python
+from strands import Agent
+
+def online_task(case):
+    agent = Agent(tools=[search_tool, calculator_tool])
+    result = agent(case.input)
+
+    return {
+        "output": str(result),
+        "trajectory": agent.session
+    }
+```
+
+Offline evaluation works with historical data. Instead of invoking an agent, your Task Function retrieves previously recorded traces from logs, databases, or observability systems. It parses these traces into the format that evaluators expect and returns them for judgment. This pattern works well when you need to evaluate production traffic, perform historical analysis, or compare agent versions against the same set of real user interactions.
+
+```python
+def offline_task(case):
+    trace = load_trace_from_database(case.session_id)
+    session = session_mapper.map_to_session(trace)
+
+    return {
+        "output": extract_final_response(trace),
+        "trajectory": session
+    }
+```
+
+Whether you are testing a new agent implementation or analyzing months of production data, the same evaluators and reporting infrastructure apply. The Task Function adapts your data source to the evaluation system.
+
+## Built-in evaluators for comprehensive assessment
+
+With your Task Function connecting agent output to the evaluation system, you can now decide which aspects of quality to measure. Strands Evals ships with ten built-in evaluators, each designed to assess a different dimension of agent quality.
+
+![Figure: Evaluator Types](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/06/image003-1024x652.png)
+
+### Rubric-based evaluators
+
+The most flexible evaluators let you define custom criteria through natural language rubrics.
+
+- **OutputEvaluator** judges the final response that your agent produces. You provide a rubric, a description of what good looks like, and the evaluators use an LLM to score the output against that criteria. This works well for general quality checks where you want to define specific standards for your use case.
+
+```python
+from strands_evals.evaluators import OutputEvaluator
+
+output_evaluator = OutputEvaluator(
+    rubric="Score 1.0 if the response correctly answers the question and is well-structured. "
+           "Score 0.5 if partially correct. Score 0.0 if incorrect or irrelevant."
+)
+```
+
+- **TrajectoryEvaluator** extends this to examine the sequence of actions (typically tool calls) that your agent took. Beyond just looking at the final answer, you can verify that the agent used appropriate tools in a logical order. The evaluators include three built-in scoring functions for comparing actual versus expected trajectories: exact match, in-order match, and any-order match. These scorers are provided as tools to the evaluation LLM, which chooses the most appropriate one based on your rubric.
+- **InteractionsEvaluator** handles multi-agent systems where multiple components communicate. It evaluates sequences of interactions between agents or system components. This is useful when your architecture involves orchestrators, sub-agents, or complex tool chains.
+
+### Semantic evaluators
+
+Some quality dimensions are common enough that Strands Evals provides pre-built evaluators with carefully designed prompts and scoring scales.
+
+- **HelpfulnessEvaluator** assesses responses from the user's perspective using a seven-point scale ranging from "Not helpful at all" to "Above and beyond." It evaluates whether the response actually addresses the user's needs, not only whether it is technically correct.
+- **FaithfulnessEvaluator** checks whether the response is grounded in the conversation history. This is particularly important for Retrieval Augmented Generation (RAG) systems where you need to make sure that the agent doesn't hallucinate information. The five-point scale ranges from "Not at all" faithful to "Completely yes."
+- **HarmfulnessEvaluator** performs safety checks, helping determine whether responses contain harmful, inappropriate, or dangerous content. It provides binary yes/no judgments for clear decision-making.
+
+### Tool-level evaluators
+
+When your agent uses tools, you often need to evaluate not only the final outcome, but the quality of individual tool invocations.
+
+- **ToolSelectionAccuracyEvaluator** examines each tool call in context and judges whether selecting that particular tool was justified given the conversation state. It answers: "At this point in the conversation, was it reasonable to call this tool?"
+- **ToolParameterAccuracyEvaluator** goes deeper, checking whether the parameters passed to each tool were correct and appropriate. It helps catch subtle errors where the right tool was chosen but called with wrong or incomplete arguments.
+
+### Session-level evaluators
+
+- **GoalSuccessRateEvaluator** takes the broadest view, evaluating entire conversation sessions to determine whether the user ultimately achieved their goal. For task-oriented agents, success is defined by outcomes rather than a single response.
+
+### Choosing the right evaluators
+
+The choice depends on what matters most for your application. A customer service agent might prioritize helpfulness and goal success. A research assistant might emphasize faithfulness. Start with a small set of evaluators that cover your core quality dimensions, then add more as you learn how your agent fails.
+
+## Simulating users for multi-turn testing
+
+The previously mentioned evaluators work well for single-turn interactions where you provide an input, get an output, and evaluate it. Multi-turn conversations present a harder challenge. Real users don't follow scripts. They ask follow-up questions, change direction, and express confusion. How do you test this? Strands Evals includes an ActorSimulator that creates AI-powered simulated users to drive multi-turn conversations with your agent.
+
+![Figure: User Simulator Flow](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/06/image004-932x1024.png)
+
+ActorSimulator starts with a test case that defines what the user wants to achieve. From this, it generates a realistic user profile using an LLM, including personality traits, expertise level, communication style, and a specific goal. This profile shapes how the simulated user behaves throughout the conversation.
+
+```python
+from strands_evals import Case, ActorSimulator
+from strands import Agent
+
+case = Case(
+    input="I need help setting up a new bank account",
+    metadata={"task_description": "Successfully open a checking account"}
+)
+
+user_sim = ActorSimulator.from_case_for_user_simulator(
+    case=case,
+    max_turns=10
+)
+```
+
+During the interaction, the simulated user sends messages to your agent, receives responses, and decides what to say next. This loop continues until either the goal is achieved, indicated by emitting a special stop token, or the maximum turn count is reached.
+
+```python
+agent = Agent(system_prompt="You are a helpful banking assistant.")
+
+user_message = case.input
+while user_sim.has_next():
+    agent_response = agent(user_message)
+    user_result = user_sim.act(str(agent_response))
+    user_message = str(user_result.structured_output.message)
+```
+
+You can then pass the resulting conversation transcript to session-level evaluators like GoalSuccessRateEvaluator to assess whether your agent successfully helped the simulated user achieve their goal. Instead of manually writing multi-turn scripts, you define goals and let the simulator create realistic interaction patterns. It might ask unexpected follow-up questions, express confusion, or take the conversation in directions that you didn't anticipate, catching edge cases that scripted tests can miss.
+
+## Evaluation levels: understanding the hierarchy
+
+Whether using simulated or real conversations, different evaluators operate at different granularities. Strands Evals uses a TraceExtractor to parse session data into the format that each evaluator needs.
+
+![Evaluation hierarchy diagram](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/06/image005-Large-902x1024.png)
+
+Session level evaluation looks at the complete conversation from beginning to end. The evaluator receives the full history, the tool executions, and understands the entire context. GoalSuccessRateEvaluator works at this level because determining goal achievement requires understanding the whole interaction.
+
+Trace level evaluation focuses on individual turns, each user prompt, and agent response pair. Evaluators at this level receive the conversation history up to that point and judge the specific response. Helpfulness, Faithfulness, and Harmfulness evaluators work here because these qualities can be assessed turn by turn.
+
+Tool level evaluation drills down to individual tool invocations. Each tool call is evaluated in context, with access to the available tools, the conversation so far, and the specific arguments passed. Tool Selection and Tool Parameter evaluators operate at this granularity.
+
+You can use the hierarchical design to compose evaluation suites that check quality at multiple levels simultaneously. Within a single evaluation run, you can verify that individual tool calls are sensible, responses are helpful, and overall goals are achieved.
+
+## Ground truth and expected behaviors
+
+At many different evaluation levels, evaluators can benefit from having reference points for comparison. Strands Evals provides first-class support for ground truth through three expected fields on Cases.
+
+The expected_output field specifies what the agent should say. This is useful when there are correct answers or standard response formats. The expected_trajectory field defines the sequence of tools or actions that the agent should take. You might require that a customer service agent checks account status before making changes, or that a research agent queries multiple sources before synthesizing. Not every Case needs every field. You define expectations based on what matters for your evaluation goals. When expected values are provided, evaluators receive both expected and actual results, enabling comparison-based scoring alongside standalone quality assessment.
+
+## Putting it all together
+
+Let's walk through a typical evaluation workflow to see how these concepts come together.
+
+![Figure: Evaluation Flow](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/06/image006-1024x608.png)
+
+First, you define your test cases, meaning the scenarios you want your agent to handle well. They might come from real user queries, synthetic generation, or edge cases that you have identified.
+
+```python
+from strands_evals import Experiment, Case
+from strands_evals.evaluators import OutputEvaluator, TrajectoryEvaluator
+from strands_evals.extractors.tools_use_extractor import extract_agent_tools_used
+
+cases = [
+    Case(
+        name="Weather Query",
+        input="What is the weather like in Tokyo?",
+        expected_output="Should include temperature and conditions",
+        expected_trajectory=["weather_api"]
+    ),
+    Case(
+        name="Calculator Usage",
+        input="What is 15% of 847?",
+        expected_output="127.05",
+        expected_trajectory=["calculator"]
+    )
+]
+```
+
+Next, you configure evaluators with appropriate rubrics or settings.
+
+```python
+output_evaluator = OutputEvaluator(
+    rubric="Score 1.0 if the response is accurate and directly answers the question. "
+           "Score 0.5 if partially correct. Score 0.0 if incorrect or irrelevant."
+)
+
+trajectory_evaluator = TrajectoryEvaluator(
+    rubric="Verify the agent used appropriate tools for the task."
+)
+```
+
+Then, you create an experiment bundling cases and evaluators.
+
+```python
+experiment = Experiment(
+    cases=cases,
+    evaluators=[output_evaluator, trajectory_evaluator]
+)
+```
+
+Finally, you run the evaluation with your Task Function and examine the results.
+
+```python
+from strands_evals.types.evaluation_report import EvaluationReport
+
+def my_task(case):
+    agent = Agent(tools=[weather_tool, calculator_tool])
+    result = agent(case.input)
+    return {
+        "output": str(result),
+        "trajectory": extract_agent_tools_used(agent.messages)
+    }
+
+reports = experiment.run_evaluations(my_task)
+
+EvaluationReport.flatten(reports).display()
+```
+
+The EvaluationReport provides overall scores, per-case breakdowns, pass/fail status, and detailed reasoning from each evaluator. You can display results interactively in the console, export to JSON for further analysis, or integrate into CI/CD pipelines. For larger test suites, Strands Evals supports asynchronous evaluation with configurable parallelism:
+
+```python
+reports = await experiment.run_evaluations_async(my_task, max_workers=10)
+```
+
+## Generating test cases at scale
+
+The previous workflow assumes that you have test cases ready. Creating comprehensive test suites by hand is tedious as your agent's capabilities grow. Strands Evals includes an ExperimentGenerator that uses LLMs to create test cases and evaluation rubrics from high-level descriptions.
+
+```python
+from strands_evals.generators import ExperimentGenerator
+from strands_evals.evaluators import OutputEvaluator
+
+generator = ExperimentGenerator(
+    input_type=str,
+    output_type=str,
+    include_expected_output=True
+)
+
+experiment = await generator.from_context_async(
+    context="A customer service agent for an e-commerce platform",
+    task_description="Handle customer inquiries about orders, returns, and products",
+    num_cases=20,
+    evaluator=OutputEvaluator
+)
+```
+
+The generator creates diverse test cases covering different aspects of the specified context, with appropriate difficulty levels. It can also generate evaluation rubrics that are tailored to the task. Generated cases are particularly valuable during early development when you want broad coverage but have not yet identified specific failure patterns. As your evaluation practice matures, supplement generated Cases with hand-crafted scenarios targeting known edge cases.
+
+## Integrating evaluation into your workflow
+
+Evaluation helps deliver the most value as part of your regular development workflow. During development, run evaluations frequently as you make changes. Fast feedback helps you catch regressions early and understand how changes affect different quality dimensions.
+
+In CI/CD pipelines, include evaluation as a quality gate before deployment. Set score thresholds that must be met for a build to pass. This helps prevent quality regressions from reaching production. For production monitoring, use offline evaluation to assess real user interactions periodically. This reveals patterns that development testing might miss: unusual queries, edge cases you did not anticipate, or gradual drift in agent behavior. Track evaluation results over time. Trending metrics help you understand whether quality is improving or degrading.
+
+## Best practices for agent evaluation
+
+- **Start small and iterate**: Begin with a handful of test cases covering your most critical user scenarios. As you observe how your agent fails in practice, add targeted cases that address those specific failure modes. A focused test suite that catches real problems is more valuable than a large suite with poor coverage.
+- **Match Evaluators to your quality goals**: Choose evaluators that directly measure what matters for your use case. A customer-facing agent might prioritize HelpfulnessEvaluator and GoalSuccessRateEvaluator, while a research assistant might weigh FaithfulnessEvaluator more heavily. Avoid the temptation to add every available evaluator, as this increases cost and can dilute focus.
+- **Write clear, specific rubrics**: Rubric-based evaluators are only as good as the rubrics you provide. Avoid vague criteria like "good response" in favor of specific, measurable standards. Include examples of what constitutes high, medium, and low scores. Test your rubrics on sample outputs before running full evaluations.
+- **Combine online and offline evaluation**: Use online evaluation during development for fast feedback on code changes. Complement this with offline evaluation of production traces to catch issues that only appear with real user behavior. The two approaches reveal different types of problems.
+- **Set meaningful thresholds**: Define pass/fail thresholds based on your actual quality requirements, not arbitrary numbers. A 0.8 threshold means nothing if your users need 0.95 accuracy. Analyze evaluation results to understand what scores correlate with good user outcomes, then set thresholds accordingly.
+- **Track trends over time**: Individual evaluation runs provide snapshots, but trends reveal the trajectory. Store evaluation results and track key metrics across releases. Gradual degradation can be harder to notice than sudden failures, but equally damaging.
+- **Invest in test case diversity**: Cover the full range of inputs that your agent will encounter: common queries, edge cases, adversarial inputs, and multi-turn conversations. Use the ExperimentGenerator for broad coverage, then supplement with hand-crafted Cases targeting known weaknesses.
+- **Evaluate at multiple levels**: Session-level success can mask tool-level problems, and the reverse. An agent might achieve user goals through inefficient or incorrect intermediate steps. Compose evaluation suites that check quality at session, trace, and tool levels to get a complete picture.
+
+## Conclusion
+
+Building reliable AI agents requires more than intuition and spot checks. It requires systematic evaluation that tracks quality across multiple dimensions over time. Strands Evals helps provide this foundation through a framework designed specifically for the unique challenges of agent evaluation.
+
+Task Functions separate agent invocation from evaluation logic, enabling both online testing during development and offline analysis of production traces. LLM-based evaluators provide the judgment that quality assessment requires. Hierarchical evaluation levels allow assessment at multiple granularities, from individual tool calls to complete conversation sessions. And the user simulator transforms multi-turn testing from a scripting exercise into realistic user behavior simulation.
+
+These capabilities help you build confidence in your AI agents through evidence rather than assumptions. You can measure whether changes improve or degrade quality, catch regressions before they reach production, and demonstrate to stakeholders that your agents meet defined quality standards.
+
+We encourage you to explore Strands Evals for your agent evaluation needs. The [samples repository](https://github.com/strands-agents/samples/tree/main/07-evals) contains practical examples that you can adapt to your own use cases. Start with a few test cases representing your most important user scenarios, add evaluators that match your quality criteria, and run evaluations as part of your development workflow. Over time, expand your test suite to cover more scenarios. Systematic evaluation is the foundation that helps you ship AI agents with confidence.

--- a/src/content/blog/simulate-realistic-users-multi-turn-agents-strands-evals.mdx
+++ b/src/content/blog/simulate-realistic-users-multi-turn-agents-strands-evals.mdx
@@ -1,0 +1,245 @@
+---
+title: "Simulate realistic users to evaluate multi-turn AI agents in Strands Evals"
+date: 2026-04-02
+description: "ActorSimulator in the Strands Evals SDK enables teams to test conversational agents through realistic, goal-driven simulated users rather than relying on static test cases or manual testing."
+authors:
+  - ishan-singh
+  - abhishek-kumar
+  - jonathan-buck
+  - vinayak-arannil
+tags:
+  - Evaluation
+  - Simulation
+canonicalUrl: "https://aws.amazon.com/blogs/machine-learning/simulate-realistic-users-to-evaluate-multi-turn-ai-agents-in-strands-evals/"
+draft: false
+---
+
+Evaluating single-turn agent interactions follows a pattern that most teams understand well. You provide an input, collect the output, and judge the result. Frameworks like [Strands Evaluation SDK](https://github.com/strands-agents/evals) make this process systematic through evaluators that assess helpfulness, faithfulness, and tool usage. In a [previous blog post](/blog/evaluating-ai-agents-practical-guide-strands-evals), we covered how to build comprehensive evaluation suites for AI agents using these capabilities. However, production conversations rarely stop at one turn.
+
+Real users engage in exchanges that unfold over multiple turns. They ask follow-up questions when answers are incomplete, change direction when new information surfaces, and express frustration when their needs go unmet. A travel assistant that handles "Book me a flight to Paris" well in isolation might struggle when the same user follows up with "Actually, can we look at trains instead?" or "What about hotels near the Eiffel Tower?" Testing these dynamic patterns requires more than static test cases with fixed inputs and expected outputs.
+
+The core difficulty is scale because you can't manually conduct hundreds of multi-turn conversations every time your agent changes, and writing scripted conversation flows locks you into predetermined paths that miss how real users behave. What evaluation teams need is a way to generate realistic, goal-driven users programmatically and let them converse naturally with an agent across multiple turns. In this post, we explore how ActorSimulator in Strands Evaluations SDK addresses this challenge with structured user simulation that integrates into your evaluation pipeline.
+
+## Why multi-turn evaluation is fundamentally harder
+
+![Multi-turn evaluation diagram](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/23/ml-20566-image-1.png)
+
+Single-turn evaluation has a straightforward structure. The input is known ahead of time, the output is self-contained, and the evaluation context is limited to that single exchange. Multi-turn conversations break every one of these assumptions.
+
+In a multi-turn interaction, each message depends on everything that came before it. The user's second question is shaped by how the agent answered the first. A partial answer draws a follow-up about whatever was left out, a misunderstanding leads the user to restate their original request, and a surprising suggestion can send the conversation in a new direction.
+
+These adaptive behaviors create conversation paths that can't be predicted at test-design time. A static dataset of I/O pairs, no matter how large, can't capture this dynamic quality because the "correct" next user message depends on what the agent just said.
+
+Manual testing covers this gap in theory but fails in practice. Testers can conduct realistic multi-turn conversations, but doing so for every scenario, across every persona type, after every agent change is not sustainable. As the agent's capabilities grow, the number of conversation paths grows combinatorially, well beyond what teams can explore manually.
+
+Some teams turn to prompt engineering as a shortcut, asking a large language model (LLM) to "act like a user" during testing. Without structured persona definitions and explicit goal tracking, these approaches produce inconsistent results. The simulated user's behavior drifts between runs, making it difficult to compare evaluations over time or identify genuine regressions versus random variation. A structured approach to user simulation can bridge this gap by combining the realism of human conversation with the repeatability and scale of automated testing.
+
+## What makes a good simulated user
+
+Simulation-based testing is well established in other engineering disciplines. Flight simulators test pilot responses to scenarios that would be dangerous or impossible to reproduce in the real world. Game engines use AI-driven agents to explore millions of player behavior paths before release. The same principle applies to conversational AI. You create a controlled environment where realistic actors interact with your system under conditions you define, then measure the outcomes.
+
+For AI agent evaluation, a useful simulated user starts with a consistent persona. One that behaves like a technical expert in one turn and a confused novice in the next produces unreliable evaluation data. Consistency means to maintain the same communication style, expertise level, and personality traits through every exchange, just as a real person would.
+
+Equally important is goal-driven behavior. Real users come to an agent with something they want to accomplish. They persist until they achieve it, adjust their approach when something is not working, and recognize when their goal has been met. Without explicit goals, a simulated user tends to either end conversations too early or continue asking questions indefinitely, neither of which reflects real usage.
+
+The simulated user must also respond adaptively to what the agent says, not follow a predetermined script. When the agent asks a clarifying question, the actor should answer it in character. If the response is incomplete, the actor follows up on whatever was left out rather than moving on. If the conversation drifts off topic, the actor steers it back toward the original goal. These adaptive behaviors make simulated conversations valuable as evaluation data because they exercise the same conversation dynamics your agent faces in production.
+
+Building persona consistency, goal tracking, and adaptive behavior into a simulation framework is what differentiates structured user simulation from ad-hoc prompting. ActorSimulator in Strands Evals is designed around exactly these principles.
+
+## How ActorSimulator works
+
+![ActorSimulator architecture](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/23/ml-20566-image-2.png)
+
+ActorSimulator implements these simulation qualities through a system that wraps a Strands Agent configured to behave as a realistic user persona. The process begins with profile generation. Given a test case containing an input query and an optional task description, ActorSimulator uses an LLM to create a complete actor profile. A test case with input "I need help booking a flight to Paris" and task description "Complete flight booking under budget" might produce a budget-conscious traveler with beginner-level experience and a casual communication style. Profile generation gives each simulated conversation a distinct, consistent character.
+
+With the profile established, the simulator manages the conversation turn by turn. It maintains the full conversation history and generates each response in context, keeping the simulated user's behavior aligned with their profile and goals throughout. When your agent addresses only part of the request, the simulated user naturally follows up on the gaps. A clarifying question from your agent gets a response that stays consistent with the persona. The conversation feels organic because every response reflects both the actor's persona and everything said so far.
+
+Goal tracking runs alongside the conversation. ActorSimulator includes a built-in goal completion assessment tool that the simulated user can invoke to evaluate whether their original objective has been met. When the goal is satisfied or the simulated user determines that the agent cannot complete their request, the simulator emits a stop signal and the conversation ends. If the maximum turn count is reached before the goal is met, the conversation also stops. This gives you a signal that the agent might not be resolving user needs efficiently. This mechanism makes sure conversations have a natural endpoint rather than running indefinitely or cutting off arbitrarily.
+
+Each response from the simulated user also includes structured reasoning alongside the message text. You can inspect why the simulated user chose to say what they said, whether they were following up on missing information, expressing confusion, or redirecting the conversation. This transparency is valuable during evaluation development because you can see the reasoning behind each turn, making it more straightforward to trace where conversations succeed or go off track.
+
+## Getting started with ActorSimulator
+
+To get started, you will need to install the Strands Evaluation SDK using: `pip install strands-agents-evals`. For a step-by-step setup, you can refer to our [documentation](https://strandsagents.com/latest/user-guide/observability-evaluation/evals/) or our [previous blog](/blog/evaluating-ai-agents-practical-guide-strands-evals) for more details. Putting these concepts into practice requires minimal code. You define a test case with an input query and a task description that captures the user's goal. ActorSimulator handles profile generation, conversation management, and goal tracking automatically.
+
+The following example evaluates a travel assistant agent through a multi-turn simulated conversation.
+
+```python
+from strands import Agent
+from strands_evals import ActorSimulator, Case, Experiment
+
+# Define your test case
+case = Case(
+    input="I want to plan a trip to Tokyo with hotel and activities",
+    metadata={"task_description": "Complete travel package arranged"}
+)
+
+# Create the agent you want to evaluate
+agent = Agent(
+    system_prompt="You are a helpful travel assistant.",
+    callback_handler=None
+)
+
+# Create user simulator from test case
+user_sim = ActorSimulator.from_case_for_user_simulator(
+    case=case,
+    max_turns=5
+)
+
+# Run the multi-turn conversation
+user_message = case.input
+conversation_history = []
+
+while user_sim.has_next():
+    # Agent responds to user
+    agent_response = agent(user_message)
+    agent_message = str(agent_response)
+    conversation_history.append({
+        "role": "assistant",
+        "content": agent_message
+    })
+
+    # Simulator generates next user message
+    user_result = user_sim.act(agent_message)
+    user_message = str(user_result.structured_output.message)
+    conversation_history.append({
+        "role": "user",
+        "content": user_message
+    })
+
+print(f"Conversation completed in {len(conversation_history) // 2} turns")
+```
+
+The conversation loop continues until `has_next()` returns False, which happens when the simulated user's goals are met or simulated user determines that the agent cannot complete the request or the maximum turn limit is reached. The resulting conversation_history contains the full multi-turn transcript, ready for evaluation.
+
+## Integration with evaluation pipelines
+
+![Evaluation pipeline integration](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/23/ml-20566-image-3.png)
+
+A standalone conversation loop is useful for quick experiments, but production evaluation requires capturing traces and feeding them into your evaluator pipeline. The next example combines ActorSimulator with OpenTelemetry telemetry collection and Strands Evals session mapping. The task function runs a simulated conversation and collects spans from each turn, then maps them into a structured session for evaluation.
+
+```python
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from strands import Agent
+from strands_evals import ActorSimulator, Case, Experiment
+from strands_evals.evaluators import HelpfulnessEvaluator
+from strands_evals.telemetry import StrandsEvalsTelemetry
+from strands_evals.mappers import StrandsInMemorySessionMapper
+from strands_evals.types.evaluation_report import EvaluationReport
+
+# Setup telemetry for capturing agent traces
+telemetry = StrandsEvalsTelemetry()
+memory_exporter = InMemorySpanExporter()
+span_processor = BatchSpanProcessor(memory_exporter)
+telemetry.tracer_provider.add_span_processor(span_processor)
+
+def evaluation_task(case: Case) -> dict:
+    # Create simulator
+    user_sim = ActorSimulator.from_case_for_user_simulator(
+        case=case,
+        max_turns=3
+    )
+
+    # Create agent
+    agent = Agent(
+        system_prompt="You are a helpful travel assistant.",
+        callback_handler=None
+    )
+
+    # Accumulate spans across conversation
+    all_target_spans = []
+    user_message = case.input
+
+    while user_sim.has_next():
+        memory_exporter.clear()
+        agent_response = agent(user_message)
+        agent_message = str(agent_response)
+
+        # Capture telemetry
+        turn_spans = list(memory_exporter.get_finished_spans())
+        all_target_spans.extend(turn_spans)
+
+        # Generate next user message
+        user_result = user_sim.act(agent_message)
+        user_message = str(user_result.structured_output.message)
+
+    # Map to session for evaluation
+    mapper = StrandsInMemorySessionMapper()
+    session = mapper.map_to_session(
+        all_target_spans,
+        session_id="test-session"
+    )
+
+    return {"output": agent_message, "trajectory": session}
+
+# Create evaluation dataset
+test_cases = [
+    Case(
+        name="booking-simple",
+        input="I need to book a flight to Paris next week",
+        metadata={
+            "category": "booking",
+            "task_description": "Flight booking confirmed"
+        }
+    )
+]
+
+experiment = Experiment(cases=test_cases, evaluators=[HelpfulnessEvaluator()])
+
+# Run evaluations
+reports = experiment.run_evaluations(evaluation_task)
+EvaluationReport.flatten(reports).display()
+```
+
+This approach captures complete traces of your agent's behavior across conversation turns. The spans include tool calls, model invocations, and timing information for every turn in the simulated conversation. By mapping these spans into a structured session, you make the full multi-turn interaction available to evaluators like GoalSuccessRateEvaluator and HelpfulnessEvaluator, which can then assess the conversation as a whole, rather than isolated turns.
+
+## Custom actor profiles for targeted testing
+
+Automatic profile generation covers most evaluation scenarios well, but some testing goals require specific personas. You might want to verify that your agent handles an impatient expert user differently from a patient beginner, or that it responds appropriately to a user with domain-specific needs. For these cases, ActorSimulator accepts a fully defined actor profile that you control.
+
+```python
+from strands_evals.types.simulation import ActorProfile
+from strands_evals import ActorSimulator
+from strands_evals.simulation.prompt_templates.actor_system_prompt import (
+    DEFAULT_USER_SIMULATOR_PROMPT_TEMPLATE
+)
+
+# Define a custom actor profile
+actor_profile = ActorProfile(
+    traits={
+        "personality": "analytical and detail-oriented",
+        "communication_style": "direct and technical",
+        "expertise_level": "expert",
+        "patience_level": "low"
+    },
+    context="Experienced business traveler with elite status who values efficiency",
+    actor_goal="Book business class flight with specific seat preferences and lounge access"
+)
+
+# Initialize simulator with custom profile
+user_sim = ActorSimulator(
+    actor_profile=actor_profile,
+    initial_query="I need to book a business class flight to London next Tuesday",
+    system_prompt_template=DEFAULT_USER_SIMULATOR_PROMPT_TEMPLATE,
+    max_turns=10
+)
+```
+
+By defining traits like patience level, communication style, and expertise, you can systematically test how your agent performs across different user segments. An agent that scores well with patient, non-technical users but poorly with impatient experts reveals a specific quality gap that you can address. Running the same goal across multiple persona configurations turns user simulation into a tool for understanding your agent's strengths and weaknesses by user type.
+
+## Best practices for simulation-based evaluation
+
+These best practices help you get the most out of simulation-based evaluation:
+
+- Set `max_turns` based on task complexity, using 3-5 for focused tasks and 8-10 for multi-step workflows. If most conversations reach the limit without completing the goal, increase it.
+- Write specific task descriptions that the simulator can evaluate against. "Help the user book a flight" is too vague to judge completion reliably, while "flight booking confirmed with dates, destination, and price" gives a concrete target.
+- Use auto-generated profiles for broad coverage across user types and custom profiles to reproduce specific patterns from your production logs, such as an impatient expert or a first-time user.
+- Focus on patterns across your test suite rather than individual transcripts. Consistent redirects from the simulated user suggests that the agent is drifting off topic, and declining goal completion rates after an agent change points to a regression.
+- Start with a small set of test cases covering your most common scenarios and expand to edge cases and additional personas as your evaluation practice matures.
+
+## Conclusion
+
+We showed how ActorSimulator in [Strands Evals](https://github.com/strands-agents/evals) enables systematic, multi-turn evaluation of conversational AI agents through realistic user simulation. Rather than relying on static test cases that capture only single exchanges, you can define goals and personas and let simulated users interact with your agent across natural, adaptive conversations. The resulting transcripts feed directly into the same evaluation pipeline that you use for single-turn testing, giving you helpfulness scores, goal success rates, and detailed traces across every conversation turn.
+
+To get started, explore the working examples in the [Strands Agents samples repository](https://github.com/strands-agents/samples/tree/main/07-evals). For teams evaluating agents deployed through Amazon Bedrock AgentCore, the [AgentCore evaluations sample](https://github.com/awslabs/amazon-bedrock-agentcore-samples/tree/main/01-tutorials/07-AgentCore-evaluations/03-advanced/02-simulating-agent-interactions) demonstrates how to simulate interactions with deployed agents. Start with a handful of test cases representing your most common user scenarios, run them through ActorSimulator, and evaluate the results. As your evaluation practice matures, expand to cover more personas, edge cases, and conversation patterns.

--- a/src/content/blog/toolsimulator-scalable-tool-testing-ai-agents.mdx
+++ b/src/content/blog/toolsimulator-scalable-tool-testing-ai-agents.mdx
@@ -1,0 +1,331 @@
+---
+title: "ToolSimulator: scalable tool testing for AI agents"
+date: 2026-04-20
+description: "ToolSimulator is an LLM-powered framework within Strands Evals that enables safe, scalable agent testing by using simulated tool responses instead of risky live API calls."
+authors:
+  - darren-wang
+  - smeet-dhakecha
+  - vinayak-arannil
+  - xuan-qi
+tags:
+  - Evaluation
+  - Simulation
+  - Tools
+canonicalUrl: "https://aws.amazon.com/blogs/machine-learning/toolsimulator-scalable-tool-testing-for-ai-agents/"
+draft: false
+---
+
+You can use ToolSimulator, an LLM-powered tool simulation framework within Strands Evals, to thoroughly and safely test AI agents that rely on external tools, at scale. Instead of risking live API calls that expose personally identifiable information (PII), trigger unintended actions, or settling for static mocks that break with multi-turn workflows, you can use ToolSimulator's large language model (LLM)-powered simulations to validate your agents. Available today as part of the [Strands Evals SDK](https://github.com/strands-agents/evals), ToolSimulator helps you catch integration bugs early, test edge cases comprehensively, and ship production-ready agents with confidence.
+
+In this post, you will learn how to:
+
+- Set up ToolSimulator and register tools for simulation
+- Configure stateful tool simulations for multi-turn agent workflows
+- Enforce response schemas with Pydantic models
+- Integrate ToolSimulator into a complete Strands Evals evaluation pipeline
+- Apply best practices for simulation-based agent evaluation
+
+## Prerequisites
+
+Before you begin, make sure that you have the following:
+
+- Python 3.10 or later installed in your environment
+- Strands Evals SDK installed: `pip install strands-agents-evals`
+- Basic familiarity with Python, including decorators and type hints
+- Familiarity with AI agents and tool-calling concepts (API calls, function schemas)
+- Pydantic knowledge is helpful for the advanced schema examples, but is not required to get started
+- An AWS account is not required to run ToolSimulator locally
+
+## Why tool testing challenges your development workflow
+
+Modern AI agents don't just reason. They call APIs, query databases, invoke Model Context Protocol (MCP) services, and interact with external systems to complete tasks. Your agent's behavior depends not only on its reasoning, but on what those tools return. When you test these agents against live APIs, you run into three challenges that slow you down and put your systems at risk.
+
+Three challenges that live APIs create:
+
+- **External dependencies slow you down.** Live APIs impose rate limits, experience downtime, and require network connectivity. When you're running hundreds of test cases, these constraints make comprehensive testing impractical.
+- **Test isolation becomes risky.** Real tool calls trigger real side effects. You risk sending actual emails, modifying production databases, or booking actual flights during testing. Your agent tests shouldn't interact with the systems that they're testing against.
+- **Privacy and security create barriers.** Many tools handle sensitive data, including user records, financial information, and PII. Running tests against live systems unnecessarily exposes that data and creates compliance risks.
+
+## Why static mocks fall short
+
+You might consider static mocks as an alternative. Static mocks work for straightforward, predictable scenarios, but they require constant maintenance as your APIs evolve. More importantly, they break down in the multi-turn, stateful workflows that real agents perform.
+
+Consider a flight booking agent. It searches for flights with one tool call, then checks booking status with another. The second response should depend on what the first call did. A hardcoded response can't reflect a database that changes state between calls. Static mocks can't capture this.
+
+## What makes ToolSimulator different
+
+ToolSimulator solves these challenges with three essential capabilities that work together to give you safe, scalable agent testing without sacrificing realism.
+
+- **Adaptive response generation.** Tool outputs reflect what your agent actually requested, not a fixed template. When your agent calls to search for Seattle-to-New York flights, ToolSimulator returns plausible options with realistic prices and times, not a generic placeholder.
+- **Stateful workflow support.** Many real-world tools maintain state across calls. A write operation should affect subsequent reads. ToolSimulator maintains consistent shared state across tool calls, making it safe to test database interactions, booking workflows, and multi-step processes without touching production systems.
+- **Schema enforcement.** Developers typically add a post-processing layer that parses raw tool output into a structured format. When a tool returns a malformed response, this layer breaks. ToolSimulator validates responses against Pydantic schemas that you define, catching malformed responses before they reach your agent.
+
+## How ToolSimulator works
+
+![ToolSimulator architecture diagram showing how tool calls are intercepted and routed to an LLM-based response generator](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/04/15/ml-20730-image-1.png)
+
+ToolSimulator intercepts calls to your registered tools and routes them to an LLM-based response generator. The generator uses the tool schema, your agent's input, and the current simulation state to produce a realistic, context-appropriate response. No handwritten fixtures required.
+
+Your workflow follows three steps: decorate and register your tools, optionally steer the simulation with context, then let ToolSimulator mock the tool responses when your agent runs.
+
+![Process flow diagram showing the three-step ToolSimulator workflow: Decorate & Register, Steer, and Mock](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/04/15/ml-20730-image-2.png)
+
+## Getting started with ToolSimulator
+
+The following sections walk you through each step of the ToolSimulator workflow, from initial setup to running your first simulation.
+
+### Step 1: Decorate and register
+
+Create a ToolSimulator instance, then wrap your tool function with the `@simulator.tool()` decorator to register it for simulation. The real function body can remain empty. ToolSimulator intercepts calls before they reach the implementation:
+
+```python
+from strands_evals.simulation.tool_simulator import ToolSimulator
+
+tool_simulator = ToolSimulator()
+
+@tool_simulator.tool()
+def search_flights(origin: str, destination: str, date: str) -> dict:
+    """Search for available flights between two airports on a given date."""
+    pass  # The real implementation is never called during simulation
+```
+
+### Step 2: Steer (optional configuration)
+
+By default, ToolSimulator automatically infers how each tool should behave from its schema and docstring. No additional configuration is needed to get started. When you need more control, you can use these three optional parameters to customize simulation behavior:
+
+- **share_state_id**: Links tools that share the same backend under a common state key. State changes made by one tool (for example, a setter) are immediately visible to subsequent calls by another (for example, a getter).
+- **initial_state_description**: Seeds the simulation with a natural language description of pre-existing state. Richer context produces more realistic and consistent responses.
+- **output_schema**: A Pydantic model defining the expected response structure. ToolSimulator generates responses that conform strictly to this schema.
+
+### Step 3: Mock
+
+When your agent calls a registered tool, the ToolSimulator wrapper intercepts the call and routes it to the dynamic response generator. The generator validates the agent's parameters against the tool schema, produces a response that matches the output_schema, and updates the state registry so subsequent tool calls see a consistent world.
+
+![Process flow diagram showing four sequential steps of ToolSimulator: Agent Calls Tool, Validate Parameters, Generate Response, and Update State](https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/04/15/ml-20730-image-3.png)
+
+The following example simulates a flight search tool attached to a flight search assistant:
+
+```python
+from strands import Agent
+from strands_evals.simulation.tool_simulator import ToolSimulator
+
+# 1. Create a simulator instance
+tool_simulator = ToolSimulator()
+
+# 2. Register a tool for simulation with initial state context
+@tool_simulator.tool(
+    initial_state_description="Flight database: SEA->JFK flights available at 8am, 12pm, and 6pm. Prices range from $180 to $420.",
+)
+def search_flights(origin: str, destination: str, date: str) -> dict:
+    """Search for available flights between two airports on a given date."""
+    pass
+
+# 3. Create an agent with the simulated tool and run it
+flight_tool = tool_simulator.get_tool("search_flights")
+agent = Agent(
+    system_prompt="You are a flight search assistant.",
+    tools=[flight_tool],
+)
+
+response = agent("Find me flights from Seattle to New York on March 15.")
+print(response)
+```
+
+## Advanced ToolSimulator usage
+
+The following sections cover three advanced capabilities that give you more control over simulation behavior: running independent instances for parallel testing, configuring shared state for multi-turn workflows, and enforcing custom response schemas.
+
+### Run independent simulator instances
+
+You can create multiple ToolSimulator instances side by side. Each instance maintains its own tool registry and state, so you can run parallel experiment configurations in the same codebase:
+
+```python
+simulator_a = ToolSimulator()
+simulator_b = ToolSimulator()
+# Each instance has an independent tool registry and state --
+# ideal for comparing agent behavior across different tool setups.
+```
+
+### Configure shared state for multi-turn workflows
+
+For stateful tools such as database getters and setters, ToolSimulator maintains consistent shared state across tool calls. Use `share_state_id` to link tools that operate on the same backend, and `initial_state_description` to seed the simulation with pre-existing context:
+
+```python
+@tool_simulator.tool(
+    share_state_id="flight_booking",
+    initial_state_description="Flight booking system: SEA->JFK flights available at 8am, 12pm, and 6pm. No bookings currently active.",
+)
+def search_flights(origin: str, destination: str, date: str) -> dict:
+    """Search for available flights between two airports on a given date."""
+    pass
+
+@tool_simulator.tool(
+    share_state_id="flight_booking",
+)
+def get_booking_status(booking_id: str) -> dict:
+    """Retrieve the current status of a flight booking by booking ID."""
+    pass
+
+# Both tools share "flight_booking" state.
+# When search_flights is called, get_booking_status sees the same
+# flight availability data in subsequent calls.
+```
+
+Inspect the state before and after agent execution to validate that tool interactions produced the expected changes:
+
+```python
+initial_state = tool_simulator.get_state("flight_booking")
+# ... run the agent ...
+final_state = tool_simulator.get_state("flight_booking")
+# Verify not just the final output, but the full sequence of tool interactions.
+```
+
+> **Tip: Seeding state from real data**
+>
+> Because `initial_state_description` accepts natural language, you can get creative with how you seed context. For tools that interact with tabular data, use a `DataFrame.describe()` call to generate statistical summaries and pass those statistics directly as the state description. ToolSimulator will generate responses that reflect realistic data distributions, without ever accessing the actual data.
+
+### Enforce a custom response schema
+
+By default, ToolSimulator infers a response structure from the tool's docstring and type hints. For tools that follow strict specifications such as OpenAPI or MCP schemas, define the expected response as a Pydantic model and pass it using `output_schema`:
+
+```python
+from pydantic import BaseModel, Field
+
+class FlightSearchResponse(BaseModel):
+    flights: list[dict] = Field(
+        ..., description="List of available flights with flight number, departure time, and price"
+    )
+    origin: str = Field(..., description="Origin airport code")
+    destination: str = Field(..., description="Destination airport code")
+    status: str = Field(default="success", description="Search operation status")
+    message: str = Field(default="", description="Additional status message")
+
+@tool_simulator.tool(output_schema=FlightSearchResponse)
+def search_flights(origin: str, destination: str, date: str) -> dict:
+    """Search for available flights between two airports on a given date."""
+    pass
+
+# ToolSimulator validates parameters strictly and returns only valid JSON
+# responses that conform to the FlightSearchResponse schema.
+```
+
+## Integration with Strands Evaluation pipelines
+
+ToolSimulator fits naturally into the Strands Evals evaluation framework. The following example shows a complete pipeline, from simulation setup to experiment report, using the GoalSuccessRateEvaluator to score agent performance on tool-calling tasks:
+
+```python
+from typing import Any
+from pydantic import BaseModel, Field
+from strands import Agent
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import GoalSuccessRateEvaluator
+from strands_evals.simulation.tool_simulator import ToolSimulator
+from strands_evals.mappers import StrandsInMemorySessionMapper
+from strands_evals.telemetry import StrandsEvalsTelemetry
+from strands_evals.types.evaluation_report import EvaluationReport
+
+# Set up telemetry and tool simulator
+telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
+memory_exporter = telemetry.in_memory_exporter
+tool_simulator = ToolSimulator()
+
+# Define the response schema
+class FlightSearchResponse(BaseModel):
+    flights: list[dict] = Field(
+        ..., description="Available flights with number, departure time, and price"
+    )
+    origin: str = Field(..., description="Origin airport code")
+    destination: str = Field(..., description="Destination airport code")
+    status: str = Field(default="success", description="Search operation status")
+    message: str = Field(default="", description="Additional status message")
+
+# Register tools for simulation
+@tool_simulator.tool(
+    share_state_id="flight_booking",
+    initial_state_description="Flight booking system: SEA->JFK flights at 8am, 12pm, and 6pm. No bookings currently active.",
+    output_schema=FlightSearchResponse,
+)
+def search_flights(origin: str, destination: str, date: str) -> dict[str, Any]:
+    """Search for available flights between two airports on a given date."""
+    pass
+
+@tool_simulator.tool(share_state_id="flight_booking")
+def get_booking_status(booking_id: str) -> dict[str, Any]:
+    """Retrieve the current status of a flight booking by booking ID."""
+    pass
+
+# Define the evaluation task
+def user_task_function(case: Case) -> dict:
+    initial_state = tool_simulator.get_state("flight_booking")
+    print(f"[State before]: {initial_state.get('initial_state')}")
+
+    search_tool = tool_simulator.get_tool("search_flights")
+    status_tool = tool_simulator.get_tool("get_booking_status")
+    agent = Agent(
+        trace_attributes={
+            "gen_ai.conversation.id": case.session_id,
+            "session.id": case.session_id
+        },
+        system_prompt="You are a flight booking assistant.",
+        tools=[search_tool, status_tool],
+        callback_handler=None,
+    )
+
+    agent_response = agent(case.input)
+    print(f"[User]: {case.input}")
+    print(f"[Agent]: {agent_response}")
+
+    final_state = tool_simulator.get_state("flight_booking")
+    print(f"[State after]: {final_state.get('previous_calls', [])}")
+
+    finished_spans = memory_exporter.get_finished_spans()
+    mapper = StrandsInMemorySessionMapper()
+    session = mapper.map_to_session(finished_spans, session_id=case.session_id)
+    return {"output": str(agent_response), "trajectory": session}
+
+# Define test cases, run the experiment, and display the report
+test_cases = [
+    Case(
+        name="flight_search",
+        input="Find me flights from Seattle to New York on March 15.",
+        metadata={"category": "flight_booking"},
+    ),
+]
+experiment = Experiment[str, str](
+    cases=test_cases,
+    evaluators=[GoalSuccessRateEvaluator()]
+)
+
+reports = experiment.run_evaluations(user_task_function)
+EvaluationReport.flatten(reports).display()
+```
+
+The task function retrieves the simulated tools, creates an agent, runs the interaction, and returns both the agent's output and the full telemetry trajectory. The trajectory gives evaluators like GoalSuccessRateEvaluator access to the complete sequence of tool calls and model invocations, not just the final response.
+
+## Best practices for simulation-based evaluation
+
+- **Start with the default configuration** for broad coverage. Add configuration overrides only for the specific tool environments that you want to control precisely. ToolSimulator's defaults are designed to produce realistic behavior without requiring setup.
+- **Provide rich initial_state_description values** for stateful tools. The more context that you seed, the more realistic and consistent the simulated responses will be. Include data ranges, entity counts, and relationship context.
+- **Use share_state_id for tools that interact with the same backend**, so write operations are visible to subsequent reads. This is essential for testing multi-turn workflows like booking, cart management, or database updates.
+- **Apply output_schema for tools that follow strict specifications**, such as OpenAPI or MCP schemas. Schema enforcement catches malformed responses before they reach your agent and break your post-processing layer.
+- **Validate tool interaction sequences, not just final outputs.** Inspect state changes before and after agent execution to confirm that tool calls occurred in the right order and produced the right state transitions.
+- **Start small and expand.** Begin with your most common tool interaction scenarios, then expand to edge cases as your evaluation practice matures. Complement simulation-based testing with targeted live API tests for critical production paths.
+
+## Conclusion
+
+ToolSimulator transforms how you test AI agents by replacing risky live API calls with intelligent, adaptive simulations. You can now safely validate complex, stateful workflows at scale, catching integration bugs early and shipping production-ready agents with confidence. Combining ToolSimulator with Strands Evals evaluation pipelines gives you full visibility into agent behavior without managing test infrastructure or risking real-world side effects.
+
+## Next steps
+
+Start testing your AI agents safely today. Install ToolSimulator with the following command:
+
+```bash
+pip install strands-agents-evals
+```
+
+To continue exploring ToolSimulator and Strands Evals:
+
+- Read the [Strands Evals documentation](https://strandsagents.com/latest/user-guide/observability-evaluation/evals/) to explore all configuration options, including advanced state management and custom evaluators.
+- Try the [examples](https://github.com/strands-agents/samples/tree/main/07-evals) to see ToolSimulator in action. Extend the example by adding more tools and testing multi-step agent workflows.
+- Explore [Amazon Bedrock](https://aws.amazon.com/bedrock/) for the LLM backend options that power ToolSimulator's response generation.
+- Join the Strands community forums to ask questions, share your evaluation setups, and connect with other agent developers.


### PR DESCRIPTION
## Description
Added strands-evals blogs:
1. https://aws.amazon.com/blogs/machine-learning/simulate-realistic-users-to-evaluate-multi-turn-ai-agents-in-strands-evals/
2. https://aws.amazon.com/blogs/machine-learning/toolsimulator-scalable-tool-testing-for-ai-agents/
3. https://aws.amazon.com/blogs/machine-learning/evaluating-ai-agents-for-production-a-practical-guide-to-strands-evals/


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
