### PR TITLE
feat: collapse Model Providers in main sidebar, expand in community

### DIFF
--- a/SITE-ARCHITECTURE.md
+++ b/SITE-ARCHITECTURE.md
@@ -10,15 +10,17 @@ We're using [Astro](https://astro.build/) with the [Starlight](https://starlight
 
 ### 1. Sidebar Generation (`src/sidebar.ts`)
 
-**What it does:** Reads the navigation structure from `src/config/navigation.yml` and converts it to Starlight's sidebar format.
+**What it does:** Reads the navigation structure from `src/config/navigation.yml` and converts it to Starlight's sidebar format. It does not apply any collapse behavior — that is handled entirely by the route middleware.
 
 **Why:** Starlight can auto-generate sidebars from the file structure, but we have a specific navigation layout defined in `navigation.yml` that we want to preserve. The config file also contains navbar and GitHub dropdown configuration.
+
+**Collapse opt-in:** Add `collapsed: true` to any group in `navigation.yml` to make it collapsed by default. This value is passed through to the middleware, which is the sole owner of collapse decisions.
 
 **Badges:** Badges (like "new", "community", "experimental") come from page frontmatter, not the navigation config. This allows page authors to control badges directly.
 
 ### 2. Route Middleware (`src/route-middleware.ts`)
 
-**What it does:** Filters the sidebar at buildtime so each page only shows items from its top-level group. For API pages (Python and TypeScript), it dynamically generates sidebars from the docs collection and computes pagination links.
+**What it does:** Filters the sidebar at buildtime so each page only shows items from its top-level group, and applies collapse behavior via `applyCollapse()`. For API pages (Python and TypeScript), it dynamically generates sidebars from the docs collection and computes pagination links.
 
 **Why:** Our sidebar is organized into top-level groups (User Guide, Community, Examples, etc.). Without this middleware, every page would show the entire sidebar. This middleware scopes the sidebar to the current section, providing a cleaner navigation experience.
 
@@ -284,7 +286,7 @@ These override default Starlight components:
 The custom sidebar components provide a flatter navigation style.
 
 **How it works:**
-1. Top-level groups render as non-collapsible section headers (uppercase labels)
+1. Top-level groups render as non-collapsible section headers (uppercase labels), unless `collapsed: true` is set in `navigation.yml`, in which case they render as a collapsible with a caret icon
 2. Nested groups are collapsible with a caret icon
 3. Group labels link to their first child page (clickable navigation)
 4. Groups auto-expand when they contain the current page

--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -113,6 +113,7 @@ sidebar:
             items:
               - docs/user-guide/concepts/experimental/agent-config
       - label: Model Providers
+        collapsed: true
         items:
           - docs/user-guide/concepts/model-providers
           - docs/user-guide/concepts/model-providers/amazon-bedrock

--- a/src/route-middleware.ts
+++ b/src/route-middleware.ts
@@ -67,23 +67,17 @@ export function filterSidebarByBasePath(entries: SidebarEntry[], basePath: strin
   return filtered
 }
 
-// Groups that should remain collapsed in the sidebar when the user
-// is not actively browsing within them. Starlight auto-expands groups
-// that contain the current page.
-const COLLAPSED_GROUPS = new Set(['Model Providers'])
-
 /**
- * Expand first-level groups (set collapsed to false), except groups
- * listed in COLLAPSED_GROUPS which stay collapsed until the user
- * navigates into them (Starlight handles that automatically).
+ * Apply collapse behavior to all sidebar groups.
+ * Starlight normalizes all unset collapsed values to false before the middleware
+ * runs, making collapsed: false indistinguishable from "not set". Only an explicit
+ * collapsed: true in navigation.yml can override the depth-based default.
  */
