### PR TITLE
docs: add multimodal evaluator user-guide pages

### DIFF
--- a/docs/examples/evals-sdk/multimodal_output_evaluator.py
+++ b/docs/examples/evals-sdk/multimodal_output_evaluator.py
@@ -1,0 +1,112 @@
+import asyncio
+import datetime
+
+from strands import Agent
+
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import (
+    MultimodalCorrectnessEvaluator,
+    MultimodalOutputEvaluator,
+)
+from strands_evals.evaluators.prompt_templates.multimodal import (
+    OVERALL_QUALITY_RUBRIC_V0,
+)
+from strands_evals.types import ImageData, MultimodalInput
+
+
+# A small public image used so the example is self-contained.
+# Replace with your own file path or ImageData instance for real experiments.
+SAMPLE_IMAGE_URL = (
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/"
+    "5/5c/Bar_chart_example.png/320px-Bar_chart_example.png"
+)
+
+
+async def multimodal_output_evaluator_example():
+    """
+    Demonstrates using MultimodalOutputEvaluator to judge multimodal agent outputs.
+
+    This example:
+    1. Defines a task function that asks a multimodal agent to describe an image
+    2. Creates multimodal test cases (reference-free and reference-based)
+    3. Creates a MultimodalOutputEvaluator (custom rubric) and a
+       MultimodalCorrectnessEvaluator (built-in rubric)
+    4. Creates an experiment with the test cases and evaluators
+    5. Runs evaluations and displays the report
+
+    Returns:
+        EvaluationReport: The evaluation results
+    """
+
+    # 1. Define a task function that invokes a multimodal agent.
+    async def get_response(case: Case) -> str:
+        agent = Agent(
+            system_prompt="You are a helpful multimodal assistant. Describe what is visible in the image.",
+            callback_handler=None,
+        )
+        multimodal_input = case.input
+        if not isinstance(multimodal_input, MultimodalInput):
+            raise TypeError("This example expects MultimodalInput cases.")
+
+        image_bytes = ImageData(source=multimodal_input.media).to_bytes()
+        image_format = ImageData(source=multimodal_input.media).format or "png"
+
+        prompt = [
+            {"image": {"format": image_format, "source": {"bytes": image_bytes}}},
+            {"text": multimodal_input.instruction},
+        ]
+        response = await agent.invoke_async(prompt)
+        return str(response)
+
+    # 2. Create multimodal test cases.
+    reference_free_case = Case(
+        name="chart-overview",
+        input=MultimodalInput(
+            media=SAMPLE_IMAGE_URL,
+            instruction="What kind of chart is shown and what does it represent?",
+        ),
+        metadata={"category": "chart-qa", "mode": "reference-free"},
+    )
+
+    reference_based_case = Case(
+        name="chart-type",
+        input=MultimodalInput(
+            media=SAMPLE_IMAGE_URL,
+            instruction="What type of chart is this? Answer in one word.",
+        ),
+        expected_output="bar chart",
+        metadata={"category": "chart-qa", "mode": "reference-based"},
+    )
+
+    # 3. Create evaluators.
+    #    - Custom rubric via the base MultimodalOutputEvaluator
+    overall_quality_judge = MultimodalOutputEvaluator(
+        rubric=OVERALL_QUALITY_RUBRIC_V0,
+        include_inputs=True,
+    )
+    #    - Built-in rubric via the convenience subclass
+    correctness_judge = MultimodalCorrectnessEvaluator()
+
+    # 4. Create an experiment.
+    experiment = Experiment(
+        cases=[reference_free_case, reference_based_case],
+        evaluators=[overall_quality_judge, correctness_judge],
+    )
+
+    # 4.5. (Optional) Save the experiment for later reloading.
+    experiment.to_file("multimodal_output_evaluator_experiment.json")
+
+    # 5. Run evaluations.
+    reports = await experiment.run_evaluations_async(get_response)
+    return reports[0]
+
+
+if __name__ == "__main__":
+    # Run as a module: python -m examples.evals-sdk.multimodal_output_evaluator
+    start_time = datetime.datetime.now()
+    report = asyncio.run(multimodal_output_evaluator_example())
+    end_time = datetime.datetime.now()
+    print("Elapsed:", end_time - start_time)
+
+    report.to_file("multimodal_output_evaluator_report.json")
+    report.run_display(include_actual_output=True)

