### PR TITLE
fix: fix mermaid diagram rendering on switching tabs

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -86,7 +86,7 @@ const structuredData = {
 <script>
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'
 
-  // Transform Expressive Code mermaid blocks into mermaid.js format and render
+  // Transform Expressive Code mermaid blocks into mermaid.js format
   document.querySelectorAll('pre[data-language="mermaid"]').forEach((pre) => {
     const diagram = [...pre.querySelectorAll('code > .ec-line')].map((it) => it.textContent).join('\n')
     const div = document.createElement('pre')
@@ -97,5 +97,35 @@ const structuredData = {
 
   const isDark = document.documentElement.dataset.theme === 'dark'
   mermaid.initialize({ startOnLoad: false, theme: isDark ? 'dark' : 'neutral' })
-  mermaid.run()
+
+  // Only render diagrams in visible panels; defer hidden ones until shown
+  const hiddenDiagrams = new Set(
+    document.querySelectorAll('[role="tabpanel"][hidden] .mermaid')
+  )
+  const visibleDiagrams = [...document.querySelectorAll('.mermaid')].filter(
+    (el) => !hiddenDiagrams.has(el)
+  )
+  if (visibleDiagrams.length > 0) {
+    await mermaid.run({ nodes: visibleDiagrams })
+  }
+
+  // Render deferred diagrams once when their panel becomes visible
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'hidden') {
+        const panel = mutation.target as Element
+        if (panel.hasAttribute('hidden')) continue
+        const pending = [...panel.querySelectorAll('.mermaid')].filter(
+          (el) => hiddenDiagrams.has(el)
+        )
+        if (pending.length === 0) continue
+        pending.forEach((el) => hiddenDiagrams.delete(el))
+        mermaid.run({ nodes: pending })
+      }
+    }
+  })
+
+  document.querySelectorAll('[role="tabpanel"]').forEach((panel) => {
+    observer.observe(panel, { attributes: true, attributeFilter: ['hidden'] })
+  })
 </script>


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
<!-- If applicable, add screenshots to help explain your changes -->

The change in this PR fixes a bug where the mermaid diagrams would not render when switching tabs. 


## Related Issues
<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/docs/issues/727


## Type of Change
<!-- What kind of change are you making -->

- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
