### PR TITLE
feat: add discord to strands website

### DIFF
--- a/src/components/DiscordLink.astro
+++ b/src/components/DiscordLink.astro
@@ -1,0 +1,36 @@
+---
+import { Icon } from '@astrojs/starlight/components'
+---
+
+<a
+  href="https://discord.gg/strandsagents"
+  target="_blank"
+  rel="noopener noreferrer"
+  class="discord-link"
+  aria-label="Strands Agents Discord"
+>
+  <Icon name="discord" size="1.25rem" />
+</a>
+
+<style>
+  @layer starlight.core {
+    .discord-link {
+      display: flex;
+      align-items: center;
+      padding: 0.375rem 0.5rem;
+      /* Push Discord a touch further from the GitHub caret so the visual
+         gap on its left matches the gap on its right (the LanguageToggle's
+         first button has internal padding before its icon, which widens
+         the perceived right-side gap). */
+      margin-left: -0.5rem;
+      color: var(--sl-color-text);
+      text-decoration: none;
+      border-radius: 0.375rem;
+      transition: background-color 0.15s;
+    }
+
+    .discord-link:hover {
+      background-color: var(--sl-color-gray-6);
+    }
+  }
+</style>

--- a/src/components/DiscordLink.astro
+++ b/src/components/DiscordLink.astro
@@ -3,7 +3,7 @@ import { Icon } from '@astrojs/starlight/components'
 ---
 
 <a
-  href="https://discord.gg/strandsagents"
+  href="https://discord.gg/strands"
   target="_blank"
   rel="noopener noreferrer"
   class="discord-link"

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -19,6 +19,7 @@ import { Icon } from '@astrojs/starlight/components';
 import { navLinks, githubSections, type NavLink } from '../../config/navbar';
 import type { GitHubSection } from '../../sidebar';
 import GitHubDropdown from '../GitHubDropdown.astro';
+import DiscordLink from '../DiscordLink.astro';
 import LanguageToggle from '../LanguageToggle.astro';
 import { findCurrentNavSection } from '../../route-middleware';
 import logoHeaderDark from '../../assets/logo-header-dark.svg';
@@ -82,12 +83,17 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
                 ))}
               </Fragment>
             ))}
+            <div class="mobile-nav-divider"></div>
+            <a href="https://discord.gg/strandsagents" target="_blank" rel="noopener noreferrer" class="mobile-nav-link">
+              Discord <span class="external-icon" aria-hidden="true">↗</span>
+            </a>
           </div>
         </details>
       </nav>
     )}
     <div class="sl-hidden md:sl-flex print:hidden right-group">
       <GitHubDropdown />
+      <DiscordLink />
       <LanguageToggle />
       <ThemeSelect />
       <LanguageSelect />

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -84,7 +84,7 @@ const { siteTitleHref } = Astro.locals.starlightRoute;
               </Fragment>
             ))}
             <div class="mobile-nav-divider"></div>
-            <a href="https://discord.gg/strandsagents" target="_blank" rel="noopener noreferrer" class="mobile-nav-link">
+            <a href="https://discord.gg/strands" target="_blank" rel="noopener noreferrer" class="mobile-nav-link">
               Discord <span class="external-icon" aria-hidden="true">↗</span>
             </a>
           </div>


### PR DESCRIPTION
## Description
Add Discord icon to Strands site

<img width="792" height="285" alt="Screenshot 2026-05-11 at 4 52 49 PM" src="https://github.com/user-attachments/assets/5c980cba-c7e2-4961-95ff-5161c79684ec" />

## Related Issues
<!-- Link to related issues using #issue-number format -->


## Type of Change
<!-- What kind of change are you making -->

- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
