### PR TITLE
Fix streamable http client reference

### DIFF
--- a/docs/examples/python/mcp_calculator.py
+++ b/docs/examples/python/mcp_calculator.py
@@ -10,7 +10,7 @@ This example demonstrates how to:
 import threading
 import time
 
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.server import FastMCP
 from strands import Agent
 from strands.tools.mcp.mcp_client import MCPClient
@@ -110,7 +110,7 @@ def main():
     print("Connecting to MCP server...")
 
     def create_streamable_http_transport():
-        return streamablehttp_client("http://localhost:8000/mcp/")
+        return streamable_http_client("http://localhost:8000/mcp/")
 
     streamable_http_mcp_client = MCPClient(create_streamable_http_transport)
 

--- a/src/content/docs/examples/python/mcp_calculator.mdx
+++ b/src/content/docs/examples/python/mcp_calculator.mdx
@@ -45,12 +45,12 @@ mcp.run(transport="streamable-http")
 Now let's walk through how to connect a Strands agent to our MCP server:
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp.mcp_client import MCPClient
 
 def create_streamable_http_transport():
-   return streamablehttp_client("http://localhost:8000/mcp/")
+   return streamable_http_client("http://localhost:8000/mcp/")
 
 streamable_http_mcp_client = MCPClient(create_streamable_http_transport)
 

--- a/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -153,12 +153,12 @@ For HTTP-based MCP servers that use Streamable HTTP transport:
 <Tab label="Python">
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp import MCPClient
 
 streamable_http_mcp_client = MCPClient(
-    lambda: streamablehttp_client("http://localhost:8000/mcp")
+    lambda: streamable_http_client("http://localhost:8000/mcp")
 )
 
 with streamable_http_mcp_client:
@@ -170,11 +170,11 @@ Additional properties like authentication can be configured:
 
 ```python
 import os
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands.tools.mcp import MCPClient
 
 github_mcp_client = MCPClient(
-    lambda: streamablehttp_client(
+    lambda: streamable_http_client(
         url="https://api.githubcopilot.com/mcp/",
         headers={"Authorization": f"Bearer {os.getenv('MCP_PAT')}"}
     )
@@ -194,10 +194,10 @@ pip install mcp-proxy-for-aws
 Then you use it like any other transport:
 
 ```python
-from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
+from mcp_proxy_for_aws.client import aws_iam_streamable_http_client
 from strands.tools.mcp import MCPClient
 
-mcp_client = MCPClient(lambda: aws_iam_streamablehttp_client(
+mcp_client = MCPClient(lambda: aws_iam_streamable_http_client(
     endpoint="https://your-service.us-east-1.amazonaws.com/mcp",
     aws_region="us-east-1",
     aws_service="bedrock-agentcore"

--- a/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -194,10 +194,10 @@ pip install mcp-proxy-for-aws
 Then you use it like any other transport:
 
 ```python
-from mcp_proxy_for_aws.client import aws_iam_streamable_http_client
+from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
 from strands.tools.mcp import MCPClient
 
-mcp_client = MCPClient(lambda: aws_iam_streamable_http_client(
+mcp_client = MCPClient(lambda: aws_iam_streamablehttp_client(
     endpoint="https://your-service.us-east-1.amazonaws.com/mcp",
     aws_region="us-east-1",
     aws_service="bedrock-agentcore"

--- a/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
+++ b/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
@@ -233,13 +233,13 @@ When using [Model Context Protocol (MCP)](../concepts/tools/mcp-tools.md) tools 
 **Establish a new MCP connection for each Lambda invocation.** Creating the `MCPClient` object itself is inexpensive - the costly operation is establishing the actual connection to the server. Use context managers to ensure connections are properly opened and closed:
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp import MCPClient
 
 def handler(event, context):
     mcp_client = MCPClient(
-        lambda: streamablehttp_client("https://your-mcp-server.example.com/mcp")
+        lambda: streamable_http_client("https://your-mcp-server.example.com/mcp")
     )
 
     # Context manager ensures connection is opened and closed safely
@@ -256,13 +256,13 @@ def handler(event, context):
 For optimization, you can establish the connection at module level using `start()` to reuse it across Lambda warm invocations:
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp import MCPClient
 
 # Create and start connection at module level (reused across warm invocations)
 mcp_client = MCPClient(
-    lambda: streamablehttp_client("https://your-mcp-server.example.com/mcp")
+    lambda: streamable_http_client("https://your-mcp-server.example.com/mcp")
 )
 mcp_client.start()
 


### PR DESCRIPTION
## Description
streamablehttp_client is deprecated, referencing streamable_http_client instead


## Related Issues



## Type of Change

- Content update/revision


## Checklist


- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
