### PR TITLE
feat: collapse Model Providers in main sidebar, expand in community

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -113,6 +113,7 @@ sidebar:
             items:
               - docs/user-guide/concepts/experimental/agent-config
       - label: Model Providers
+        collapsed: true
         items:
           - docs/user-guide/concepts/model-providers
           - docs/user-guide/concepts/model-providers/amazon-bedrock

--- a/src/route-middleware.ts
+++ b/src/route-middleware.ts
@@ -67,23 +67,17 @@ export function filterSidebarByBasePath(entries: SidebarEntry[], basePath: strin
   return filtered
 }
 
-// Groups that should remain collapsed in the sidebar when the user
-// is not actively browsing within them. Starlight auto-expands groups
-// that contain the current page.
-const COLLAPSED_GROUPS = new Set(['Model Providers'])
-
 /**
- * Expand first-level groups (set collapsed to false), except groups
- * listed in COLLAPSED_GROUPS which stay collapsed until the user
- * navigates into them (Starlight handles that automatically).
+ * Apply collapse behavior to all sidebar groups:
+ * - depth 0 (top-level): expanded by default
+ * - depth >= 1 (nested): collapsed by default
+ * An explicit collapsed value in the navigation config always takes precedence.
  */
-export function expandFirstLevelGroups(items: SidebarEntry[]): SidebarEntry[] {
+export function applyCollapse(items: SidebarEntry[], depth: number = 0): SidebarEntry[] {
   return items.map((item) => {
     if (item.type === 'group') {
-      if (COLLAPSED_GROUPS.has(item.label)) {
-        return { ...item, collapsed: true }
-      }
-      return { ...item, collapsed: false }
+      const collapsed = item.collapsed === true || depth >= 1
+      return { ...item, collapsed, entries: applyCollapse(item.entries, depth + 1) }
     }
     return item
   })
@@ -166,8 +160,7 @@ export const onRequest = defineRouteMiddleware(async (context) => {
 
   // Otherwise filter it down to the major section that we're in
   const filteredSidebar = filterSidebarByBasePath(sidebar, allBasePaths)
-  const expandedSidebar = expandFirstLevelGroups(filteredSidebar)
-  starlightRoute.sidebar = expandedSidebar
+  starlightRoute.sidebar = applyCollapse(filteredSidebar)
 
   // Starlight pre-computes pagination from the full sidebar before our middleware runs.
   // Prune any prev/next links that fall outside the current nav section, then override

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -12,8 +12,8 @@ export type StarlightSidebarItem =
 interface NavConfigItem {
   label?: string
   items?: NavConfigItem[]
-  slug?: string  // For labeled leaf items (e.g., { label: "Adding Tools", slug: "docs/user-guide/concepts/tools" })
-  collapsed?: boolean  // Explicit collapse state for groups (overrides auto-collapse)
+  slug?: string // For labeled leaf items "Adding Tools"
+  collapsed?: boolean // Explicit collapse state for groups (overrides auto-collapse)
 }
 type NavConfigEntry = string | NavConfigItem
 
@@ -82,7 +82,11 @@ function convertConfigItem(item: NavConfigEntry, ctx: ConvertContext): Starlight
 
       if (children.length === 0) return null
 
-      return { label: item.label, items: children }
+      return {
+        label: item.label,
+        items: children,
+        ...(typeof item.collapsed === 'boolean' && { collapsed: item.collapsed }),
+      }
     }
 
     // Object with label and slug (labeled leaf item)
@@ -93,23 +97,6 @@ function convertConfigItem(item: NavConfigEntry, ctx: ConvertContext): Starlight
   }
 
   return null
-}
-
-/**
- * Apply collapse behavior to nested groups (depth >= 1)
- */
-function applyCollapse(items: StarlightSidebarItem[], depth: number = 0): StarlightSidebarItem[] {
-  return items.map((item) => {
-    if ('items' in item) {
-      const collapsed = depth >= 1
-      return {
-        ...item,
-        items: applyCollapse(item.items, depth + 1),
-        ...(collapsed && { collapsed }),
-      }
-    }
-    return item
-  })
 }
 
 /**
@@ -133,7 +120,7 @@ export function loadSidebarFromConfig(configPath: string, docsContentDir?: strin
     .map((item) => convertConfigItem(item, ctx))
     .filter((i): i is StarlightSidebarItem => i !== null)
 
-  return applyCollapse(items)
+  return items
 }
 
 /**
@@ -151,5 +138,3 @@ export function loadGitHubSectionsFromConfig(configPath: string): GitHubSection[
   const config = loadNavigationConfig(configPath)
   return config.github?.sections || []
 }
-
-


### PR DESCRIPTION
## Description

The main User Guide sidebar has 14 Model Providers entries that should be collapsed by default. The community sidebar also has a Model Providers group that should stay expanded. Previously this was handled by a hardcoded `COLLAPSED_GROUPS` set that matched by label name, which collapsed both.

This replaces that with an explicit `collapsed: true` in `navigation.yml` on the main group only. As part of this, collapse logic was moved entirely into the middleware — `sidebar.ts` was running its own depth-based collapse pass that the middleware then immediately undid for first-level groups, creating a hidden ordering dependency between the two. Now `sidebar.ts` just builds the tree, and `applyCollapse` in the middleware is the single owner: top-level expanded, nested collapsed, explicit YAML values win.

One gotcha: the override check uses `=== true` rather than `!== undefined` because Starlight normalizes unset `collapsed` to `false` before the middleware sees it.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [x] Structure/organization improvement

## Checklist

- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working