--- a/docs/examples/evals-sdk/multimodal_output_evaluator.py
+++ b/docs/examples/evals-sdk/multimodal_output_evaluator.py
@@ -14,12 +14,10 @@ from strands_evals.evaluators.prompt_templates.multimodal import (
 from strands_evals.types import ImageData, MultimodalInput
 
 
-# A small public image used so the example is self-contained.
-# Replace with your own file path or ImageData instance for real experiments.
-SAMPLE_IMAGE_URL = (
-    "https://upload.wikimedia.org/wikipedia/commons/thumb/"
-    "5/5c/Bar_chart_example.png/320px-Bar_chart_example.png"
-)
+# Replace with a path to your own image before running the example.
+# `MultimodalInput.media` also accepts an `ImageData` instance, base64 string,
+# data URL, HTTP(S) URL, raw bytes, or a PIL Image.
+SAMPLE_IMAGE_PATH = "/path/to/your/chart.png"
 
 
 async def multimodal_output_evaluator_example():
@@ -48,11 +46,13 @@ async def multimodal_output_evaluator_example():
         if not isinstance(multimodal_input, MultimodalInput):
             raise TypeError("This example expects MultimodalInput cases.")
 
-        image_bytes = ImageData(source=multimodal_input.media).to_bytes()
-        image_format = ImageData(source=multimodal_input.media).format or "png"
-
+        # Normalize media to an ImageData instance.
+        # MultimodalInput.media can be a str, ImageData, or list[ImageData];
+        # this example assumes a single str or ImageData.
+        media = multimodal_input.media
+        image = media if isinstance(media, ImageData) else ImageData(source=media)
         prompt = [
-            {"image": {"format": image_format, "source": {"bytes": image_bytes}}},
+            {"image": {"format": image.format or "png", "source": {"bytes": image.to_bytes()}}},
             {"text": multimodal_input.instruction},
         ]
         response = await agent.invoke_async(prompt)
@@ -62,7 +62,7 @@ async def multimodal_output_evaluator_example():
     reference_free_case = Case(
         name="chart-overview",
         input=MultimodalInput(
-            media=SAMPLE_IMAGE_URL,
+            media=SAMPLE_IMAGE_PATH,
             instruction="What kind of chart is shown and what does it represent?",
         ),
         metadata={"category": "chart-qa", "mode": "reference-free"},
@@ -71,7 +71,7 @@ async def multimodal_output_evaluator_example():
     reference_based_case = Case(
         name="chart-type",
         input=MultimodalInput(
-            media=SAMPLE_IMAGE_URL,
+            media=SAMPLE_IMAGE_PATH,
             instruction="What type of chart is this? Answer in one word.",
         ),
         expected_output="bar chart",
@@ -84,7 +84,7 @@ async def multimodal_output_evaluator_example():
         rubric=OVERALL_QUALITY_RUBRIC_V0,
         include_inputs=True,
     )
-    #    - Built-in rubric via the convenience subclass
+    #    - Built-in rubric via the matching subclass
     correctness_judge = MultimodalCorrectnessEvaluator()
 
     # 4. Create an experiment.

--- a/docs/examples/evals-sdk/multimodal_output_evaluator.py
+++ b/docs/examples/evals-sdk/multimodal_output_evaluator.py
@@ -12,6 +12,7 @@ from strands_evals.evaluators.prompt_templates.multimodal import (
     OVERALL_QUALITY_RUBRIC_V0,
 )
 from strands_evals.types import ImageData, MultimodalInput
+from strands_evals.types.evaluation_report import EvaluationReport
 
 
 # Replace with a path to your own image before running the example.
@@ -96,9 +97,9 @@ async def multimodal_output_evaluator_example():
     # 4.5. (Optional) Save the experiment for later reloading.
     experiment.to_file("multimodal_output_evaluator_experiment.json")
 
-    # 5. Run evaluations.
+    # 5. Run evaluations. Each evaluator returns its own report; flatten to combine them.
     reports = await experiment.run_evaluations_async(get_response)
-    return reports[0]
+    return EvaluationReport.flatten(reports)
 
 
 if __name__ == "__main__":

--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -182,6 +182,11 @@ sidebar:
               - docs/user-guide/evals-sdk/evaluators/refusal_evaluator
               - docs/user-guide/evals-sdk/evaluators/stereotyping_evaluator
               - docs/user-guide/evals-sdk/evaluators/instruction_following_evaluator
+              - docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator
+              - docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator
+              - docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator
+              - docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator
+              - docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator
               - docs/user-guide/evals-sdk/evaluators/goal_success_rate_evaluator
               - docs/user-guide/evals-sdk/evaluators/tool_selection_evaluator
               - docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator

--- a/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
@@ -141,7 +141,7 @@ Evaluators operate at different levels of granularity:
 **[MultimodalFaithfulnessEvaluator](multimodal_faithfulness_evaluator.md)**
 
 - **Level**: OUTPUT_LEVEL
-- **Purpose**: Strict binary hallucination detection — flags claims not verifiable from the image
+- **Purpose**: Strict binary hallucination detection that flags claims not verifiable from the image
 - **Use Case**: Catch invented details, assumptions, and ungrounded inferences in image captions
 
 **[MultimodalInstructionFollowingEvaluator](multimodal_instruction_following_evaluator.md)**

--- a/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
@@ -147,7 +147,7 @@ Evaluators operate at different levels of granularity:
 **[MultimodalInstructionFollowingEvaluator](multimodal_instruction_following_evaluator.md)**
 
 - **Level**: OUTPUT_LEVEL
-- **Purpose**: Strict binary evaluation of constraint compliance (counts, format, scope, order, style)
+- **Purpose**: Strict binary evaluation of constraint compliance (count, format, scope, order, completeness, style)
 - **Use Case**: Verify that multimodal responses respect explicit instructions independently of correctness
 
 ### Tool Usage Evaluators

--- a/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/index.mdx
@@ -118,6 +118,38 @@ Evaluators operate at different levels of granularity:
 - **Purpose**: Binary evaluation for instruction compliance
 - **Use Case**: Verify that agents follow explicit format, length, style, and content constraints
 
+### Multimodal Evaluators
+
+**[MultimodalOutputEvaluator](multimodal_output_evaluator.md)**
+
+- **Level**: OUTPUT_LEVEL
+- **Purpose**: MLLM-as-a-Judge evaluation with custom rubrics for image/document-to-text tasks
+- **Use Case**: Evaluate responses for VQA, chart/document QA, image captioning, and OCR-style tasks
+
+**[MultimodalOverallQualityEvaluator](multimodal_overall_quality_evaluator.md)**
+
+- **Level**: OUTPUT_LEVEL
+- **Purpose**: Likert-5 overall quality scoring across visual accuracy, instruction adherence, completeness, and coherence
+- **Use Case**: Track single-score quality trends for image-to-text responses
+
+**[MultimodalCorrectnessEvaluator](multimodal_correctness_evaluator.md)**
+
+- **Level**: OUTPUT_LEVEL
+- **Purpose**: Strict binary fact-check of a response against the image content
+- **Use Case**: Verify factual accuracy of VQA or chart-QA answers
+
+**[MultimodalFaithfulnessEvaluator](multimodal_faithfulness_evaluator.md)**
+
+- **Level**: OUTPUT_LEVEL
+- **Purpose**: Strict binary hallucination detection — flags claims not verifiable from the image
+- **Use Case**: Catch invented details, assumptions, and ungrounded inferences in image captions
+
+**[MultimodalInstructionFollowingEvaluator](multimodal_instruction_following_evaluator.md)**
+
+- **Level**: OUTPUT_LEVEL
+- **Purpose**: Strict binary evaluation of constraint compliance (counts, format, scope, order, style)
+- **Use Case**: Verify that multimodal responses respect explicit instructions independently of correctness
+
 ### Tool Usage Evaluators
 
 **[ToolSelectionEvaluator](tool_selection_evaluator.md)**
@@ -373,6 +405,7 @@ def compare_agent_versions(cases: list, agents: dict) -> dict:
 
 - [OutputEvaluator](output_evaluator.md): Start with flexible custom evaluation
 - [HelpfulnessEvaluator](helpfulness_evaluator.md): Assess response helpfulness
+- [MultimodalOutputEvaluator](multimodal_output_evaluator.md): Evaluate image/document-to-text responses with an MLLM judge
 - [CustomEvaluator](custom_evaluator.md): Create domain-specific evaluators
 - [Detectors](../detectors/index.md): Understand _why_ cases fail with automatic failure detection and root cause analysis
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
@@ -1,0 +1,114 @@
+---
+title: Multimodal Correctness Evaluator
+sidebar:
+  label: "Multimodal Correctness"
+---
+
+## Overview
+
+The `MultimodalCorrectnessEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `CORRECTNESS_RUBRIC_V0` rubric. It grades whether a text response is factually correct given the image content, acting as a strict fact-checker that catches errors in objects, counts, colors, positions, readable text, and described actions.
+
+## Key Features
+
+- **Output-Level Evaluation**: Scores a single agent response per case
+- **Strict Binary Scoring**: `1.0` for correct, `0.0` if any single factual error is found
+- **Reference-Free or Reference-Based**: Adds the reference suffix automatically when `expected_output` is set
+- **MLLM Judge**: Inspects the image and response together
+
+## When to Use
+
+Use the `MultimodalCorrectnessEvaluator` when you need to:
+
+- Verify factual accuracy of image captions, VQA answers, or chart/document QA responses
+- Measure exact correctness on benchmark tasks with a known answer
+- Catch small but important errors (off-by-one counts, wrong colors, misread text)
+
+## Parameters
+
+### `rubric` (optional)
+- **Type**: `str | None`
+- **Default**: `CORRECTNESS_RUBRIC_V0`
+- **Description**: Custom rubric. Leave unset to use the shipped image-to-text correctness rubric.
+
+### `model` (optional)
+- **Type**: `Model | str | None`
+- **Default**: `None` (uses default Bedrock model)
+- **Description**: Multimodal judge model.
+
+### `include_inputs` (optional)
+- **Type**: `bool`
+- **Default**: `True`
+
+### `system_prompt` (optional)
+- **Type**: `str | None`
+- **Default**: `None` (uses the built-in `MLLM_JUDGE_SYSTEM_PROMPT`)
+
+### `reference_suffix` (optional)
+- **Type**: `str | None`
+- **Default**: The `MultimodalOutputEvaluator` default suffix
+- **Description**: Override to customize reference-based grading.
+
+## Scoring System
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 1.0 | Correct | No factual errors found |
+| 0.0 | Incorrect | One or more factual errors found |
+
+A response passes only if the score is `1.0`.
+
+## Basic Usage
+
+### Reference-Free (fact-check against the image)
+
+```python
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import MultimodalCorrectnessEvaluator
+from strands_evals.types import MultimodalInput
+
+
+def task_function(case: Case) -> str:
+    # Replace with your multimodal agent invocation.
+    return "There are 3 people sitting on the red couch."
+
+
+cases = [
+    Case(
+        name="scene-count",
+        input=MultimodalInput(
+            media="/path/to/living_room.jpg",
+            instruction="How many people are on the couch and what color is it?",
+        ),
+    ),
+]
+
+experiment = Experiment(cases=cases, evaluators=[MultimodalCorrectnessEvaluator()])
+reports = experiment.run_evaluations(task_function)
+reports[0].run_display()
+```
+
+### Reference-Based (compare against a known answer)
+
+```python
+cases = [
+    Case(
+        name="chart-value",
+        input=MultimodalInput(
+            media="/path/to/revenue_chart.png",
+            instruction="What is the Q3 revenue for Product A?",
+        ),
+        expected_output="$4.2M",
+    ),
+]
+
+experiment = Experiment(cases=cases, evaluators=[MultimodalCorrectnessEvaluator()])
+reports = experiment.run_evaluations(task_function)
+```
+
+When `expected_output` is set, the evaluator automatically appends the reference suffix so the judge compares the response to the Oracle answer.
+
+## Related Evaluators
+
+- [**MultimodalOutputEvaluator**](multimodal_output_evaluator.md): Parent class with full parameter reference
+- [**MultimodalFaithfulnessEvaluator**](multimodal_faithfulness_evaluator.md): Catches hallucinations (claims not verifiable from the image)
+- [**CorrectnessEvaluator**](correctness_evaluator.md): Text-only counterpart

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Overview
 
-The `MultimodalCorrectnessEvaluator` assesses whether an agent response is factually correct given the image content. It catches errors in objects, counts, colors, positions, readable text, and described actions. Uses the built-in `CORRECTNESS_RUBRIC_V0` rubric by default.
+The `MultimodalCorrectnessEvaluator` assesses whether an agent response is factually correct given the image content. It catches errors in objects, counts, colors, positions, readable text, and described actions.
 
 ## Key Features
 
@@ -49,7 +49,7 @@ This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response
 
 ### `reference_suffix` (optional)
 - **Type**: `str | None`
-- **Default**: The `MultimodalOutputEvaluator` default suffix
+- **Default**: `None` (uses the built-in default suffix)
 - **Description**: Override to customize reference-based grading.
 
 ## Scoring System
@@ -109,7 +109,7 @@ experiment = Experiment(cases=cases, evaluators=[MultimodalCorrectnessEvaluator(
 reports = experiment.run_evaluations(task_function)
 ```
 
-When `expected_output` is set, the evaluator automatically appends the reference suffix so the judge compares the response to the Oracle answer.
+When `expected_output` is set, the evaluator automatically appends the reference suffix so the judge compares the response to the reference answer.
 
 ## Related Evaluators
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
@@ -6,14 +6,14 @@ sidebar:
 
 ## Overview
 
-The `MultimodalCorrectnessEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `CORRECTNESS_RUBRIC_V0` rubric. It grades whether a text response is factually correct given the image content, acting as a strict fact-checker that catches errors in objects, counts, colors, positions, readable text, and described actions.
+The `MultimodalCorrectnessEvaluator` assesses whether an agent response is factually correct given the image content. It catches errors in objects, counts, colors, positions, readable text, and described actions. Uses the built-in `CORRECTNESS_RUBRIC_V0` rubric by default.
 
 ## Key Features
 
 - **Output-Level Evaluation**: Scores a single agent response per case
-- **Strict Binary Scoring**: `1.0` for correct, `0.0` if any single factual error is found
-- **Reference-Free or Reference-Based**: Adds the reference suffix automatically when `expected_output` is set
-- **MLLM Judge**: Inspects the image and response together
+- **Binary Scoring**: `1.0` for correct, `0.0` if any factual error is found
+- **Automatic Reference Comparison**: Appends a reference suffix to the rubric when `expected_output` is provided on the case
+- **Fact-Checking Focus**: Designed to catch factual errors in image descriptions and VQA answers
 
 ## When to Use
 
@@ -23,12 +23,16 @@ Use the `MultimodalCorrectnessEvaluator` when you need to:
 - Measure exact correctness on benchmark tasks with a known answer
 - Catch small but important errors (off-by-one counts, wrong colors, misread text)
 
+## Evaluation Level
+
+This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response per case.
+
 ## Parameters
 
 ### `rubric` (optional)
 - **Type**: `str | None`
 - **Default**: `CORRECTNESS_RUBRIC_V0`
-- **Description**: Custom rubric. Leave unset to use the shipped image-to-text correctness rubric.
+- **Description**: Custom rubric. Leave unset to use the default rubric.
 
 ### `model` (optional)
 - **Type**: `Model | str | None`

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_correctness_evaluator.mdx
@@ -69,6 +69,7 @@ A response passes only if the score is `1.0`.
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import MultimodalCorrectnessEvaluator
 from strands_evals.types import MultimodalInput
+from strands_evals.types.evaluation_report import EvaluationReport
 
 
 def task_function(case: Case) -> str:
@@ -88,7 +89,7 @@ cases = [
 
 experiment = Experiment(cases=cases, evaluators=[MultimodalCorrectnessEvaluator()])
 reports = experiment.run_evaluations(task_function)
-reports[0].run_display()
+EvaluationReport.flatten(reports).run_display()
 ```
 
 ### Reference-Based (compare against a known answer)

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Overview
 
-The `MultimodalFaithfulnessEvaluator` assesses whether an agent response is grounded in the image content, detecting hallucinations such as invented details, unsupported assumptions, external knowledge, and speculation. Uses the built-in `FAITHFULNESS_RUBRIC_V0` rubric by default.
+The `MultimodalFaithfulnessEvaluator` assesses whether an agent response is grounded in the image content, detecting hallucinations such as invented details, unsupported assumptions, external knowledge, and speculation.
 
 ## Key Features
 
@@ -50,7 +50,7 @@ This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response
 
 ### `reference_suffix` (optional)
 - **Type**: `str | None`
-- **Default**: The `MultimodalOutputEvaluator` default suffix
+- **Default**: `None` (uses the built-in default suffix)
 
 ## Scoring System
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
@@ -6,16 +6,14 @@ sidebar:
 
 ## Overview
 
-The `MultimodalFaithfulnessEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `FAITHFULNESS_RUBRIC_V0` rubric. It grades whether a text response is strictly grounded in what is visible in the image, acting as a hallucination detector that penalizes invented details, assumptions, external knowledge, and speculation.
-
-Correctness asks "is the claim true?"; faithfulness asks "is the claim actually supported by the image?" — a response can be plausible and still fail faithfulness if it goes beyond what the pixels show.
+The `MultimodalFaithfulnessEvaluator` assesses whether an agent response is grounded in the image content, detecting hallucinations such as invented details, unsupported assumptions, external knowledge, and speculation. Uses the built-in `FAITHFULNESS_RUBRIC_V0` rubric by default.
 
 ## Key Features
 
 - **Output-Level Evaluation**: Scores a single agent response per case
-- **Strict Binary Scoring**: `1.0` if fully grounded in the image, `0.0` if any hallucination is found
-- **Reference-Free or Reference-Based**: Adds the reference suffix automatically when `expected_output` is set
-- **MLLM Judge**: Inspects the image and response together
+- **Binary Scoring**: `1.0` if fully grounded, `0.0` if any hallucination is found
+- **Automatic Reference Comparison**: Appends a reference suffix to the rubric when `expected_output` is provided on the case
+- **Hallucination Detection**: Designed to catch invented details, unsupported assumptions, and speculation
 
 ## When to Use
 
@@ -26,12 +24,16 @@ Use the `MultimodalFaithfulnessEvaluator` when you need to:
 - Screen for inferred-but-unseen details (emotions, off-screen events, brand names, locations)
 - Complement correctness checks with a groundedness check
 
+## Evaluation Level
+
+This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response per case.
+
 ## Parameters
 
 ### `rubric` (optional)
 - **Type**: `str | None`
 - **Default**: `FAITHFULNESS_RUBRIC_V0`
-- **Description**: Custom rubric. Leave unset to use the shipped image-to-text faithfulness rubric.
+- **Description**: Custom rubric. Leave unset to use the default rubric.
 
 ### `model` (optional)
 - **Type**: `Model | str | None`
@@ -86,8 +88,6 @@ experiment = Experiment(cases=cases, evaluators=[MultimodalFaithfulnessEvaluator
 reports = experiment.run_evaluations(task_function)
 reports[0].run_display()
 ```
-
-A response like "A family is having a picnic in Central Park" would score `0.0` if the location cannot be verified from the pixels, even if the scene correctly depicts a picnic.
 
 ## Combining with Other Evaluators
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
@@ -1,0 +1,107 @@
+---
+title: Multimodal Faithfulness Evaluator
+sidebar:
+  label: "Multimodal Faithfulness"
+---
+
+## Overview
+
+The `MultimodalFaithfulnessEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `FAITHFULNESS_RUBRIC_V0` rubric. It grades whether a text response is strictly grounded in what is visible in the image, acting as a hallucination detector that penalizes invented details, assumptions, external knowledge, and speculation.
+
+Correctness asks "is the claim true?"; faithfulness asks "is the claim actually supported by the image?" — a response can be plausible and still fail faithfulness if it goes beyond what the pixels show.
+
+## Key Features
+
+- **Output-Level Evaluation**: Scores a single agent response per case
+- **Strict Binary Scoring**: `1.0` if fully grounded in the image, `0.0` if any hallucination is found
+- **Reference-Free or Reference-Based**: Adds the reference suffix automatically when `expected_output` is set
+- **MLLM Judge**: Inspects the image and response together
+
+## When to Use
+
+Use the `MultimodalFaithfulnessEvaluator` when you need to:
+
+- Detect hallucinations in image captions or VQA answers
+- Verify that a response only states what is verifiable from the image
+- Screen for inferred-but-unseen details (emotions, off-screen events, brand names, locations)
+- Complement correctness checks with a groundedness check
+
+## Parameters
+
+### `rubric` (optional)
+- **Type**: `str | None`
+- **Default**: `FAITHFULNESS_RUBRIC_V0`
+- **Description**: Custom rubric. Leave unset to use the shipped image-to-text faithfulness rubric.
+
+### `model` (optional)
+- **Type**: `Model | str | None`
+- **Default**: `None` (uses default Bedrock model)
+- **Description**: Multimodal judge model.
+
+### `include_inputs` (optional)
+- **Type**: `bool`
+- **Default**: `True`
+
+### `system_prompt` (optional)
+- **Type**: `str | None`
+- **Default**: `None` (uses the built-in `MLLM_JUDGE_SYSTEM_PROMPT`)
+
+### `reference_suffix` (optional)
+- **Type**: `str | None`
+- **Default**: The `MultimodalOutputEvaluator` default suffix
+
+## Scoring System
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 1.0 | Faithful | Response only contains information verifiable from the image |
+| 0.0 | Unfaithful | Response contains one or more hallucinations |
+
+A response passes only if the score is `1.0`.
+
+## Basic Usage
+
+```python
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import MultimodalFaithfulnessEvaluator
+from strands_evals.types import MultimodalInput
+
+
+def task_function(case: Case) -> str:
+    # Replace with your multimodal agent invocation.
+    return "A family is having a picnic in Central Park."
+
+
+cases = [
+    Case(
+        name="park-scene",
+        input=MultimodalInput(
+            media="/path/to/picnic.jpg",
+            instruction="Describe what is happening in the image.",
+        ),
+    ),
+]
+
+experiment = Experiment(cases=cases, evaluators=[MultimodalFaithfulnessEvaluator()])
+reports = experiment.run_evaluations(task_function)
+reports[0].run_display()
+```
+
+A response like "A family is having a picnic in Central Park" would score `0.0` if the location cannot be verified from the pixels, even if the scene correctly depicts a picnic.
+
+## Combining with Other Evaluators
+
+Pair with correctness to distinguish "wrong" from "ungrounded":
+
+```python
+evaluators = [
+    MultimodalCorrectnessEvaluator(),   # Are the claims factually right?
+    MultimodalFaithfulnessEvaluator(),  # Are they supported by the image?
+]
+```
+
+## Related Evaluators
+
+- [**MultimodalOutputEvaluator**](multimodal_output_evaluator.md): Parent class with full parameter reference
+- [**MultimodalCorrectnessEvaluator**](multimodal_correctness_evaluator.md): Strict factual correctness
+- [**FaithfulnessEvaluator**](faithfulness_evaluator.md): Text-only counterpart grounded in conversation history

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_faithfulness_evaluator.mdx
@@ -67,6 +67,7 @@ A response passes only if the score is `1.0`.
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import MultimodalFaithfulnessEvaluator
 from strands_evals.types import MultimodalInput
+from strands_evals.types.evaluation_report import EvaluationReport
 
 
 def task_function(case: Case) -> str:
@@ -86,18 +87,29 @@ cases = [
 
 experiment = Experiment(cases=cases, evaluators=[MultimodalFaithfulnessEvaluator()])
 reports = experiment.run_evaluations(task_function)
-reports[0].run_display()
+EvaluationReport.flatten(reports).run_display()
 ```
 
 ## Combining with Other Evaluators
 
-Pair with correctness to distinguish "wrong" from "ungrounded":
+Pair with correctness to distinguish "wrong" from "ungrounded". `Experiment.run_evaluations` returns one report per evaluator, so use `EvaluationReport.flatten` to view them together:
 
 ```python
+from strands_evals import Experiment
+from strands_evals.evaluators import (
+    MultimodalCorrectnessEvaluator,
+    MultimodalFaithfulnessEvaluator,
+)
+from strands_evals.types.evaluation_report import EvaluationReport
+
 evaluators = [
     MultimodalCorrectnessEvaluator(),   # Are the claims factually right?
     MultimodalFaithfulnessEvaluator(),  # Are they supported by the image?
 ]
+
+experiment = Experiment(cases=cases, evaluators=evaluators)
+reports = experiment.run_evaluations(task_function)
+EvaluationReport.flatten(reports).run_display()
 ```
 
 ## Related Evaluators

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Overview
 
-The `MultimodalInstructionFollowingEvaluator` assesses whether an agent response satisfies the explicit constraints in the user's instruction (counts, format, scope, order, completeness, and style), independently of factual accuracy. Uses the built-in `INSTRUCTION_FOLLOWING_RUBRIC_V0` rubric by default.
+The `MultimodalInstructionFollowingEvaluator` assesses whether an agent response satisfies the explicit constraints in the user's instruction (count, format, scope, order, completeness, and style), independently of factual accuracy.
 
 ## Key Features
 
@@ -20,7 +20,7 @@ The `MultimodalInstructionFollowingEvaluator` assesses whether an agent response
 Use the `MultimodalInstructionFollowingEvaluator` when you need to:
 
 - Verify that responses respect format constraints (bullet vs. numbered list, paragraph, JSON)
-- Check length constraints ("exactly N sentences", "in one paragraph")
+- Check count constraints ("exactly N sentences", "in one paragraph")
 - Assess scope constraints ("describe only the foreground", "do not mention people")
 - Validate order constraints ("left to right", "largest to smallest")
 - Evaluate instruction compliance independently from factual correctness
@@ -51,7 +51,7 @@ This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response
 
 ### `reference_suffix` (optional)
 - **Type**: `str | None`
-- **Default**: The `MultimodalOutputEvaluator` default suffix
+- **Default**: `None` (uses the built-in default suffix)
 
 ## Scoring System
 
@@ -99,7 +99,7 @@ Pair with correctness and faithfulness to assess different failure modes separat
 
 ```python
 evaluators = [
-    MultimodalInstructionFollowingEvaluator(),  # Did it follow the format/scope?
+    MultimodalInstructionFollowingEvaluator(),  # Did it follow the instruction constraints?
     MultimodalCorrectnessEvaluator(),           # Are the listed objects correct?
     MultimodalFaithfulnessEvaluator(),          # Are they actually in the image?
 ]

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
@@ -6,14 +6,14 @@ sidebar:
 
 ## Overview
 
-The `MultimodalInstructionFollowingEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `INSTRUCTION_FOLLOWING_RUBRIC_V0` rubric. It grades whether a text response satisfies the explicit constraints in the user's instruction — counts, format, scope, order, completeness, and style — independently of factual accuracy.
+The `MultimodalInstructionFollowingEvaluator` assesses whether an agent response satisfies the explicit constraints in the user's instruction (counts, format, scope, order, completeness, and style), independently of factual accuracy. Uses the built-in `INSTRUCTION_FOLLOWING_RUBRIC_V0` rubric by default.
 
 ## Key Features
 
 - **Output-Level Evaluation**: Scores a single agent response per case
-- **Strict Binary Scoring**: `1.0` if all constraints are satisfied, `0.0` if any single constraint is violated
+- **Binary Scoring**: `1.0` if all constraints are satisfied, `0.0` if any constraint is violated
 - **Constraint-Focused**: Evaluates compliance with directives, not overall correctness or quality
-- **MLLM Judge**: Sees both the image and the response so it can verify image-referential constraints (e.g., "describe only the background")
+- **Image-Aware**: Verifies image-referential constraints (e.g., "describe only the background")
 
 ## When to Use
 
@@ -25,12 +25,16 @@ Use the `MultimodalInstructionFollowingEvaluator` when you need to:
 - Validate order constraints ("left to right", "largest to smallest")
 - Evaluate instruction compliance independently from factual correctness
 
+## Evaluation Level
+
+This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response per case.
+
 ## Parameters
 
 ### `rubric` (optional)
 - **Type**: `str | None`
 - **Default**: `INSTRUCTION_FOLLOWING_RUBRIC_V0`
-- **Description**: Custom rubric. Leave unset to use the shipped image-to-text instruction-following rubric.
+- **Description**: Custom rubric. Leave unset to use the default rubric.
 
 ### `model` (optional)
 - **Type**: `Model | str | None`
@@ -88,8 +92,6 @@ experiment = Experiment(
 reports = experiment.run_evaluations(task_function)
 reports[0].run_display()
 ```
-
-Because the rubric is strict, a response that lists four objects, uses numbered format instead of bullets, or mentions a foreground object would score `0.0`.
 
 ## Combining with Other Evaluators
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
@@ -1,0 +1,109 @@
+---
+title: Multimodal Instruction Following Evaluator
+sidebar:
+  label: "Multimodal Instruction Following"
+---
+
+## Overview
+
+The `MultimodalInstructionFollowingEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `INSTRUCTION_FOLLOWING_RUBRIC_V0` rubric. It grades whether a text response satisfies the explicit constraints in the user's instruction — counts, format, scope, order, completeness, and style — independently of factual accuracy.
+
+## Key Features
+
+- **Output-Level Evaluation**: Scores a single agent response per case
+- **Strict Binary Scoring**: `1.0` if all constraints are satisfied, `0.0` if any single constraint is violated
+- **Constraint-Focused**: Evaluates compliance with directives, not overall correctness or quality
+- **MLLM Judge**: Sees both the image and the response so it can verify image-referential constraints (e.g., "describe only the background")
+
+## When to Use
+
+Use the `MultimodalInstructionFollowingEvaluator` when you need to:
+
+- Verify that responses respect format constraints (bullet vs. numbered list, paragraph, JSON)
+- Check length constraints ("exactly N sentences", "in one paragraph")
+- Assess scope constraints ("describe only the foreground", "do not mention people")
+- Validate order constraints ("left to right", "largest to smallest")
+- Evaluate instruction compliance independently from factual correctness
+
+## Parameters
+
+### `rubric` (optional)
+- **Type**: `str | None`
+- **Default**: `INSTRUCTION_FOLLOWING_RUBRIC_V0`
+- **Description**: Custom rubric. Leave unset to use the shipped image-to-text instruction-following rubric.
+
+### `model` (optional)
+- **Type**: `Model | str | None`
+- **Default**: `None` (uses default Bedrock model)
+- **Description**: Multimodal judge model.
+
+### `include_inputs` (optional)
+- **Type**: `bool`
+- **Default**: `True`
+
+### `system_prompt` (optional)
+- **Type**: `str | None`
+- **Default**: `None` (uses the built-in `MLLM_JUDGE_SYSTEM_PROMPT`)
+
+### `reference_suffix` (optional)
+- **Type**: `str | None`
+- **Default**: The `MultimodalOutputEvaluator` default suffix
+
+## Scoring System
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 1.0 | Following | All explicit constraints are satisfied |
+| 0.0 | Not Following | One or more constraints are violated |
+
+A response passes only if the score is `1.0`.
+
+## Basic Usage
+
+```python
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import MultimodalInstructionFollowingEvaluator
+from strands_evals.types import MultimodalInput
+
+
+def task_function(case: Case) -> str:
+    # Replace with your multimodal agent invocation.
+    return "- tree\n- bench\n- lamppost"
+
+
+cases = [
+    Case(
+        name="bullet-format",
+        input=MultimodalInput(
+            media="/path/to/park.jpg",
+            instruction="List exactly three objects visible in the background as bullet points.",
+        ),
+    ),
+]
+
+experiment = Experiment(
+    cases=cases,
+    evaluators=[MultimodalInstructionFollowingEvaluator()],
+)
+reports = experiment.run_evaluations(task_function)
+reports[0].run_display()
+```
+
+Because the rubric is strict, a response that lists four objects, uses numbered format instead of bullets, or mentions a foreground object would score `0.0`.
+
+## Combining with Other Evaluators
+
+Pair with correctness and faithfulness to assess different failure modes separately:
+
+```python
+evaluators = [
+    MultimodalInstructionFollowingEvaluator(),  # Did it follow the format/scope?
+    MultimodalCorrectnessEvaluator(),           # Are the listed objects correct?
+    MultimodalFaithfulnessEvaluator(),          # Are they actually in the image?
+]
+```
+
+## Related Evaluators
+
+- [**MultimodalOutputEvaluator**](multimodal_output_evaluator.md): Parent class with full parameter reference
+- [**InstructionFollowingEvaluator**](instruction_following_evaluator.md): Text-only counterpart

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_instruction_following_evaluator.mdx
@@ -68,6 +68,7 @@ A response passes only if the score is `1.0`.
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import MultimodalInstructionFollowingEvaluator
 from strands_evals.types import MultimodalInput
+from strands_evals.types.evaluation_report import EvaluationReport
 
 
 def task_function(case: Case) -> str:
@@ -90,19 +91,31 @@ experiment = Experiment(
     evaluators=[MultimodalInstructionFollowingEvaluator()],
 )
 reports = experiment.run_evaluations(task_function)
-reports[0].run_display()
+EvaluationReport.flatten(reports).run_display()
 ```
 
 ## Combining with Other Evaluators
 
-Pair with correctness and faithfulness to assess different failure modes separately:
+Pair with correctness and faithfulness to assess different failure modes separately. `Experiment.run_evaluations` returns one report per evaluator, so use `EvaluationReport.flatten` to view them together:
 
 ```python
+from strands_evals import Experiment
+from strands_evals.evaluators import (
+    MultimodalCorrectnessEvaluator,
+    MultimodalFaithfulnessEvaluator,
+    MultimodalInstructionFollowingEvaluator,
+)
+from strands_evals.types.evaluation_report import EvaluationReport
+
 evaluators = [
     MultimodalInstructionFollowingEvaluator(),  # Did it follow the instruction constraints?
     MultimodalCorrectnessEvaluator(),           # Are the listed objects correct?
     MultimodalFaithfulnessEvaluator(),          # Are they actually in the image?
 ]
+
+experiment = Experiment(cases=cases, evaluators=evaluators)
+reports = experiment.run_evaluations(task_function)
+EvaluationReport.flatten(reports).run_display()
 ```
 
 ## Related Evaluators

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
@@ -6,16 +6,16 @@ sidebar:
 
 ## Overview
 
-The `MultimodalOutputEvaluator` is an MLLM-as-a-Judge evaluator that assesses the quality of agent outputs for tasks that involve non-text inputs such as images and documents. It extends [`OutputEvaluator`](output_evaluator.md) by overriding the `_build_prompt()` hook: `evaluate()` and `evaluate_async()` are inherited unchanged, so the SDK-level invocation pattern is identical to the text-only evaluator. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/multimodal_output_evaluator.py).
+The `MultimodalOutputEvaluator` assesses the quality of agent outputs for tasks that involve images or documents alongside text. It uses an MLLM as the judge and evaluates responses against a user-defined rubric, extending [`OutputEvaluator`](output_evaluator.md) with multimodal input support. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/multimodal_output_evaluator.py).
 
 ## Key Features
 
-- **MLLM-as-a-Judge**: Uses a multimodal judge model to evaluate responses against both the rubric and the original media
-- **Data-Driven Dispatch**: When the input carries media, the evaluator emits Strands SDK content blocks; otherwise it falls back to a plain text prompt — no `include_media` flag to set
-- **Reference-Free and Reference-Based**: Automatically appends a reference comparison suffix to the rubric when `expected_output` is provided on the case
-- **Flexible Media Sources**: Accepts file paths, base64 strings, data URLs, HTTP(S) URLs (auto-fetched via the stdlib), raw bytes, and PIL Images
-- **Convenience Subclasses**: Ships with `MultimodalOverallQualityEvaluator`, `MultimodalCorrectnessEvaluator`, `MultimodalFaithfulnessEvaluator`, and `MultimodalInstructionFollowingEvaluator`, each pre-wired with a built-in rubric
-- **Async Support**: Inherits `evaluate_async()` from `OutputEvaluator`
+- **MLLM-as-a-Judge**: Uses a multimodal judge model to evaluate responses against the rubric and the media
+- **Data-Driven Dispatch**: Emits Strands SDK content blocks when the input carries media; falls back to a plain text prompt otherwise
+- **Automatic Reference Comparison**: Appends a reference suffix to the rubric when `expected_output` is provided on the case
+- **Multiple Media Sources**: Accepts file paths, base64 strings, data URLs, HTTP(S) URLs (auto-fetched via the stdlib), raw bytes, and PIL Images
+- **Built-in Subclasses**: `MultimodalOverallQualityEvaluator`, `MultimodalCorrectnessEvaluator`, `MultimodalFaithfulnessEvaluator`, and `MultimodalInstructionFollowingEvaluator` each default to a built-in rubric
+- **Async Support**: Supports both synchronous and asynchronous evaluation
 
 ## When to Use
 
@@ -67,7 +67,7 @@ This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response
 The evaluator decides whether to call the judge as a multimodal or text-only model based on the shape of `case.input`:
 
 - If `case.input` is a `MultimodalInput` carrying non-empty media, the composer returns a list of content blocks (media first, then the evaluation text), and the judge is invoked as an MLLM.
-- If `case.input` is anything else (e.g., a plain string) — or a `MultimodalInput` whose `media` is empty — the composer returns a plain text prompt, and the judge behaves exactly like `OutputEvaluator`.
+- If `case.input` is anything else (e.g., a plain string, or a `MultimodalInput` whose `media` is empty), the composer returns a plain text prompt, and the judge behaves exactly like `OutputEvaluator`.
 
 This means the same evaluator can grade a mixed experiment containing both multimodal and text-only cases without any flags to set.
 
@@ -94,18 +94,26 @@ This means the same evaluator can grade a mixed experiment containing both multi
 | Raw bytes | `b"\x89PNG..."` |
 | PIL Image | `PIL.Image.Image` instance (requires `Pillow`) |
 
-HTTP(S) URLs are auto-fetched via `urllib.request` from the standard library — no extra dependencies. The `format` field (`"jpeg"`, `"png"`, `"gif"`, `"webp"`) is auto-detected from the extension or data URL when omitted. S3 URIs and boto3 auto-fetch are not supported; pre-download S3 objects to bytes or a local path before constructing `ImageData`.
+HTTP(S) URLs are auto-fetched via `urllib.request` from the standard library, so no extra dependencies are required. The `format` field (`"jpeg"`, `"png"`, `"gif"`, `"webp"`) is auto-detected from the extension or data URL when omitted. S3 URIs and boto3 auto-fetch are not supported; pre-download S3 objects to bytes or a local path before constructing `ImageData`.
 
 ## Built-in Rubrics
 
 The following rubric constants are available from `strands_evals.evaluators.prompt_templates.multimodal`:
 
-- `OVERALL_QUALITY_RUBRIC_V0` — Likert-5 scale (`0.0`, `0.25`, `0.5`, `0.75`, `1.0`) across visual accuracy, instruction adherence, completeness, and coherence
-- `CORRECTNESS_RUBRIC_V0` — Strict binary (`1.0` / `0.0`) fact-check against the image
-- `FAITHFULNESS_RUBRIC_V0` — Strict binary, catches hallucinations not grounded in the image
-- `INSTRUCTION_FOLLOWING_RUBRIC_V0` — Strict binary, checks format/length/scope/order/completeness constraints
+- `OVERALL_QUALITY_RUBRIC_V0`: Likert-5 scale (`0.0`, `0.25`, `0.5`, `0.75`, `1.0`) across visual accuracy, instruction adherence, completeness, and coherence
+- `CORRECTNESS_RUBRIC_V0`: strict binary (`1.0` / `0.0`) fact-check against the image
+- `FAITHFULNESS_RUBRIC_V0`: strict binary, catches hallucinations not grounded in the image
+- `INSTRUCTION_FOLLOWING_RUBRIC_V0`: strict binary, checks format/length/scope/order/completeness constraints
 
-Each built-in rubric is the default for the matching convenience subclass (see [Related Evaluators](#related-evaluators)).
+Each built-in rubric is the default for the matching subclass (see [Related Evaluators](#related-evaluators)).
+
+## Scoring System
+
+The score is a float between `0.0` and `1.0`; the granularity is determined by the rubric:
+
+- **Strict binary** (`CORRECTNESS_RUBRIC_V0`, `FAITHFULNESS_RUBRIC_V0`, `INSTRUCTION_FOLLOWING_RUBRIC_V0`): `1.0` on success, `0.0` on any violation. A response passes only if the score is `1.0`.
+- **Likert-5** (`OVERALL_QUALITY_RUBRIC_V0`): `0.0`, `0.25`, `0.5`, `0.75`, or `1.0`. A response typically passes if the score is `>= 0.5`.
+- **Custom rubric**: any granularity you define in the rubric text. Specify the pass threshold in the rubric itself (e.g., "Score 1.0 if ...").
 
 ## Basic Usage
 
@@ -189,10 +197,10 @@ Case(
 
 Like `OutputEvaluator`, `MultimodalOutputEvaluator` returns `EvaluationOutput` objects with:
 
-- **score**: Float between `0.0` and `1.0` (granularity depends on the rubric — binary for the strict rubrics, Likert-5 for `OVERALL_QUALITY_RUBRIC_V0`)
-- **test_pass**: Boolean pass/fail
-- **reason**: The judge's written reasoning, including any factual errors or hallucinations it flagged
-- **label**: Optional categorical label from the rubric
+- **score**: Float between `0.0` and `1.0` (see [Scoring System](#scoring-system))
+- **test_pass**: Boolean indicating if the test passed
+- **reason**: String containing the judge's reasoning for the score
+- **label**: Optional label categorizing the result
 
 ## Best Practices
 
@@ -200,7 +208,7 @@ Like `OutputEvaluator`, `MultimodalOutputEvaluator` returns `EvaluationOutput` o
 2. **Keep Images at Reasonable Resolution**: Very large images increase latency and cost without improving judgment; resize to the minimum resolution needed for the task.
 3. **Write Rubrics That Reference the Image**: Phrases like "based on what is visible in the image" anchor the judge to the media rather than to its prior knowledge.
 4. **Use Reference Mode for Ground-Truth Tasks**: Chart QA and VQA benchmarks with known answers benefit from `expected_output` and the reference suffix.
-5. **Start with a Built-in Rubric**: The four shipped rubrics are tuned on Strands-evals benchmarks; customize only once you see where they fall short on your data.
+5. **Start with a Built-in Rubric**: The four built-in rubrics are tuned on Strands-evals benchmarks; customize only once you see where they fall short on your data.
 
 ## Related Evaluators
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
@@ -1,0 +1,211 @@
+---
+title: Multimodal Output Evaluator
+sidebar:
+  label: "Multimodal Output"
+---
+
+## Overview
+
+The `MultimodalOutputEvaluator` is an MLLM-as-a-Judge evaluator that assesses the quality of agent outputs for tasks that involve non-text inputs such as images and documents. It extends [`OutputEvaluator`](output_evaluator.md) by overriding the `_build_prompt()` hook: `evaluate()` and `evaluate_async()` are inherited unchanged, so the SDK-level invocation pattern is identical to the text-only evaluator. A complete example can be found [here](https://github.com/strands-agents/docs/blob/main/docs/examples/evals-sdk/multimodal_output_evaluator.py).
+
+## Key Features
+
+- **MLLM-as-a-Judge**: Uses a multimodal judge model to evaluate responses against both the rubric and the original media
+- **Data-Driven Dispatch**: When the input carries media, the evaluator emits Strands SDK content blocks; otherwise it falls back to a plain text prompt — no `include_media` flag to set
+- **Reference-Free and Reference-Based**: Automatically appends a reference comparison suffix to the rubric when `expected_output` is provided on the case
+- **Flexible Media Sources**: Accepts file paths, base64 strings, data URLs, HTTP(S) URLs (auto-fetched via the stdlib), raw bytes, and PIL Images
+- **Convenience Subclasses**: Ships with `MultimodalOverallQualityEvaluator`, `MultimodalCorrectnessEvaluator`, `MultimodalFaithfulnessEvaluator`, and `MultimodalInstructionFollowingEvaluator`, each pre-wired with a built-in rubric
+- **Async Support**: Inherits `evaluate_async()` from `OutputEvaluator`
+
+## When to Use
+
+Use the `MultimodalOutputEvaluator` when you need to:
+
+- Evaluate image or document understanding (VQA, chart QA, document QA, image captioning, OCR-style tasks)
+- Assess whether a text response is grounded in the visual content it describes
+- Score multimodal responses against a custom rubric that cannot be expressed as exact-match assertions
+- Compare multimodal agent configurations or prompts
+- Benchmark MLLM judges against text-only LLM judges on the same tasks
+
+## Evaluation Level
+
+This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response per case.
+
+## Parameters
+
+### `rubric` (required)
+- **Type**: `str`
+- **Description**: The evaluation criteria that define what constitutes a good response. Should include scoring guidelines (e.g., "Score 1.0 if ..., 0.0 if ..."). You can author your own or reuse a built-in (see [Built-in Rubrics](#built-in-rubrics)).
+
+### `model` (optional)
+- **Type**: `Model | str | None`
+- **Default**: `None` (uses default Bedrock model)
+- **Description**: The multimodal judge model. Can be a model ID string or a `Model` instance. The default must support image input.
+
+### `system_prompt` (optional)
+- **Type**: `str | None`
+- **Default**: `None` (uses the built-in `MLLM_JUDGE_SYSTEM_PROMPT`)
+- **Description**: Custom system prompt to guide the judge model's behavior.
+
+### `include_inputs` (optional)
+- **Type**: `bool`
+- **Default**: `True`
+- **Description**: Whether to include the user instruction in the evaluation prompt. Set to `False` to score the response in isolation.
+
+### `reference_suffix` (optional)
+- **Type**: `str | None`
+- **Default**: `None` (uses the built-in `DEFAULT_REFERENCE_SUFFIX`)
+- **Description**: Text appended to the rubric when `expected_output` is present on the case. Lets you customize how the judge should use the reference (e.g., strict vs. lenient grading).
+
+### `uses_environment_state` (optional)
+- **Type**: `bool`
+- **Default**: `False`
+- **Description**: Whether to include environment state in the evaluation prompt, enabling assessment of agent side effects alongside the output.
+
+## Data-Driven Dispatch
+
+The evaluator decides whether to call the judge as a multimodal or text-only model based on the shape of `case.input`:
+
+- If `case.input` is a `MultimodalInput` carrying non-empty media, the composer returns a list of content blocks (media first, then the evaluation text), and the judge is invoked as an MLLM.
+- If `case.input` is anything else (e.g., a plain string) — or a `MultimodalInput` whose `media` is empty — the composer returns a plain text prompt, and the judge behaves exactly like `OutputEvaluator`.
+
+This means the same evaluator can grade a mixed experiment containing both multimodal and text-only cases without any flags to set.
+
+## `MultimodalInput`
+
+`MultimodalInput` is the Pydantic model used for multimodal cases. It has three fields:
+
+- **`media`** (`ImageData | list[ImageData] | str`): one or more image sources. A plain string is accepted as shorthand for a single `ImageData(source=...)`.
+- **`instruction`** (`str`): the user's question or request about the media.
+- **`context`** (`str | None`): optional additional context surfaced to the judge.
+
+`MultimodalInput` round-trips through `Experiment.to_dict` / `from_dict`: when a saved experiment is reloaded, raw dicts are coerced back to `MultimodalInput` at the prompt-composer boundary.
+
+## `ImageData`
+
+`ImageData` normalizes image sources so the judge receives raw bytes in the correct format. Accepted forms for the `source` field:
+
+| Source | Example |
+|--------|---------|
+| Local file path | `"/path/to/chart.png"` or `pathlib.Path(...)` |
+| Base64 string | `"iVBORw0KGgo..."` |
+| Data URL | `"data:image/png;base64,iVBORw0KGgo..."` |
+| HTTP(S) URL | `"https://upload.wikimedia.org/.../image.jpg"` |
+| Raw bytes | `b"\x89PNG..."` |
+| PIL Image | `PIL.Image.Image` instance (requires `Pillow`) |
+
+HTTP(S) URLs are auto-fetched via `urllib.request` from the standard library — no extra dependencies. The `format` field (`"jpeg"`, `"png"`, `"gif"`, `"webp"`) is auto-detected from the extension or data URL when omitted. S3 URIs and boto3 auto-fetch are not supported; pre-download S3 objects to bytes or a local path before constructing `ImageData`.
+
+## Built-in Rubrics
+
+The following rubric constants are available from `strands_evals.evaluators.prompt_templates.multimodal`:
+
+- `OVERALL_QUALITY_RUBRIC_V0` — Likert-5 scale (`0.0`, `0.25`, `0.5`, `0.75`, `1.0`) across visual accuracy, instruction adherence, completeness, and coherence
+- `CORRECTNESS_RUBRIC_V0` — Strict binary (`1.0` / `0.0`) fact-check against the image
+- `FAITHFULNESS_RUBRIC_V0` — Strict binary, catches hallucinations not grounded in the image
+- `INSTRUCTION_FOLLOWING_RUBRIC_V0` — Strict binary, checks format/length/scope/order/completeness constraints
+
+Each built-in rubric is the default for the matching convenience subclass (see [Related Evaluators](#related-evaluators)).
+
+## Basic Usage
+
+### Reference-Free Evaluation
+
+```python
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import MultimodalOutputEvaluator
+from strands_evals.evaluators.prompt_templates.multimodal import OVERALL_QUALITY_RUBRIC_V0
+from strands_evals.types import ImageData, MultimodalInput
+
+
+def task_function(case: Case) -> str:
+    # Replace with a call to your multimodal agent. For illustration we return
+    # a fixed response so the evaluator has something to score.
+    return "The chart is a bar chart showing quarterly revenue for three product lines in 2024."
+
+
+cases = [
+    Case(
+        name="chart-overview",
+        input=MultimodalInput(
+            media="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Bar_chart_example.png/320px-Bar_chart_example.png",
+            instruction="What kind of chart is shown and what does it represent?",
+        ),
+    ),
+]
+
+evaluator = MultimodalOutputEvaluator(rubric=OVERALL_QUALITY_RUBRIC_V0)
+experiment = Experiment(cases=cases, evaluators=[evaluator])
+reports = experiment.run_evaluations(task_function)
+reports[0].run_display()
+```
+
+### Reference-Based Evaluation
+
+Setting `expected_output` on a case switches the evaluator into reference-based mode. The configured `reference_suffix` is appended to the rubric so the judge compares the response against the Oracle answer.
+
+```python
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import MultimodalOutputEvaluator
+from strands_evals.evaluators.prompt_templates.multimodal import CORRECTNESS_RUBRIC_V0
+from strands_evals.types import ImageData, MultimodalInput
+
+
+cases = [
+    Case(
+        name="chart-value",
+        input=MultimodalInput(
+            media=ImageData(source="/path/to/revenue_chart.png"),
+            instruction="What is the Q3 revenue for Product A?",
+        ),
+        expected_output="$4.2M",
+    ),
+]
+
+evaluator = MultimodalOutputEvaluator(rubric=CORRECTNESS_RUBRIC_V0)
+experiment = Experiment(cases=cases, evaluators=[evaluator])
+reports = experiment.run_evaluations(task_function)
+```
+
+### Multiple Images per Case
+
+Pass a list of `ImageData` (or a list of source strings) to evaluate responses that reason over several images at once:
+
+```python
+Case(
+    name="before-after",
+    input=MultimodalInput(
+        media=[
+            ImageData(source="/path/to/before.jpg"),
+            ImageData(source="/path/to/after.jpg"),
+        ],
+        instruction="What changed between the two photos?",
+        context="Both photos were taken at the same location one year apart.",
+    ),
+)
+```
+
+## Evaluation Output
+
+Like `OutputEvaluator`, `MultimodalOutputEvaluator` returns `EvaluationOutput` objects with:
+
+- **score**: Float between `0.0` and `1.0` (granularity depends on the rubric — binary for the strict rubrics, Likert-5 for `OVERALL_QUALITY_RUBRIC_V0`)
+- **test_pass**: Boolean pass/fail
+- **reason**: The judge's written reasoning, including any factual errors or hallucinations it flagged
+- **label**: Optional categorical label from the rubric
+
+## Best Practices
+
+1. **Use a Multimodal-Capable Judge**: The default Bedrock model must support image input. If you override `model`, confirm the model ID accepts image content blocks.
+2. **Keep Images at Reasonable Resolution**: Very large images increase latency and cost without improving judgment; resize to the minimum resolution needed for the task.
+3. **Write Rubrics That Reference the Image**: Phrases like "based on what is visible in the image" anchor the judge to the media rather than to its prior knowledge.
+4. **Use Reference Mode for Ground-Truth Tasks**: Chart QA and VQA benchmarks with known answers benefit from `expected_output` and the reference suffix.
+5. **Start with a Built-in Rubric**: The four shipped rubrics are tuned on Strands-evals benchmarks; customize only once you see where they fall short on your data.
+
+## Related Evaluators
+
+- [**MultimodalOverallQualityEvaluator**](multimodal_overall_quality_evaluator.md): Likert-5 quality scoring
+- [**MultimodalCorrectnessEvaluator**](multimodal_correctness_evaluator.md): Strict binary factual correctness
+- [**MultimodalFaithfulnessEvaluator**](multimodal_faithfulness_evaluator.md): Strict binary hallucination detection against the image
+- [**MultimodalInstructionFollowingEvaluator**](multimodal_instruction_following_evaluator.md): Strict binary instruction compliance
+- [**OutputEvaluator**](output_evaluator.md): Text-only parent class with the same `evaluate()` contract

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
@@ -54,7 +54,7 @@ This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response
 
 ### `reference_suffix` (optional)
 - **Type**: `str | None`
-- **Default**: `None` (uses the built-in `DEFAULT_REFERENCE_SUFFIX`)
+- **Default**: `None` (uses the built-in default suffix)
 - **Description**: Text appended to the rubric when `expected_output` is present on the case. Lets you customize how the judge should use the reference (e.g., strict vs. lenient grading).
 
 ### `uses_environment_state` (optional)
@@ -90,7 +90,7 @@ This means the same evaluator can grade a mixed experiment containing both multi
 | Local file path | `"/path/to/chart.png"` or `pathlib.Path(...)` |
 | Base64 string | `"iVBORw0KGgo..."` |
 | Data URL | `"data:image/png;base64,iVBORw0KGgo..."` |
-| HTTP(S) URL | `"https://upload.wikimedia.org/.../image.jpg"` |
+| HTTP(S) URL | `"https://example.com/image.jpg"` |
 | Raw bytes | `b"\x89PNG..."` |
 | PIL Image | `PIL.Image.Image` instance (requires `Pillow`) |
 
@@ -103,7 +103,7 @@ The following rubric constants are available from `strands_evals.evaluators.prom
 - `OVERALL_QUALITY_RUBRIC_V0`: Likert-5 scale (`0.0`, `0.25`, `0.5`, `0.75`, `1.0`) across visual accuracy, instruction adherence, completeness, and coherence
 - `CORRECTNESS_RUBRIC_V0`: strict binary (`1.0` / `0.0`) fact-check against the image
 - `FAITHFULNESS_RUBRIC_V0`: strict binary, catches hallucinations not grounded in the image
-- `INSTRUCTION_FOLLOWING_RUBRIC_V0`: strict binary, checks format/length/scope/order/completeness constraints
+- `INSTRUCTION_FOLLOWING_RUBRIC_V0`: strict binary, checks count/format/scope/order/completeness/style constraints
 
 Each built-in rubric is the default for the matching subclass (see [Related Evaluators](#related-evaluators)).
 
@@ -112,7 +112,7 @@ Each built-in rubric is the default for the matching subclass (see [Related Eval
 The score is a float between `0.0` and `1.0`; the granularity is determined by the rubric:
 
 - **Strict binary** (`CORRECTNESS_RUBRIC_V0`, `FAITHFULNESS_RUBRIC_V0`, `INSTRUCTION_FOLLOWING_RUBRIC_V0`): `1.0` on success, `0.0` on any violation. A response passes only if the score is `1.0`.
-- **Likert-5** (`OVERALL_QUALITY_RUBRIC_V0`): `0.0`, `0.25`, `0.5`, `0.75`, or `1.0`. A response typically passes if the score is `>= 0.5`.
+- **Likert-5** (`OVERALL_QUALITY_RUBRIC_V0`): `0.0`, `0.25`, `0.5`, `0.75`, or `1.0`. A response typically passes if the score is `>= 0.75`.
 - **Custom rubric**: any granularity you define in the rubric text. Specify the pass threshold in the rubric itself (e.g., "Score 1.0 if ...").
 
 ## Basic Usage
@@ -136,7 +136,7 @@ cases = [
     Case(
         name="chart-overview",
         input=MultimodalInput(
-            media="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Bar_chart_example.png/320px-Bar_chart_example.png",
+            media="/path/to/your/chart.png",
             instruction="What kind of chart is shown and what does it represent?",
         ),
     ),
@@ -150,7 +150,7 @@ reports[0].run_display()
 
 ### Reference-Based Evaluation
 
-Setting `expected_output` on a case switches the evaluator into reference-based mode. The configured `reference_suffix` is appended to the rubric so the judge compares the response against the Oracle answer.
+Setting `expected_output` on a case switches the evaluator into reference-based mode. The configured `reference_suffix` is appended to the rubric so the judge compares the response against the reference answer.
 
 ```python
 from strands_evals import Case, Experiment
@@ -208,7 +208,7 @@ Like `OutputEvaluator`, `MultimodalOutputEvaluator` returns `EvaluationOutput` o
 2. **Keep Images at Reasonable Resolution**: Very large images increase latency and cost without improving judgment; resize to the minimum resolution needed for the task.
 3. **Write Rubrics That Reference the Image**: Phrases like "based on what is visible in the image" anchor the judge to the media rather than to its prior knowledge.
 4. **Use Reference Mode for Ground-Truth Tasks**: Chart QA and VQA benchmarks with known answers benefit from `expected_output` and the reference suffix.
-5. **Start with a Built-in Rubric**: The four built-in rubrics are tuned on Strands-evals benchmarks; customize only once you see where they fall short on your data.
+5. **Start with a Built-in Rubric**: The four built-in rubrics are the defaults shipped with Strands Evals; customize only once you see where they fall short on your data.
 
 ## Related Evaluators
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_output_evaluator.mdx
@@ -124,6 +124,7 @@ from strands_evals import Case, Experiment
 from strands_evals.evaluators import MultimodalOutputEvaluator
 from strands_evals.evaluators.prompt_templates.multimodal import OVERALL_QUALITY_RUBRIC_V0
 from strands_evals.types import ImageData, MultimodalInput
+from strands_evals.types.evaluation_report import EvaluationReport
 
 
 def task_function(case: Case) -> str:
@@ -145,7 +146,7 @@ cases = [
 evaluator = MultimodalOutputEvaluator(rubric=OVERALL_QUALITY_RUBRIC_V0)
 experiment = Experiment(cases=cases, evaluators=[evaluator])
 reports = experiment.run_evaluations(task_function)
-reports[0].run_display()
+EvaluationReport.flatten(reports).run_display()
 ```
 
 ### Reference-Based Evaluation
@@ -158,6 +159,7 @@ from strands_evals.evaluators import MultimodalOutputEvaluator
 from strands_evals.evaluators.prompt_templates.multimodal import CORRECTNESS_RUBRIC_V0
 from strands_evals.types import ImageData, MultimodalInput
 
+# Reuses the task_function defined in the reference-free example above.
 
 cases = [
     Case(
@@ -208,7 +210,7 @@ Like `OutputEvaluator`, `MultimodalOutputEvaluator` returns `EvaluationOutput` o
 2. **Keep Images at Reasonable Resolution**: Very large images increase latency and cost without improving judgment; resize to the minimum resolution needed for the task.
 3. **Write Rubrics That Reference the Image**: Phrases like "based on what is visible in the image" anchor the judge to the media rather than to its prior knowledge.
 4. **Use Reference Mode for Ground-Truth Tasks**: Chart QA and VQA benchmarks with known answers benefit from `expected_output` and the reference suffix.
-5. **Start with a Built-in Rubric**: The four built-in rubrics are the defaults shipped with Strands Evals; customize only once you see where they fall short on your data.
+5. **Start with a Built-in Rubric**: The four built-in rubrics are the defaults that come with Strands Evals; customize only once you see where they fall short on your data.
 
 ## Related Evaluators
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Overview
 
-The `MultimodalOverallQualityEvaluator` assesses the overall quality of an agent response across four dimensions: visual accuracy, instruction adherence, completeness, and coherence/helpfulness. It produces a single Likert-5 score and uses the built-in `OVERALL_QUALITY_RUBRIC_V0` rubric by default.
+The `MultimodalOverallQualityEvaluator` assesses the overall quality of an agent response across four dimensions: visual accuracy, instruction adherence, completeness, and coherence/helpfulness. It produces a single Likert-5 score.
 
 ## Key Features
 
@@ -61,6 +61,8 @@ This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response
 | 0.5 | Average | Partially correct; misses important details or has minor errors |
 | 0.25 | Poor | Weak response with multiple inaccuracies or significant omissions |
 | 0.0 | Very Poor | Factually wrong, off-topic, and unhelpful |
+
+A response typically passes if the score is `>= 0.75`.
 
 ## Basic Usage
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
@@ -1,0 +1,94 @@
+---
+title: Multimodal Overall Quality Evaluator
+sidebar:
+  label: "Multimodal Overall Quality"
+---
+
+## Overview
+
+The `MultimodalOverallQualityEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `OVERALL_QUALITY_RUBRIC_V0` rubric and a dimension-specific reference suffix that grades responses on factual content rather than word-for-word match. It evaluates an image-to-text response across four dimensions — visual accuracy, instruction adherence, completeness, and coherence/helpfulness — and produces a single Likert-5 score.
+
+## Key Features
+
+- **Output-Level Evaluation**: Scores a single agent response per case
+- **Likert-5 Scoring**: Score is one of `0.0`, `0.25`, `0.5`, `0.75`, `1.0`
+- **Reference-Free or Reference-Based**: Adds the reference suffix automatically when `expected_output` is set
+- **MLLM Judge**: Inspects the image and response together
+
+## When to Use
+
+Use the `MultimodalOverallQualityEvaluator` when you need to:
+
+- Get a single, interpretable quality score for image-to-text responses
+- Track overall quality trends across model or prompt versions
+- Grade open-ended multimodal responses where binary judgments are too coarse
+
+## Parameters
+
+### `rubric` (optional)
+- **Type**: `str | None`
+- **Default**: `OVERALL_QUALITY_RUBRIC_V0`
+- **Description**: Custom rubric. Leave unset to use the shipped rubric.
+
+### `model` (optional)
+- **Type**: `Model | str | None`
+- **Default**: `None` (uses default Bedrock model)
+- **Description**: Multimodal judge model.
+
+### `include_inputs` (optional)
+- **Type**: `bool`
+- **Default**: `True`
+
+### `system_prompt` (optional)
+- **Type**: `str | None`
+- **Default**: `None` (uses the built-in `MLLM_JUDGE_SYSTEM_PROMPT`)
+
+### `reference_suffix` (optional)
+- **Type**: `str | None`
+- **Default**: An overall-quality-specific suffix that grades factual content rather than verbatim match
+- **Description**: Override only if you want stricter or looser reference handling than the shipped default.
+
+## Scoring System
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 1.0 | Excellent | Accurate, complete, directly addresses the instruction |
+| 0.75 | Good | Mostly accurate with minor imprecisions |
+| 0.5 | Average | Partially correct; misses important details or has minor errors |
+| 0.25 | Poor | Weak response with multiple inaccuracies or significant omissions |
+| 0.0 | Very Poor | Factually wrong, off-topic, and unhelpful |
+
+## Basic Usage
+
+```python
+from strands_evals import Case, Experiment
+from strands_evals.evaluators import MultimodalOverallQualityEvaluator
+from strands_evals.types import MultimodalInput
+
+
+def task_function(case: Case) -> str:
+    # Replace with your multimodal agent invocation.
+    return "The chart is a bar chart of quarterly revenue for products A, B, and C."
+
+
+cases = [
+    Case(
+        name="chart-overview",
+        input=MultimodalInput(
+            media="/path/to/revenue_chart.png",
+            instruction="What kind of chart is shown and what does it represent?",
+        ),
+    ),
+]
+
+experiment = Experiment(cases=cases, evaluators=[MultimodalOverallQualityEvaluator()])
+reports = experiment.run_evaluations(task_function)
+reports[0].run_display()
+```
+
+## Related Evaluators
+
+- [**MultimodalOutputEvaluator**](multimodal_output_evaluator.md): Parent class with full parameter reference
+- [**MultimodalCorrectnessEvaluator**](multimodal_correctness_evaluator.md): Strict binary factual correctness
+- [**MultimodalFaithfulnessEvaluator**](multimodal_faithfulness_evaluator.md): Strict binary hallucination detection
+- [**MultimodalInstructionFollowingEvaluator**](multimodal_instruction_following_evaluator.md): Strict binary instruction compliance

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
@@ -6,14 +6,14 @@ sidebar:
 
 ## Overview
 
-The `MultimodalOverallQualityEvaluator` is a convenience subclass of [`MultimodalOutputEvaluator`](multimodal_output_evaluator.md) pre-wired with the built-in `OVERALL_QUALITY_RUBRIC_V0` rubric and a dimension-specific reference suffix that grades responses on factual content rather than word-for-word match. It evaluates an image-to-text response across four dimensions — visual accuracy, instruction adherence, completeness, and coherence/helpfulness — and produces a single Likert-5 score.
+The `MultimodalOverallQualityEvaluator` assesses the overall quality of an agent response across four dimensions: visual accuracy, instruction adherence, completeness, and coherence/helpfulness. It produces a single Likert-5 score and uses the built-in `OVERALL_QUALITY_RUBRIC_V0` rubric by default.
 
 ## Key Features
 
 - **Output-Level Evaluation**: Scores a single agent response per case
 - **Likert-5 Scoring**: Score is one of `0.0`, `0.25`, `0.5`, `0.75`, `1.0`
-- **Reference-Free or Reference-Based**: Adds the reference suffix automatically when `expected_output` is set
-- **MLLM Judge**: Inspects the image and response together
+- **Automatic Reference Comparison**: Appends a reference suffix to the rubric when `expected_output` is provided on the case
+- **Four-Dimension Rubric**: Evaluates visual accuracy, instruction adherence, completeness, and coherence together
 
 ## When to Use
 
@@ -23,12 +23,16 @@ Use the `MultimodalOverallQualityEvaluator` when you need to:
 - Track overall quality trends across model or prompt versions
 - Grade open-ended multimodal responses where binary judgments are too coarse
 
+## Evaluation Level
+
+This evaluator operates at the **OUTPUT_LEVEL**, scoring a single agent response per case.
+
 ## Parameters
 
 ### `rubric` (optional)
 - **Type**: `str | None`
 - **Default**: `OVERALL_QUALITY_RUBRIC_V0`
-- **Description**: Custom rubric. Leave unset to use the shipped rubric.
+- **Description**: Custom rubric. Leave unset to use the default rubric.
 
 ### `model` (optional)
 - **Type**: `Model | str | None`
@@ -46,7 +50,7 @@ Use the `MultimodalOverallQualityEvaluator` when you need to:
 ### `reference_suffix` (optional)
 - **Type**: `str | None`
 - **Default**: An overall-quality-specific suffix that grades factual content rather than verbatim match
-- **Description**: Override only if you want stricter or looser reference handling than the shipped default.
+- **Description**: Override only if you want stricter or looser reference handling than the built-in default.
 
 ## Scoring System
 

--- a/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
+++ b/src/content/docs/user-guide/evals-sdk/evaluators/multimodal_overall_quality_evaluator.mdx
@@ -70,6 +70,7 @@ A response typically passes if the score is `>= 0.75`.
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import MultimodalOverallQualityEvaluator
 from strands_evals.types import MultimodalInput
+from strands_evals.types.evaluation_report import EvaluationReport
 
 
 def task_function(case: Case) -> str:
@@ -89,7 +90,7 @@ cases = [
 
 experiment = Experiment(cases=cases, evaluators=[MultimodalOverallQualityEvaluator()])
 reports = experiment.run_evaluations(task_function)
-reports[0].run_display()
+EvaluationReport.flatten(reports).run_display()
 ```
 
 ## Related Evaluators


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->

Adds user-facing documentation for the multimodal evaluators released in strands-agents/evals#187 (merged 2026-04-30).

New pages under `src/content/docs/user-guide/evals-sdk/evaluators/`:
- `multimodal_output_evaluator.mdx`: primary reference page for the base class.
- `multimodal_overall_quality_evaluator.mdx` (Likert-5).
- `multimodal_correctness_evaluator.mdx` (binary).
- `multimodal_faithfulness_evaluator.mdx` (binary).
- `multimodal_instruction_following_evaluator.mdx` (binary).

Also:
- Runnable example: `docs/examples/evals-sdk/multimodal_output_evaluator.py`
- Index update: new "Multimodal Evaluators" section in `evaluators/index.mdx` and a pointer in Next Steps.
- Sidebar: adds the five pages to `src/config/navigation.yml`.

## Related Issues
<!-- Link to related issues using #issue-number format -->

- strands-agents/evals [Issue #128](https://github.com/strands-agents/evals/issues/128)
- Implementation: strands-agents/evals [PR #187](https://github.com/strands-agents/evals/pull/187) (merged 2026-04-30)
- design-doc PR: #674

## Type of Change
<!-- What kind of change are you making -->

- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
