### PR TITLE
chore(detectors): use better import

### DIFF
--- a/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
+++ b/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
@@ -89,8 +89,7 @@ The most powerful way to use diagnosis is through the `Experiment` class. Pass a
 
 ```python
 from strands_evals import DiagnosisConfig
-from strands_evals.detectors import ConfidenceLevel
-from strands_evals.types.detector import DiagnosisTrigger
+from strands_evals.detectors import ConfidenceLevel, DiagnosisTrigger
 
 class DiagnosisConfig(BaseModel):
     trigger: DiagnosisTrigger = DiagnosisTrigger.ON_FAILURE
@@ -109,9 +108,8 @@ class DiagnosisConfig(BaseModel):
 ```python
 from strands import Agent
 from strands_evals import Case, Experiment, DiagnosisConfig, eval_task, TracedHandler
-from strands_evals.detectors import ConfidenceLevel
+from strands_evals.detectors import ConfidenceLevel, DiagnosisTrigger
 from strands_evals.evaluators import GoalSuccessRateEvaluator
-from strands_evals.types.detector import DiagnosisTrigger
 
 @eval_task(TracedHandler())
 def my_agent_task():
@@ -214,9 +212,8 @@ This example shows the complete workflow: run evaluations with diagnosis, then a
 ```python
 from strands import Agent
 from strands_evals import Case, Experiment, DiagnosisConfig, eval_task, TracedHandler
-from strands_evals.detectors import ConfidenceLevel
+from strands_evals.detectors import ConfidenceLevel, DiagnosisTrigger
 from strands_evals.evaluators import OutputEvaluator, GoalSuccessRateEvaluator
-from strands_evals.types.detector import DiagnosisTrigger
 from strands_tools import calculator
 
 @eval_task(TracedHandler())

--- a/src/content/docs/user-guide/evals-sdk/detectors/index.mdx
+++ b/src/content/docs/user-guide/evals-sdk/detectors/index.mdx
@@ -106,7 +106,7 @@ Detectors integrate directly into the evaluation pipeline. Pass a `DiagnosisConf
 ```python
 from strands_evals import Experiment, Case, DiagnosisConfig
 from strands_evals.evaluators import GoalSuccessRateEvaluator
-from strands_evals.types.detector import DiagnosisTrigger
+from strands_evals.detectors import DiagnosisTrigger
 
 experiment = Experiment(
     cases=test_cases,


### PR DESCRIPTION
## Description
instead of using `from strands_evals.types.detector import ...`, use from `strands_evals.detectors import DiagnosisTrigger, ...`


## Related Issues
N/A


## Type of Change
<!-- What kind of change are you making -->

- New content
- Content update/revision
- Structure/organization improvement
- Typo/formatting fix
- Bug fix
- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [ ] I have read the CONTRIBUTING document
- [ ] My changes follow the project's documentation style
- [ ] I have tested the documentation locally using `npm run dev`
- [ ] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