-export function expandFirstLevelGroups(items: SidebarEntry[]): SidebarEntry[] {
+export function applyCollapse(items: SidebarEntry[], depth: number = 0): SidebarEntry[] {
   return items.map((item) => {
     if (item.type === 'group') {
-      if (COLLAPSED_GROUPS.has(item.label)) {
-        return { ...item, collapsed: true }
-      }
-      return { ...item, collapsed: false }
+      const collapsed = item.collapsed === true ? true : depth >= 1
+      return { ...item, collapsed, entries: applyCollapse(item.entries, depth + 1) }
     }
     return item
   })
@@ -166,8 +160,7 @@ export const onRequest = defineRouteMiddleware(async (context) => {
 
   // Otherwise filter it down to the major section that we're in
   const filteredSidebar = filterSidebarByBasePath(sidebar, allBasePaths)
-  const expandedSidebar = expandFirstLevelGroups(filteredSidebar)
-  starlightRoute.sidebar = expandedSidebar
+  starlightRoute.sidebar = applyCollapse(filteredSidebar)
 
   // Starlight pre-computes pagination from the full sidebar before our middleware runs.
   // Prune any prev/next links that fall outside the current nav section, then override

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -12,8 +12,8 @@ export type StarlightSidebarItem =
 interface NavConfigItem {
   label?: string
   items?: NavConfigItem[]
-  slug?: string  // For labeled leaf items (e.g., { label: "Adding Tools", slug: "docs/user-guide/concepts/tools" })
-  collapsed?: boolean  // Explicit collapse state for groups (overrides auto-collapse)
+  slug?: string // For labeled leaf items "Adding Tools"
+  collapsed?: boolean // Explicit collapse state for groups (overrides auto-collapse)
 }
 type NavConfigEntry = string | NavConfigItem
 
@@ -82,7 +82,11 @@ function convertConfigItem(item: NavConfigEntry, ctx: ConvertContext): Starlight
 
       if (children.length === 0) return null
 
-      return { label: item.label, items: children }
+      return {
+        label: item.label,
+        items: children,
+        ...(typeof item.collapsed === 'boolean' && { collapsed: item.collapsed }),
+      }
     }
 
     // Object with label and slug (labeled leaf item)
@@ -93,23 +97,6 @@ function convertConfigItem(item: NavConfigEntry, ctx: ConvertContext): Starlight
   }
 
   return null
-}
-
-/**
- * Apply collapse behavior to nested groups (depth >= 1)
- */
-function applyCollapse(items: StarlightSidebarItem[], depth: number = 0): StarlightSidebarItem[] {
-  return items.map((item) => {
-    if ('items' in item) {
-      const collapsed = depth >= 1
-      return {
-        ...item,
-        items: applyCollapse(item.items, depth + 1),
-        ...(collapsed && { collapsed }),
-      }
-    }
-    return item
-  })
 }
 
 /**
@@ -133,7 +120,7 @@ export function loadSidebarFromConfig(configPath: string, docsContentDir?: strin
     .map((item) => convertConfigItem(item, ctx))
     .filter((i): i is StarlightSidebarItem => i !== null)
 
-  return applyCollapse(items)
+  return items
 }
 
 /**
@@ -151,5 +138,3 @@ export function loadGitHubSectionsFromConfig(configPath: string): GitHubSection[
   const config = loadNavigationConfig(configPath)
   return config.github?.sections || []
 }
-
-

--- a/test/route-middleware.test.ts
+++ b/test/route-middleware.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import {
   findCurrentNavSection,
   filterSidebarByBasePath,
-  expandFirstLevelGroups,
+  applyCollapse,
 } from '../src/route-middleware'
 import { type NavLink } from '../src/config/navbar'
 import { loadSidebarFromConfig, type StarlightSidebarItem } from '../src/sidebar'
@@ -199,7 +199,7 @@ describe('Integration: Full filtering flow', () => {
 
     const basePath = currentNav?.basePath || currentNav?.href || ''
     const filtered = filterSidebarByBasePath(runtimeSidebar as any, basePath)
-    const result = expandFirstLevelGroups(filtered)
+    const result = applyCollapse(filtered)
 
     const allLinks = getAllLinks(result)
     console.log(`\n/docs/examples/ page should show ${allLinks.length} sidebar links`)
@@ -219,7 +219,7 @@ describe('Integration: Full filtering flow', () => {
 
     const basePath = currentNav?.basePath || currentNav?.href || ''
     const filtered = filterSidebarByBasePath(runtimeSidebar as any, basePath)
-    const result = expandFirstLevelGroups(filtered)
+    const result = applyCollapse(filtered)
 
     const allLinks = getAllLinks(result)
     expect(allLinks.length).toBeGreaterThan(0)
@@ -237,7 +237,7 @@ describe('Integration: Full filtering flow', () => {
 
     const basePath = currentNav?.basePath || currentNav?.href || ''
     const filtered = filterSidebarByBasePath(runtimeSidebar as any, basePath)
-    const result = expandFirstLevelGroups(filtered)
+    const result = applyCollapse(filtered)
 
     const allLinks = getAllLinks(result)
     expect(allLinks.length).toBeGreaterThan(0)
@@ -247,23 +247,63 @@ describe('Integration: Full filtering flow', () => {
   })
 })
 
-describe('expandFirstLevelGroups', () => {
-  it('should set collapsed to false for first-level groups', () => {
+describe('applyCollapse', () => {
+  it('should keep top-level groups expanded by default', () => {
     const input: SidebarEntry[] = [
-      { type: 'group', label: 'Group 1', collapsed: true, entries: [] },
-      { type: 'group', label: 'Group 2', collapsed: true, entries: [] },
+      { type: 'group', label: 'Group 1', collapsed: false, entries: [] },
+      { type: 'group', label: 'Group 2', collapsed: false, entries: [] },
     ]
 
-    const result = expandFirstLevelGroups(input as any)
+    const result = applyCollapse(input as any)
 
     expect((result[0] as SidebarGroup).collapsed).toBe(false)
     expect((result[1] as SidebarGroup).collapsed).toBe(false)
   })
 
+  it('should respect explicit collapsed: true at top level', () => {
+    const input: SidebarEntry[] = [
+      { type: 'group', label: 'Group 1', collapsed: true, entries: [] },
+      { type: 'group', label: 'Group 2', collapsed: false, entries: [] },
+    ]
+
+    const result = applyCollapse(input as any)
+
+    expect((result[0] as SidebarGroup).collapsed).toBe(true)
+    expect((result[1] as SidebarGroup).collapsed).toBe(false)
+  })
+
+  it('should collapse nested groups by default when no explicit value', () => {
+    // Note: in production Starlight pre-normalizes all unset collapsed to false,
+    // so this path (no collapsed property) is only exercised outside Starlight.
+    const nested = { type: 'group' as const, label: 'Nested', entries: [] }
+    const input = [{ type: 'group' as const, label: 'Top', entries: [nested] }]
+
+    const result = applyCollapse(input as any)
+
+    const top = result[0] as SidebarGroup
+    expect(top.collapsed).toBe(false)
+    expect((top.entries[0] as SidebarGroup).collapsed).toBe(true)
+  })
+
+  it('should collapse nested groups when Starlight has normalized collapsed to false', () => {
+    // Starlight normalizes unset collapsed to false before the middleware runs,
+    // making collapsed: false indistinguishable from "not set". Depth-based
+    // default still applies — only explicit collapsed: true in navigation.yml
+    // can override it.
+    const nested: SidebarGroup = { type: 'group', label: 'Nested', collapsed: false, entries: [] }
+    const input: SidebarEntry[] = [{ type: 'group', label: 'Top', collapsed: false, entries: [nested] }]
+
+    const result = applyCollapse(input as any)
+
+    const top = result[0] as SidebarGroup
+    expect(top.collapsed).toBe(false)
+    expect((top.entries[0] as SidebarGroup).collapsed).toBe(true)
+  })
+
   it('should not modify links', () => {
     const input: SidebarEntry[] = [{ type: 'link', label: 'Link', href: '/link/', isCurrent: false }]
 
-    const result = expandFirstLevelGroups(input as any)
+    const result = applyCollapse(input as any)
 
     expect(result[0]!.type).toBe('link')
     expect((result[0] as SidebarLink).href).toBe('/link/')

--- a/test/sidebar.test.ts
+++ b/test/sidebar.test.ts
@@ -74,7 +74,7 @@ describe('Sidebar Generation from navigation.yml', () => {
     expect(topLevelLabels).toContain('Community')
   })
 
-  it('should have collapsed groups at depth >= 1', () => {
+  it('should not set collapsed on groups unless explicitly specified in YAML', () => {
     const sidebar = loadSidebarFromConfig(pathToNavigationYml)
 
     // Find the Docs section
@@ -85,16 +85,16 @@ describe('Sidebar Generation from navigation.yml', () => {
 
     expect(docs).toBeDefined()
     if (docs) {
-      // Top level should not be collapsed
+      // Top level should not have collapsed set (middleware handles depth-based defaults)
       expect(docs).not.toHaveProperty('collapsed')
 
-      // Find a nested group (like "Get Started")
+      // Find a nested group (like "Get Started") — no explicit collapsed in YAML
       const getStarted = docs.items.find(
         (item): item is StarlightSidebarItem & { label: string } => 'label' in item && item.label === 'Get Started'
       )
 
-      // Nested groups should be collapsed
-      expect(getStarted).toHaveProperty('collapsed', true)
+      // Nested groups without explicit YAML collapsed flag should also lack the property
+      expect(getStarted).not.toHaveProperty('collapsed')
     }
   })
 


### PR DESCRIPTION
## Description

The main User Guide sidebar has 14 Model Providers entries that should be collapsed by default. The community sidebar also has a Model Providers group that should stay expanded. Previously this was handled by a hardcoded `COLLAPSED_GROUPS` set that matched by label name, which collapsed both.

This replaces that with an explicit `collapsed: true` in `navigation.yml` on the main group only. As part of this, collapse logic was moved entirely into the middleware — `sidebar.ts` was running its own depth-based collapse pass that the middleware then immediately undid for first-level groups, creating a hidden ordering dependency between the two. Now `sidebar.ts` just builds the tree, and `applyCollapse` in the middleware is the single owner: top-level expanded, nested collapsed, explicit YAML values win.

One gotcha: the override check uses `=== true` rather than `!== undefined` because Starlight normalizes unset `collapsed` to `false` before the middleware sees it.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [x] Structure/organization improvement

## Checklist

- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working