### PR TITLE
docs: Add strands-spraay community tool page

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -283,9 +283,7 @@ sidebar:
           - docs/community/tools/strands-sql
           - docs/community/tools/strands-teams
           - docs/community/tools/strands-telegram
-          - docs/community/tools/strands-telegram-listener
-          
-          
+          - docs/community/tools/strands-telegram-listener             
 
 github:
   sections:

--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -279,11 +279,13 @@ sidebar:
         items:
           - docs/community/tools/strands-deepgram
           - docs/community/tools/strands-hubspot
+          - docs/community/tools/strands-spraay
+          - docs/community/tools/strands-sql
           - docs/community/tools/strands-teams
           - docs/community/tools/strands-telegram
           - docs/community/tools/strands-telegram-listener
-          - docs/community/tools/strands-sql
-          - docs/community/tools/strands-spraay
+          
+          
 
 github:
   sections:

--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -283,6 +283,7 @@ sidebar:
           - docs/community/tools/strands-telegram
           - docs/community/tools/strands-telegram-listener
           - docs/community/tools/strands-sql
+          - docs/community/tools/strands-spraay
 
 github:
   sections:

--- a/src/content/docs/community/tools/strands-spraay.mdx
+++ b/src/content/docs/community/tools/strands-spraay.mdx
@@ -1,0 +1,57 @@
+---
+project:
+  pypi: https://pypi.org/project/strands-agents-spraay/
+  github: https://github.com/plagtech/strands-agents-spraay
+  maintainer: plagtech
+service:
+  name: Spraay Protocol
+  link: https://spraay.app
+title: strands-spraay
+community: true
+description: Spraay batch payments on Base
+integrationType: tool
+languages: Python
+sidebar:
+  label: "spraay"
+---
+
+[strands-agents-spraay](https://github.com/plagtech/strands-agents-spraay) is a batch payment tool for Strands Agents, powered by the [Spraay Protocol](https://spraay.app). Send ETH or ERC-20 tokens to up to 200 recipients in a single transaction on Base with ~80% gas savings.
+
+## Installation
+
+```bash
+pip install strands-agents-spraay
+```
+
+## Usage
+
+```python
+from strands import Agent
+from strands_spraay import spraay_batch_payment
+
+agent = Agent(tools=[spraay_batch_payment])
+
+# Send equal ETH to multiple recipients
+agent("Send 0.01 ETH to 0xAAA..., 0xBBB..., and 0xCCC... using batch payment")
+```
+
+## Key Features
+
+- **Batch ETH**: Send equal or variable ETH amounts to multiple recipients
+- **Batch ERC-20**: Send equal or variable token amounts with automatic approval handling
+- **Up to 200 recipients**: Per transaction with ~80% gas savings
+- **Chain ID verification**: Prevents sending to wrong network
+- **Gas buffer**: 10% buffer on estimates to prevent out-of-gas errors
+
+## Configuration
+
+```bash
+SPRAAY_PRIVATE_KEY=your_wallet_private_key    # Required
+BASE_RPC_URL=https://mainnet.base.org         # Optional
+```
+
+## Resources
+
+- [PyPI Package](https://pypi.org/project/strands-agents-spraay/)
+- [GitHub Repository](https://github.com/plagtech/strands-agents-spraay)
+- [Spraay Protocol](https://spraay.app)

--- a/src/content/docs/community/tools/strands-spraay.mdx
+++ b/src/content/docs/community/tools/strands-spraay.mdx
@@ -47,8 +47,11 @@ agent("Send 0.01 ETH to 0xAAA..., 0xBBB..., and 0xCCC... using batch payment")
 
 ```bash
 SPRAAY_PRIVATE_KEY=your_wallet_private_key    # Required
+PRIVATE_KEY=your_wallet_private_key            # Alternative
 BASE_RPC_URL=https://mainnet.base.org         # Optional
 ```
+
+> ⚠️ **Security**: Never commit your private key to source control. Use environment variables or a secrets manager.
 
 ## Resources
 


### PR DESCRIPTION
## Description

Adds documentation page for [strands-agents-spraay](https://github.com/plagtech/strands-agents-spraay) to the community tools catalog.

Spraay is a batch payment tool for Strands Agents — send ETH or ERC-20 tokens to up to 200 recipients in a single transaction on Base with ~80% gas savings.

- Added `src/content/docs/community/tools/strands-spraay.mdx`
- Updated `src/config/navigation.yml` to include the new tool in the sidebar

## Related Issues

N/A

## Type of Change

Other: New community tool documentation page

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have followed the community docs format (matching strands-deepgram.mdx)
- [x] I have updated navigation.yml
- [x] My changes generate no new warnings