### PR TITLE
feat: batch TS updates including hooks updates, retries, multi-agent …

### DIFF
--- a/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -95,12 +95,12 @@ Key features of the `SlidingWindowConversationManager`:
 - **Maintains Window Size**: Automatically removes messages from the window if the number of messages exceeds the limit.
 - **Dangling Message Cleanup**: Removes incomplete message sequences to maintain valid conversation state.
 - **Overflow Trimming**: In the case of a context window overflow, it will trim the oldest messages from history until the request fits in the models context window.
-- **Configurable Tool Result Truncation**: Enable or disable truncation of tool results when the message exceeds context window limits. When `should_truncate_results=True` (default), the oldest message with tool results is truncated first so recent context is preserved as long as possible. Truncation depends on content type:
+- **Configurable Tool Result Truncation**: Enable or disable truncation of tool results when the message exceeds context window limits. When enabled (the default; `should_truncate_results=True` in Python, `shouldTruncateResults: true` in TypeScript), the oldest message with tool results is truncated first so recent context is preserved as long as possible. Truncation depends on content type:
     - Text payloads keep their head and tail, separated by a `<truncated chars="N"/>` marker.
     - Images, videos, binary documents, and oversized JSON are replaced by a typed placeholder, for example `[image: png, source: bytes, 12345 bytes]`.
     - The tool result's original `status` and `error` fields are preserved.
 
-    When `False`, full results are preserved but more historical messages may be removed. For a proactive alternative that preserves full content externally, see the [Context Offloader](../plugins/context-offloader) plugin.
+    When disabled, full results are preserved but more historical messages may be removed. For a proactive alternative that preserves full content externally, see the [Context Offloader](../plugins/context-offloader) plugin.
 - **Per-Turn Management**: Optionally apply context management proactively during the agent loop execution, not just at the end.
 - **Proactive Compression**: Pass `proactiveCompression: true` or `proactiveCompression: { compressionThreshold: 0.7 }` to trigger context reduction before the model call when projected input tokens exceed a configurable threshold. See [Proactive Context Compression](#proactive-context-compression).
 

--- a/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -95,7 +95,12 @@ Key features of the `SlidingWindowConversationManager`:
 - **Maintains Window Size**: Automatically removes messages from the window if the number of messages exceeds the limit.
 - **Dangling Message Cleanup**: Removes incomplete message sequences to maintain valid conversation state.
 - **Overflow Trimming**: In the case of a context window overflow, it will trim the oldest messages from history until the request fits in the models context window.
-- **Configurable Tool Result Truncation**: Enable / disable truncation of tool results when the message exceeds context window limits. When `should_truncate_results=True` (default), large results are truncated with a placeholder message. When `False`, full results are preserved but more historical messages may be removed. For a proactive alternative that preserves full content externally, see the [Context Offloader](../plugins/context-offloader) plugin.
+- **Configurable Tool Result Truncation**: Enable or disable truncation of tool results when the message exceeds context window limits. When `should_truncate_results=True` (default), the oldest message with tool results is truncated first so recent context is preserved as long as possible. Truncation depends on content type:
+    - Text payloads keep their head and tail, separated by a `<truncated chars="N"/>` marker.
+    - Images, videos, binary documents, and oversized JSON are replaced by a typed placeholder, for example `[image: png, source: bytes, 12345 bytes]`.
+    - The tool result's original `status` and `error` fields are preserved.
+
+    When `False`, full results are preserved but more historical messages may be removed. For a proactive alternative that preserves full content externally, see the [Context Offloader](../plugins/context-offloader) plugin.
 - **Per-Turn Management**: Optionally apply context management proactively during the agent loop execution, not just at the end.
 - **Proactive Compression**: Pass `proactiveCompression: true` or `proactiveCompression: { compressionThreshold: 0.7 }` to trigger context reduction before the model call when projected input tokens exceed a configurable threshold. See [Proactive Context Compression](#proactive-context-compression).
 

--- a/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -202,7 +202,9 @@ flowchart LR
     direction TB
         AgentResultEvent["AgentResultEvent"]
         AfterInvocationEvent["AfterInvocationEvent"]
+        InterruptEvent["InterruptEvent"]
         AgentResultEvent --> AfterInvocationEvent
+        InterruptEvent --> AfterInvocationEvent
   end
 Start --> Model
 Model <--> Tool
@@ -317,6 +319,7 @@ All events extend `HookableEvent`, making them both streamable via `agent.stream
 | `ToolStreamUpdateEvent`  | Wraps streaming progress events from tool execution. Access via `.event`                                      |
 | `ToolResultEvent`        | Wraps a completed tool result. Access via `.result`                                                           |
 | `AgentResultEvent`       | Wraps the final agent result at the end of the invocation. Access via `.result`                               |
+| `InterruptEvent`         | Fires once per unanswered interrupt when the agent halts to wait for responses. Access via `.interrupt`       |
 | `MultiAgentInitializedEvent`       | Triggered when a multi-agent orchestrator has finished initialization                                |
 | `BeforeMultiAgentInvocationEvent`  | Triggered before orchestrator execution starts                                                       |
 | `AfterMultiAgentInvocationEvent`   | Triggered after orchestrator execution completes. Uses reverse callback ordering                     |
@@ -369,12 +372,18 @@ Most event properties are read-only to prevent unintended modifications. However
 
 - `BeforeToolCallEvent`
     - `cancel` - Cancel tool execution with a message. See [Limit Tool Counts](#limit-tool-counts).
+    - `selectedTool` - Replace the tool to be executed with a different `Tool` instance. See [Tool Interception](#tool-interception).
+    - `toolUse` - Mutable. Rewrite `name`, `toolUseId`, or `input` before execution. Renaming `name` re-resolves the tool from the registry when `selectedTool` is not set. See [Fixed Tool Arguments](#fixed-tool-arguments).
 
 - `AfterModelCallEvent`
     - `retry` - Request a retry of the model invocation.
 
 - `AfterToolCallEvent`
     - `retry` - Request a retry of the tool invocation.
+    - `result` - Mutable. Rewrite the `ToolResultBlock` before it propagates to the model. See [Result Modification](#result-modification).
+
+- `AfterInvocationEvent`
+    - `resume` - Trigger a follow-up agent invocation with new input. Setting it re-enters the agent loop under the same invocation lock. See [Invocation resume](#invocation-resume).
 </Tab>
 </Tabs>
 
@@ -513,8 +522,10 @@ class ToolInterceptor(HookProvider):
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Changing of tools is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks_imports.ts:tool_interception_imports"
+
+--8<-- "user-guide/concepts/agents/hooks.ts:tool_interception"
 ```
 </Tab>
 </Tabs>
@@ -540,8 +551,10 @@ class ResultProcessor(HookProvider):
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Changing of tool results is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks_imports.ts:result_modification_imports"
+
+--8<-- "user-guide/concepts/agents/hooks.ts:result_modification"
 ```
 </Tab>
 </Tabs>
@@ -626,8 +639,10 @@ class ResultProcessor(HookProvider):
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Changing of tools is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks_imports.ts:logging_modifications_imports"
+
+--8<-- "user-guide/concepts/agents/hooks.ts:logging_modifications"
 ```
 </Tab>
 </Tabs>
@@ -1107,8 +1122,10 @@ result = agent("Look up the weather in Seattle")
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// This feature is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks_imports.ts:summarize_after_tools_imports"
+
+--8<-- "user-guide/concepts/agents/hooks.ts:summarize_after_tools"
 ```
 </Tab>
 </Tabs>
@@ -1140,8 +1157,10 @@ result = agent("Draft a haiku about programming")
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// This feature is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks_imports.ts:iterative_refinement_imports"
+
+--8<-- "user-guide/concepts/agents/hooks.ts:iterative_refinement"
 ```
 </Tab>
 </Tabs>
@@ -1194,8 +1213,10 @@ result = agent("Send an email to alice@example.com saying hello")
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// This feature is not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/agents/hooks_imports.ts:auto_approve_interrupts_imports"
+
+--8<-- "user-guide/concepts/agents/hooks.ts:auto_approve_interrupts"
 ```
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/agents/hooks.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks.ts
@@ -1,5 +1,5 @@
 import { Agent, FunctionTool, HookOrder } from '@strands-agents/sdk'
-import type { LocalAgent, Plugin } from '@strands-agents/sdk'
+import type { LocalAgent, Plugin, Interrupt } from '@strands-agents/sdk'
 import {
   BeforeInvocationEvent,
   AfterInvocationEvent,
@@ -8,6 +8,9 @@ import {
   BeforeModelCallEvent,
   AfterModelCallEvent,
   MessageAddedEvent,
+  InterruptEvent,
+  ToolResultBlock,
+  TextBlock,
 } from '@strands-agents/sdk'
 import {
   Graph,
@@ -80,23 +83,34 @@ async function hookOrderingExample() {
 
   agent.addHook(BeforeToolCallEvent, (event) => {
     console.log('[logging] Tool called:', event.toolUse.name)
-  })  // HookOrder.DEFAULT (0)
+  }) // HookOrder.DEFAULT (0)
 
   // Run before the SDK's earliest hooks
-  agent.addHook(BeforeToolCallEvent, (event) => {
-    console.log('[guardrail] Runs before SDK hooks')
-  }, { order: HookOrder.SDK_FIRST - 1 })
-
+  agent.addHook(
+    BeforeToolCallEvent,
+    (event) => {
+      console.log('[guardrail] Runs before SDK hooks')
+    },
+    { order: HookOrder.SDK_FIRST - 1 }
+  )
 
   // Arbitrary numbers for fine-grained control
-  agent.addHook(BeforeToolCallEvent, (event) => {
-    console.log('[validation] Validating input')
-  }, { order: -50 })
+  agent.addHook(
+    BeforeToolCallEvent,
+    (event) => {
+      console.log('[validation] Validating input')
+    },
+    { order: -50 }
+  )
 
   // Use -Infinity/Infinity for guaranteed absolute first/last
-  agent.addHook(BeforeToolCallEvent, (event) => {
-    console.log('[absolute] Always runs first, no matter what')
-  }, { order: -Infinity })
+  agent.addHook(
+    BeforeToolCallEvent,
+    (event) => {
+      console.log('[absolute] Always runs first, no matter what')
+    },
+    { order: -Infinity }
+  )
   // --8<-- [end:hook_ordering]
 }
 
@@ -136,16 +150,18 @@ async function toolInterceptionExample() {
   class ToolInterceptor implements Plugin {
     name = 'tool-interceptor'
 
+    constructor(private readonly safeAlternative: FunctionTool) {}
+
     initAgent(agent: LocalAgent): void {
       agent.addHook(BeforeToolCallEvent, (event) => this.interceptTool(event))
     }
 
     private interceptTool(event: BeforeToolCallEvent): void {
-      if (event.toolUse.name === 'sensitive_tool') {
-        // Replace with a safer alternative
-        // Note: This is conceptual - actual API may differ
-        console.log('Intercepting sensitive tool with safe alternative')
-      }
+      if (event.toolUse.name !== 'sensitive_tool') return
+      // Run a safer tool in place of the registry's match for this call.
+      event.selectedTool = this.safeAlternative
+      // Mirror the rename on toolUse so the model sees the substitution.
+      event.toolUse.name = this.safeAlternative.name
     }
   }
   // --8<-- [end:tool_interception]
@@ -157,20 +173,21 @@ async function resultModificationExample() {
     name = 'result-processor'
 
     initAgent(agent: LocalAgent): void {
-      agent.addHook(AfterToolCallEvent, (ev) => this.processResult(ev))
+      agent.addHook(AfterToolCallEvent, (event) => this.processResult(event))
     }
 
     private processResult(event: AfterToolCallEvent): void {
-      if (event.toolUse.name === 'calculator') {
-        // Add formatting to calculator results
-        const textContent = event.result.content.find(
-          (block) => block.type === 'textBlock'
-        )
-        if (textContent && textContent.type === 'textBlock') {
-          // Note: In actual implementation, result modification may work differently
-          console.log(`Would modify result: ${textContent.text}`)
-        }
-      }
+      if (event.toolUse.name !== 'calculator') return
+
+      // Prefix calculator output before it propagates to the model.
+      event.result = new ToolResultBlock({
+        toolUseId: event.result.toolUseId,
+        status: event.result.status,
+        content: event.result.content.map((block) =>
+          block.type === 'textBlock' ? new TextBlock(`Result: ${block.text}`) : block
+        ),
+        ...(event.result.error !== undefined ? { error: event.result.error } : {}),
+      })
     }
   }
   // --8<-- [end:result_modification]
@@ -214,21 +231,25 @@ async function loggingModificationsExample() {
     name = 'result-processor'
 
     initAgent(agent: LocalAgent): void {
-      agent.addHook(AfterToolCallEvent, (ev) => this.processResult(ev))
+      agent.addHook(AfterToolCallEvent, (event) => this.processResult(event))
     }
 
     private processResult(event: AfterToolCallEvent): void {
-      if (event.toolUse.name === 'calculator') {
-        const textContent = event.result.content.find(
-          (block) => block.type === 'textBlock'
-        )
-        if (textContent && textContent.type === 'textBlock') {
-          const originalContent = textContent.text
-          console.log(`Modifying calculator result: ${originalContent}`)
-          // Note: In actual implementation, result modification may work differently
-          console.log(`Would modify to: Result: ${originalContent}`)
-        }
-      }
+      if (event.toolUse.name !== 'calculator') return
+
+      const original = event.result.content.find((block) => block.type === 'textBlock')
+      if (original?.type !== 'textBlock') return
+
+      // Log the change before mutating so the audit trail captures both states.
+      console.log(`Modifying calculator result: ${original.text}`)
+      event.result = new ToolResultBlock({
+        toolUseId: event.result.toolUseId,
+        status: event.result.status,
+        content: event.result.content.map((block) =>
+          block.type === 'textBlock' ? new TextBlock(`Result: ${block.text}`) : block
+        ),
+        ...(event.result.error !== undefined ? { error: event.result.error } : {}),
+      })
     }
   }
   // --8<-- [end:logging_modifications]
@@ -469,6 +490,75 @@ async function layeredHooksExample() {
   void graph
 }
 
+async function summarizeAfterToolsExample() {
+  // --8<-- [start:summarize_after_tools]
+  let resumeCount = 0
+
+  const agent = new Agent({})
+  agent.addHook(AfterInvocationEvent, (event) => {
+    // Resume once after a clean turn to ask the model for a one-line summary.
+    if (resumeCount === 0) {
+      resumeCount += 1
+      event.resume = 'Now summarize what you just did in one sentence.'
+    }
+  })
+
+  const result = await agent.invoke('Look up the weather in Seattle')
+  // --8<-- [end:summarize_after_tools]
+  void result
+}
+
+async function iterativeRefinementExample() {
+  // --8<-- [start:iterative_refinement]
+  const MAX_ITERATIONS = 3
+  let iteration = 0
+
+  const agent = new Agent({})
+  agent.addHook(AfterInvocationEvent, (event) => {
+    if (iteration >= MAX_ITERATIONS) return
+    iteration += 1
+    event.resume = `Review your previous response and improve it. Iteration ${iteration} of ${MAX_ITERATIONS}.`
+  })
+
+  const result = await agent.invoke('Draft a haiku about programming')
+  // --8<-- [end:iterative_refinement]
+  void result
+}
+
+async function autoApproveInterruptsExample() {
+  // --8<-- [start:auto_approve_interrupts]
+  const agent = new Agent({ tools: [] })
+
+  // Track interrupts as they fire so AfterInvocationEvent can build resume input.
+  const pendingInterrupts: Interrupt[] = []
+
+  agent.addHook(BeforeToolCallEvent, (event) => {
+    if (event.toolUse.name === 'send_email') {
+      event.interrupt({ name: 'email_approval', reason: 'Approve this email?' })
+    }
+  })
+
+  agent.addHook(InterruptEvent, (event) => {
+    pendingInterrupts.push(event.interrupt)
+  })
+
+  agent.addHook(AfterInvocationEvent, (event) => {
+    if (pendingInterrupts.length === 0) return
+    // Auto-approve every interrupted tool call so the caller never sees the interrupt.
+    event.resume = pendingInterrupts.map((interrupt) => ({
+      interruptResponse: {
+        interruptId: interrupt.id,
+        response: 'approved',
+      },
+    }))
+    pendingInterrupts.length = 0
+  })
+
+  const result = await agent.invoke('Send an email to alice@example.com saying hello')
+  // --8<-- [end:auto_approve_interrupts]
+  void result
+}
+
 // Suppress unused function warnings
 void invocationStateInHooksExample
 void hookOrderingExample
@@ -477,3 +567,6 @@ void orchestratorCallbackExample
 void conditionalNodeExecutionExample
 void orchestratorAgnosticDesignExample
 void layeredHooksExample
+void summarizeAfterToolsExample
+void iterativeRefinementExample
+void autoApproveInterruptsExample

--- a/src/content/docs/user-guide/concepts/agents/hooks_imports.ts
+++ b/src/content/docs/user-guide/concepts/agents/hooks_imports.ts
@@ -3,3 +3,50 @@
 // --8<-- [start:hook_ordering_imports]
 import { Agent, HookOrder, BeforeToolCallEvent } from '@strands-agents/sdk'
 // --8<-- [end:hook_ordering_imports]
+
+// --8<-- [start:tool_interception_imports]
+import {
+  BeforeToolCallEvent,
+  type LocalAgent,
+  type Plugin,
+  type FunctionTool,
+} from '@strands-agents/sdk'
+// --8<-- [end:tool_interception_imports]
+
+// --8<-- [start:result_modification_imports]
+import {
+  AfterToolCallEvent,
+  ToolResultBlock,
+  TextBlock,
+  type LocalAgent,
+  type Plugin,
+} from '@strands-agents/sdk'
+// --8<-- [end:result_modification_imports]
+
+// --8<-- [start:logging_modifications_imports]
+import {
+  AfterToolCallEvent,
+  ToolResultBlock,
+  TextBlock,
+  type LocalAgent,
+  type Plugin,
+} from '@strands-agents/sdk'
+// --8<-- [end:logging_modifications_imports]
+
+// --8<-- [start:summarize_after_tools_imports]
+import { Agent, AfterInvocationEvent } from '@strands-agents/sdk'
+// --8<-- [end:summarize_after_tools_imports]
+
+// --8<-- [start:iterative_refinement_imports]
+import { Agent, AfterInvocationEvent } from '@strands-agents/sdk'
+// --8<-- [end:iterative_refinement_imports]
+
+// --8<-- [start:auto_approve_interrupts_imports]
+import {
+  Agent,
+  AfterInvocationEvent,
+  BeforeToolCallEvent,
+  InterruptEvent,
+} from '@strands-agents/sdk'
+import type { Interrupt } from '@strands-agents/sdk'
+// --8<-- [end:auto_approve_interrupts_imports]

--- a/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
+++ b/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
@@ -3,11 +3,11 @@ title: Retry Strategies
 tags: [event-loop, error-handling]
 ---
 
-Model providers occasionally encounter errors such as rate limits, service unavailability, or network timeouts. By default, the agent retries `ModelThrottledException` failures automatically with exponential backoff and the `Angent.retry_strategy` parameter lets you customize this behavior.
+Model providers occasionally encounter errors such as rate limits, service unavailability, or network timeouts. By default, the agent retries throttled responses automatically with exponential backoff. The `Agent.retry_strategy` (Python) or `Agent.retryStrategy` (TypeScript) parameter lets you customize this behavior.
 
 ## Default Behavior
 
-Without configuration, agents retry `ModelThrottledException` up to 5 times (6 total attempts) with exponential backoff starting at 4 seconds:
+Without configuration, agents retry throttling errors up to 5 times (6 total attempts) with exponential backoff starting at 4 seconds:
 
 ```
 Attempt 1: fails → wait 4s
@@ -20,7 +20,7 @@ Attempt 6: fails → exception raised
 
 ## Customizing Retry Behavior
 
-Use `ModelRetryStrategy` to adjust the retry parameters:
+To adjust retry parameters, pass a configured strategy to the agent constructor.
 
 <Tabs>
 <Tab label="Python">
@@ -39,19 +39,68 @@ agent = Agent(
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Not supported in TypeScript
+In TypeScript, `ModelRetryStrategy` is the abstract base class. Use `DefaultModelRetryStrategy` for the standard configurable strategy:
+
+```typescript
+--8<-- "user-guide/concepts/agents/retry-strategies_imports.ts:default_strategy_imports"
+
+--8<-- "user-guide/concepts/agents/retry-strategies.ts:default_strategy"
 ```
 </Tab>
 </Tabs>
 
 ### Parameters
 
+<Tabs>
+<Tab label="Python">
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `max_attempts` | `int` | `6` | Total number of attempts including the initial call. Set to `1` to disable retries. |
 | `initial_delay` | `float` | `4` | Seconds to wait before the first retry. Subsequent retries double this value. |
 | `max_delay` | `float` | `128` | Maximum seconds to wait between retries. Caps the exponential growth. |
+
+</Tab>
+<Tab label="TypeScript">
+
+`DefaultModelRetryStrategy` accepts:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `maxAttempts` | `number` | `6` | Total number of attempts including the initial call. Must be `>= 1`. |
+| `backoff` | `BackoffStrategy` | `new ExponentialBackoff({ baseMs: 4000, maxMs: 240000 })` | Computes delay between retries. See [Backoff Strategies](#backoff-strategies). |
+
+</Tab>
+</Tabs>
+
+### Backoff Strategies
+
+In TypeScript, the delay between retries is delegated to a `BackoffStrategy` passed via the `backoff` parameter. The Python SDK does not expose a separate backoff interface; configure exponential backoff through the `initial_delay` and `max_delay` parameters above.
+
+<Tabs>
+<Tab label="Python">
+
+Configure backoff through `ModelRetryStrategy` parameters in [Customizing Retry Behavior](#customizing-retry-behavior).
+
+</Tab>
+<Tab label="TypeScript">
+
+The TypeScript SDK ships three built-in strategies:
+
+- `ExponentialBackoff` (default): delay grows as `baseMs * multiplier^(attempt-1)`, capped at `maxMs`.
+- `LinearBackoff`: delay grows as `baseMs * attempt`, capped at `maxMs`.
+- `ConstantBackoff`: same delay for every retry.
+
+Each accepts a `jitter` option (`'none'`, `'full'`, `'equal'`, `'decorrelated'`). Default is `'full'` jitter, which spreads concurrent clients across the wait window.
+
+```typescript
+--8<-- "user-guide/concepts/agents/retry-strategies_imports.ts:custom_backoff_imports"
+
+--8<-- "user-guide/concepts/agents/retry-strategies.ts:custom_backoff"
+```
+
+</Tab>
+</Tabs>
 
 ## Disabling Retries
 
@@ -61,7 +110,7 @@ To disable automatic retries entirely:
 <Tab label="Python">
 
 ```python
-from strands import Agent, ModelRetryStrategy
+from strands import Agent
 
 agent = Agent(
     retry_strategy=None
@@ -70,19 +119,55 @@ agent = Agent(
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Not supported in TypeScript
+```typescript
+--8<-- "user-guide/concepts/agents/retry-strategies_imports.ts:disable_imports"
+
+--8<-- "user-guide/concepts/agents/retry-strategies.ts:disable"
 ```
 </Tab>
 </Tabs>
 
 ## When Retries Occur
 
-`ModelRetryStrategy` handles `ModelThrottledException`, which model providers raise for rate-limiting. Other exceptions propagate immediately without retry.
+Default retry strategies handle throttling errors (`ModelThrottledException` in Python, `ModelThrottledError` in TypeScript) raised by model providers for rate-limiting. Other exceptions propagate immediately without retry.
+
+To extend or narrow the retryable set, see [Custom Retry Logic](#custom-retry-logic).
 
 ## Custom Retry Logic
 
-Built in retry constructs like `ModelRetryStrategy` are useful for customizing model rate-limiting behavior, but for more fine-grained control - like validating model responses or handling additional exception types - use a hook instead. The `AfterModelCallEvent` fires after each model call and lets you set `event.retry = True` to trigger another attempt:
+For more control over retry decisions, such as validating model responses or handling additional error types, two paths are available:
+
+1. Subclass the retry strategy class to own the full decision shape and reuse hook plumbing.
+2. Use a hook on `AfterModelCallEvent` to set `event.retry = true` directly.
+
+### Subclassing the Retry Strategy
+
+<Tabs>
+<Tab label="Python">
+
+The Python SDK's `ModelRetryStrategy` is a concrete configurable class. To customize beyond its `max_attempts` / `initial_delay` / `max_delay` parameters, use the hook approach below.
+
+</Tab>
+<Tab label="TypeScript">
+
+To extend or narrow which errors are retryable, subclass `DefaultModelRetryStrategy` and override `isRetryable`. The default implementation retries `ModelThrottledError` only; `super.isRetryable(error)` preserves that base behavior so you can opt additional error types in (or specific ones out) without reimplementing the rest of the retry policy.
+
+```typescript
+--8<-- "user-guide/concepts/agents/retry-strategies_imports.ts:custom_subclass_imports"
+
+--8<-- "user-guide/concepts/agents/retry-strategies.ts:custom_subclass"
+```
+
+For full control over the retry decision (custom backoff state, attempt-aware logic), subclass the abstract `ModelRetryStrategy` directly and implement `computeRetryDecision`. The base class handles short-circuits, per-turn state reset, and sleeping between attempts.
+
+A retry-strategy instance carries per-turn state and must not be shared across agents. Create a new instance per agent.
+
+</Tab>
+</Tabs>
+
+### Using a Hook
+
+Hooks are simpler when you only need to inspect a model error and request a retry. Set `event.retry = true` from an `AfterModelCallEvent` callback. Hooks do not introduce delays automatically; the example below adds a 2-second wait.
 
 <Tabs>
 <Tab label="Python">
@@ -112,12 +197,14 @@ agent = Agent(hooks=[CustomRetry()])
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Not supported in TypeScript
+The `AfterModelCallEvent` exposes `attemptCount` (1-indexed). Use it to bound retry counts without tracking state outside the hook.
+
+```typescript
+--8<-- "user-guide/concepts/agents/retry-strategies_imports.ts:hook_retry_imports"
+
+--8<-- "user-guide/concepts/agents/retry-strategies.ts:hook_retry"
 ```
 </Tab>
 </Tabs>
-
-Unlike `ModelRetryStrategy`, hooks don't automatically introduce delays between retries. The example above uses `asyncio.sleep` to add a 2-second delay before each retry.
 
 See [Hooks](hooks.md#model-call-retry) for more examples.

--- a/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
+++ b/src/content/docs/user-guide/concepts/agents/retry-strategies.mdx
@@ -91,7 +91,7 @@ The TypeScript SDK ships three built-in strategies:
 - `LinearBackoff`: delay grows as `baseMs * attempt`, capped at `maxMs`.
 - `ConstantBackoff`: same delay for every retry.
 
-Each accepts a `jitter` option (`'none'`, `'full'`, `'equal'`, `'decorrelated'`). Default is `'full'` jitter, which spreads concurrent clients across the wait window.
+`ExponentialBackoff` and `LinearBackoff` accept a `jitter` option (`'none'`, `'full'`, `'equal'`, `'decorrelated'`). Default is `'full'` jitter, which spreads concurrent clients across the wait window. `ConstantBackoff` returns the configured delay unchanged.
 
 ```typescript
 --8<-- "user-guide/concepts/agents/retry-strategies_imports.ts:custom_backoff_imports"

--- a/src/content/docs/user-guide/concepts/agents/retry-strategies.ts
+++ b/src/content/docs/user-guide/concepts/agents/retry-strategies.ts
@@ -1,0 +1,85 @@
+// @ts-nocheck
+
+import {
+  Agent,
+  DefaultModelRetryStrategy,
+  ExponentialBackoff,
+  AfterModelCallEvent,
+} from '@strands-agents/sdk'
+
+async function defaultStrategyExample() {
+  // --8<-- [start:default_strategy]
+  const agent = new Agent({
+    retryStrategy: new DefaultModelRetryStrategy({ maxAttempts: 3 }),
+  })
+  // --8<-- [end:default_strategy]
+  void agent
+}
+
+async function customBackoffExample() {
+  // --8<-- [start:custom_backoff]
+  const agent = new Agent({
+    retryStrategy: new DefaultModelRetryStrategy({
+      maxAttempts: 4,
+      backoff: new ExponentialBackoff({
+        baseMs: 2_000,
+        maxMs: 60_000,
+        multiplier: 2,
+        jitter: 'full',
+      }),
+    }),
+  })
+  // --8<-- [end:custom_backoff]
+  void agent
+}
+
+async function disableExample() {
+  // --8<-- [start:disable]
+  const agent = new Agent({
+    retryStrategy: null,
+  })
+  // --8<-- [end:disable]
+  void agent
+}
+
+async function customSubclassExample() {
+  // --8<-- [start:custom_subclass]
+  class TransientServiceError extends Error {
+    readonly name = 'TransientServiceError'
+  }
+
+  // Retry throttles (the default retryable set) plus our own transient error class.
+  class WiderRetryStrategy extends DefaultModelRetryStrategy {
+    protected override isRetryable(error: Error): boolean {
+      return super.isRetryable(error) || error instanceof TransientServiceError
+    }
+  }
+
+  const agent = new Agent({
+    retryStrategy: new WiderRetryStrategy({ maxAttempts: 5 }),
+  })
+  // --8<-- [end:custom_subclass]
+  void agent
+}
+
+async function hookRetryExample() {
+  // --8<-- [start:hook_retry]
+  const agent = new Agent({})
+
+  let attempts = 0
+  agent.addHook(AfterModelCallEvent, async (event) => {
+    if (event.error && attempts < 3) {
+      attempts += 1
+      await new Promise((resolve) => setTimeout(resolve, 2_000))
+      event.retry = true
+    }
+  })
+  // --8<-- [end:hook_retry]
+  void agent
+}
+
+void defaultStrategyExample
+void customBackoffExample
+void disableExample
+void customSubclassExample
+void hookRetryExample

--- a/src/content/docs/user-guide/concepts/agents/retry-strategies_imports.ts
+++ b/src/content/docs/user-guide/concepts/agents/retry-strategies_imports.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+
+// --8<-- [start:default_strategy_imports]
+import { Agent, DefaultModelRetryStrategy } from '@strands-agents/sdk'
+// --8<-- [end:default_strategy_imports]
+
+// --8<-- [start:custom_backoff_imports]
+import { Agent, DefaultModelRetryStrategy, ExponentialBackoff } from '@strands-agents/sdk'
+// --8<-- [end:custom_backoff_imports]
+
+// --8<-- [start:disable_imports]
+import { Agent } from '@strands-agents/sdk'
+// --8<-- [end:disable_imports]
+
+// --8<-- [start:custom_subclass_imports]
+import { Agent, DefaultModelRetryStrategy } from '@strands-agents/sdk'
+// --8<-- [end:custom_subclass_imports]
+
+// --8<-- [start:hook_retry_imports]
+import { Agent, AfterModelCallEvent } from '@strands-agents/sdk'
+// --8<-- [end:hook_retry_imports]

--- a/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -494,11 +494,11 @@ Swarms also support interrupts raised from within the nodes themselves following
 </Tab>
 <Tab label="TypeScript">
 
-- [`BeforeNodeCallEvent`](@api/typescript/BeforeNodeCallEvent): orchestrator hook event that exposes the ability to interrupt before a node runs
+- `BeforeNodeCallEvent`: orchestrator hook event that exposes the ability to interrupt before a node runs
     - `event.interrupt({ name, reason? })`: halts the orchestrator. `name` is a string identifier and `reason` is an optional JSON-serializable value providing context for why the interrupt was raised.
     - The `name` must be unique across all interrupt calls configured on the same event. In the example above, we demonstrate using a namespace prefix for the interrupt call. This is particularly helpful if you plan to vend your hooks to other users.
     - `event.cancel`: cancel node execution based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
-- [`MultiAgentResult`](@api/typescript/MultiAgentResult): returned by `invoke()` / `stream()`, contains interrupt information when the orchestrator pauses
+- `MultiAgentResult`: returned by `invoke()` / `stream()`, contains interrupt information when the orchestrator pauses
     - `result.status`: check if the swarm stopped due to `Status.INTERRUPTED`
     - `result.interrupts`: array of `Interrupt` objects, each with `name`, `reason`, and a unique `id`. Each interrupt's `source` field is `'multiagent-hook'` when raised from `BeforeNodeCallEvent`.
 - `InterruptResponseContent`: content block type for resuming from an interrupt
@@ -606,11 +606,11 @@ Graphs also support interrupts raised from within the nodes themselves following
 </Tab>
 <Tab label="TypeScript">
 
-- [`BeforeNodeCallEvent`](@api/typescript/BeforeNodeCallEvent): orchestrator hook event that exposes the ability to interrupt before a node runs
+- `BeforeNodeCallEvent`: orchestrator hook event that exposes the ability to interrupt before a node runs
     - `event.interrupt({ name, reason? })`: halts the orchestrator. `name` is a string identifier and `reason` is an optional JSON-serializable value providing context for why the interrupt was raised.
     - The `name` must be unique across all interrupt calls configured on the same event. In the example above, we demonstrate using a namespace prefix for the interrupt call. This is particularly helpful if you plan to vend your hooks to other users.
     - `event.cancel`: cancel node execution based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
-- [`MultiAgentResult`](@api/typescript/MultiAgentResult): returned by `invoke()` / `stream()`, contains interrupt information when the orchestrator pauses
+- `MultiAgentResult`: returned by `invoke()` / `stream()`, contains interrupt information when the orchestrator pauses
     - `result.status`: check if the graph stopped due to `Status.INTERRUPTED`
     - `result.interrupts`: array of `Interrupt` objects, each with `name`, `reason`, and a unique `id`. Each interrupt's `source` field is `'multiagent-hook'` when raised from `BeforeNodeCallEvent`.
 - `InterruptResponseContent`: content block type for resuming from an interrupt

--- a/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -27,7 +27,7 @@ Users can raise interrupts within their [hook callbacks](./agents/hooks.md) to p
 <Tabs>
 <Tab label="Python">
 
-Currently, only the `BeforeToolCallEvent` is interruptible. Interrupting on a `BeforeToolCallEvent` allows users to intercept tool calls before execution to request human approval or additional inputs.
+Only the `BeforeToolCallEvent` is interruptible. Interrupting on a `BeforeToolCallEvent` allows users to intercept tool calls before execution to request human approval or additional inputs.
 
 ```python
 import json
@@ -102,12 +102,16 @@ Both `BeforeToolCallEvent` and `BeforeToolsEvent` are interruptible. Interruptin
 #### BeforeToolCallEvent
 
 ```typescript
+--8<-- "user-guide/concepts/interrupts_imports.ts:hooks_before_tool_call_imports"
+
 --8<-- "user-guide/concepts/interrupts.ts:hooks_before_tool_call"
 ```
 
 #### BeforeToolsEvent
 
 ```typescript
+--8<-- "user-guide/concepts/interrupts_imports.ts:hooks_before_tools_imports"
+
 --8<-- "user-guide/concepts/interrupts.ts:hooks_before_tools"
 ```
 </Tab>
@@ -135,14 +139,14 @@ For additional details on each of these components, refer to the [Python API Ref
 </Tab>
 <Tab label="TypeScript">
 
-- [`BeforeToolCallEvent`](@api/typescript/BeforeToolCallEvent) / [`BeforeToolsEvent`](@api/typescript/BeforeToolsEvent) — hook events that expose the ability to interrupt via the `interrupt` method
-    - `event.interrupt({ name, reason? })` — halts the agent loop. `name` is a string identifier and `reason` is an optional JSON-serializable value providing context for why the interrupt was raised.
+- [`BeforeToolCallEvent`](@api/typescript/BeforeToolCallEvent) / [`BeforeToolsEvent`](@api/typescript/BeforeToolsEvent): hook events that expose the ability to interrupt via the `interrupt` method
+    - `event.interrupt({ name, reason? })`: halts the agent loop. `name` is a string identifier and `reason` is an optional JSON-serializable value providing context for why the interrupt was raised.
     - The `name` must be unique across all interrupt calls configured on the same event. In the example above, we demonstrate using a namespace prefix for the interrupt call. This is particularly helpful if you plan to vend your hooks to other users.
-    - `event.cancel` — cancel tool execution based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
-- [`AgentResult`](@api/typescript/AgentResult) — returned by `invoke()` / `stream()`, contains interrupt information when the agent pauses
-    - `result.stopReason` — check if agent stopped due to `'interrupt'`
-    - `result.interrupts` — array of `Interrupt` objects, each containing the user-provided `name` and `reason`, along with a unique `id`
-- `InterruptResponseContent` — content block type for resuming from an interrupt
+    - `event.cancel`: cancel tool execution based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
+- [`AgentResult`](@api/typescript/AgentResult): returned by `invoke()` / `stream()`, contains interrupt information when the agent pauses
+    - `result.stopReason`: check if agent stopped due to `'interrupt'`
+    - `result.interrupts`: array of `Interrupt` objects, each containing the user-provided `name` and `reason`, along with a unique `id`
+- `InterruptResponseContent`: content block type for resuming from an interrupt
     - Pass an array of these to `agent.invoke()` to resume. Each response is keyed by the interrupt's `id` and will be returned from the associated `interrupt()` call when the tool/hook re-executes. The `response` must be JSON-serializable.
 </Tab>
 </Tabs>
@@ -167,7 +171,7 @@ Strands enforces the following rules for interrupts:
 - All hooks configured on the interrupted event are allowed to raise an interrupt
 - A single hook can raise multiple interrupts but only one at a time
     - In other words, within a single hook, you can interrupt, respond to that interrupt, and then proceed to interrupt again.
-- When an interrupt fires from `BeforeToolCallEvent`, `AfterToolCallEvent` does not fire for that tool — but `AfterToolsEvent` always fires
+- When an interrupt fires from `BeforeToolCallEvent`, `AfterToolCallEvent` does not fire for that tool, but `AfterToolsEvent` always fires
 - When an interrupt fires mid-batch, completed tool results are preserved so the agent skips the model call on resume and only executes remaining tools
 - Both assistant and tool result messages are appended only after tool execution completes, preventing dangling `toolUse` blocks without matching results
 </Tab>
@@ -218,7 +222,7 @@ agent = Agent(
 
 ```
 
-> ⚠️ Interrupts are not supported in [direct tool calls](./tools/index.md#direct-method-calls) (i.e., calls such as `agent.tool.my_tool()`).
+Interrupts are not supported in [direct tool calls](./tools/index.md#direct-method-calls) (i.e., calls such as `agent.tool.my_tool()`).
 
 </Tab>
 <Tab label="TypeScript">
@@ -226,6 +230,8 @@ agent = Agent(
 The tool callback receives a `context` parameter (the second argument) which provides the `interrupt` method.
 
 ```typescript
+--8<-- "user-guide/concepts/interrupts_imports.ts:tools_example_imports"
+
 --8<-- "user-guide/concepts/interrupts.ts:tools_example"
 ```
 </Tab>
@@ -233,7 +239,7 @@ The tool callback receives a `context` parameter (the second argument) which pro
 
 ### Components
 
-Tool interrupts work similarly to hook interrupts with only a few notable differences. For more on tool context, see [ToolContext](./tools/custom-tools.md#toolcontext).
+Tool interrupts work like hook interrupts, with two differences: tools receive `context` instead of `event`, and interrupt names need only be unique within a tool definition rather than across all hooks on an event. For more on tool context, see [ToolContext](./tools/custom-tools.md#toolcontext).
 
 <Tabs>
 <Tab label="Python">
@@ -244,8 +250,8 @@ Tool interrupts work similarly to hook interrupts with only a few notable differ
 </Tab>
 <Tab label="TypeScript">
 
-- [`ToolContext`](@api/typescript/ToolContext) — the second argument passed to the tool callback, providing access to the `interrupt` method
-    - `context.interrupt({ name, reason? })` — halts the agent loop. `name` is a string identifier and `reason` is an optional JSON-serializable value.
+- [`ToolContext`](@api/typescript/ToolContext): the second argument passed to the tool callback, providing access to the `interrupt` method
+    - `context.interrupt({ name, reason? })`: halts the agent loop. `name` is a string identifier and `reason` is an optional JSON-serializable value.
     - The `name` must be unique only among interrupt calls configured in the same tool definition. It is still advisable however to namespace your interrupts so as to more easily distinguish the calls when constructing responses outside the agent.
 </Tab>
 </Tabs>
@@ -366,6 +372,8 @@ print(f"MESSAGE: {json.dumps(result.message)}")
 <Tab label="TypeScript">
 
 ```typescript
+--8<-- "user-guide/concepts/interrupts_imports.ts:session_management_imports"
+
 --8<-- "user-guide/concepts/interrupts.ts:session_management"
 ```
 </Tab>
@@ -379,30 +387,26 @@ Session managing interrupts involves the following key components:
 <Tab label="Python">
 
 - `session_manager` - Automatically persists the agent interrupt state between tear down and start up
-    - For more information on session management in Strands, please refer to [here](./agents/session-management.md).
+    - See [Session Management](./agents/session-management.md) for more.
 - `agent.state` - General purpose key-value store that can be used to persist interrupt responses
-    - On subsequent tool calls, you can reference the responses stored in `agent.state` to decide whether another interrupt is necessary. For more information on `agent.state`, please refer to [here](./agents/state.md#agent-state).
+    - On subsequent tool calls, you can reference the responses stored in `agent.state` to decide whether another interrupt is necessary. See [Agent State](./agents/state.md#agent-state) for more.
 </Tab>
 <Tab label="TypeScript">
 
 - `sessionManager` - Automatically persists the agent interrupt state between tear down and start up
-    - For more information on session management in Strands, please refer to [here](./agents/session-management.md).
+    - See [Session Management](./agents/session-management.md) for more.
 - `agent.appState` - General purpose key-value store that can be used to persist interrupt responses
-    - On subsequent tool calls, you can reference the responses stored in `appState` to decide whether another interrupt is necessary. For more information on `appState`, please refer to [here](./agents/state.md#agent-state).
+    - On subsequent tool calls, you can reference the responses stored in `appState` to decide whether another interrupt is necessary. See [Agent State](./agents/state.md#agent-state) for more.
 </Tab>
 </Tabs>
 
 ## MCP Elicitation
 
-Similar to interrupts, an MCP server can request additional information from the user by sending an elicitation request to the connecting client. Currently, elicitation requests are handled by conventional means of an elicitation callback. For more details, please refer to the docs [here](./tools/mcp-tools.md#elicitation).
+To collect additional information from a user during an MCP tool call, use elicitation. An MCP server sends an elicitation request to the connecting client, which is handled by an elicitation callback. See [MCP Elicitation](./tools/mcp-tools.md#elicitation) for details.
 
 ## Multi-Agents
 
 Interrupts are supported in multi-agent patterns, enabling human-in-the-loop workflows across agent orchestration systems. The interfaces mirror those used for single-agent interrupts. You can raise interrupts from `BeforeNodeCallEvent` hooks executed before each node or from within the nodes themselves. Session management is also supported, allowing you to persist and resume your interrupted multi-agents.
-
-:::note
-Multi-agent interrupts are currently only available in the Python SDK. TypeScript multi-agent interrupt support is planned for a future release.
-:::
 
 ### Swarm
 
@@ -462,8 +466,10 @@ print(f"MESSAGE: {json.dumps(result.results['cleanup'].result.message, indent=2)
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Multi-agent interrupts are not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/interrupts_imports.ts:multiagent_swarm_imports"
+
+--8<-- "user-guide/concepts/interrupts.ts:multiagent_swarm"
 ```
 </Tab>
 </Tabs>
@@ -488,9 +494,15 @@ Swarms also support interrupts raised from within the nodes themselves following
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Multi-agent interrupts are not yet available in TypeScript SDK
-```
+- [`BeforeNodeCallEvent`](@api/typescript/BeforeNodeCallEvent): orchestrator hook event that exposes the ability to interrupt before a node runs
+    - `event.interrupt({ name, reason? })`: halts the orchestrator. `name` is a string identifier and `reason` is an optional JSON-serializable value providing context for why the interrupt was raised.
+    - The `name` must be unique across all interrupt calls configured on the same event. In the example above, we demonstrate using a namespace prefix for the interrupt call. This is particularly helpful if you plan to vend your hooks to other users.
+    - `event.cancel`: cancel node execution based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
+- [`MultiAgentResult`](@api/typescript/MultiAgentResult): returned by `invoke()` / `stream()`, contains interrupt information when the orchestrator pauses
+    - `result.status`: check if the swarm stopped due to `Status.INTERRUPTED`
+    - `result.interrupts`: array of `Interrupt` objects, each with `name`, `reason`, and a unique `id`. Each interrupt's `source` field is `'multiagent-hook'` when raised from `BeforeNodeCallEvent`.
+- `InterruptResponseContent`: content block type for resuming from an interrupt
+    - Pass an array of these to `swarm.invoke()` to resume. The orchestrator routes each response to the node that raised the matching interrupt.
 </Tab>
 </Tabs>
 
@@ -566,8 +578,10 @@ print(f"MESSAGE: {json.dumps(result.results['cleanup'].result.message, indent=2)
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Multi-agent interrupts are not yet available in TypeScript SDK
+```typescript
+--8<-- "user-guide/concepts/interrupts_imports.ts:multiagent_graph_imports"
+
+--8<-- "user-guide/concepts/interrupts.ts:multiagent_graph"
 ```
 </Tab>
 </Tabs>
@@ -592,9 +606,15 @@ Graphs also support interrupts raised from within the nodes themselves following
 </Tab>
 <Tab label="TypeScript">
 
-```ts
-// Multi-agent interrupts are not yet available in TypeScript SDK
-```
+- [`BeforeNodeCallEvent`](@api/typescript/BeforeNodeCallEvent): orchestrator hook event that exposes the ability to interrupt before a node runs
+    - `event.interrupt({ name, reason? })`: halts the orchestrator. `name` is a string identifier and `reason` is an optional JSON-serializable value providing context for why the interrupt was raised.
+    - The `name` must be unique across all interrupt calls configured on the same event. In the example above, we demonstrate using a namespace prefix for the interrupt call. This is particularly helpful if you plan to vend your hooks to other users.
+    - `event.cancel`: cancel node execution based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
+- [`MultiAgentResult`](@api/typescript/MultiAgentResult): returned by `invoke()` / `stream()`, contains interrupt information when the orchestrator pauses
+    - `result.status`: check if the graph stopped due to `Status.INTERRUPTED`
+    - `result.interrupts`: array of `Interrupt` objects, each with `name`, `reason`, and a unique `id`. Each interrupt's `source` field is `'multiagent-hook'` when raised from `BeforeNodeCallEvent`.
+- `InterruptResponseContent`: content block type for resuming from an interrupt
+    - Pass an array of these to `graph.invoke()` to resume. The orchestrator routes each response to the node that raised the matching interrupt; concurrent nodes already in flight run to completion.
 </Tab>
 </Tabs>
 

--- a/src/content/docs/user-guide/concepts/interrupts.ts
+++ b/src/content/docs/user-guide/concepts/interrupts.ts
@@ -2,7 +2,14 @@
 // NOTE: Type-checking is disabled because the interrupt feature is not yet published in the installed SDK.
 
 import { Agent, tool, SessionManager, FileStorage } from '@strands-agents/sdk'
-import { BeforeToolCallEvent, BeforeToolsEvent } from '@strands-agents/sdk'
+import {
+  BeforeToolCallEvent,
+  BeforeToolsEvent,
+  BeforeNodeCallEvent,
+  Graph,
+  Swarm,
+  Status,
+} from '@strands-agents/sdk'
 import { z } from 'zod'
 
 // =====================
@@ -74,7 +81,9 @@ async function hooksBeforeToolCallExample() {
 async function hooksBeforeToolsExample() {
   // --8<-- [start:hooks_before_tools]
   const agent = new Agent({
-    tools: [/* ... */],
+    tools: [
+      /* ... */
+    ],
   })
 
   agent.addHook(BeforeToolsEvent, (event) => {
@@ -221,8 +230,103 @@ async function sessionManagementExample() {
   // --8<-- [end:session_management]
 }
 
+// =====================
+// Multi-Agent — Swarm BeforeNodeCallEvent Example
+// =====================
+
+async function swarmBeforeNodeCallExample() {
+  // --8<-- [start:multiagent_swarm]
+  const cleanupAgent = new Agent({
+    id: 'cleanup',
+    systemPrompt: 'You clean up resources older than 5 days.',
+  })
+
+  const swarm = new Swarm({ nodes: [cleanupAgent], start: 'cleanup' })
+
+  swarm.addHook(BeforeNodeCallEvent, (event) => {
+    if (event.nodeId !== 'cleanup') return
+
+    const approval = event.interrupt<string>({
+      name: 'myapp-approval',
+      reason: { resources: 'example' },
+    })
+    if (approval.toLowerCase() !== 'y') {
+      event.cancel = 'User denied permission to cleanup resources'
+    }
+  })
+
+  let result = await swarm.invoke('Clean up my resources')
+
+  while (result.status === Status.INTERRUPTED) {
+    const responses = result.interrupts!.map((interrupt) => ({
+      interruptResponse: {
+        interruptId: interrupt.id,
+        // In a real app, collect user input here
+        response: 'y',
+      },
+    }))
+
+    result = await swarm.invoke(responses)
+  }
+
+  console.log('MESSAGE:', JSON.stringify(result.results, null, 2))
+  // --8<-- [end:multiagent_swarm]
+}
+
+// =====================
+// Multi-Agent — Graph BeforeNodeCallEvent Example
+// =====================
+
+async function graphBeforeNodeCallExample() {
+  // --8<-- [start:multiagent_graph]
+  const inspectorAgent = new Agent({
+    id: 'inspector',
+    systemPrompt: 'You inspect resources.',
+  })
+  const cleanupAgent = new Agent({
+    id: 'cleanup',
+    systemPrompt: 'You clean up resources older than 5 days.',
+  })
+
+  const graph = new Graph({
+    nodes: [inspectorAgent, cleanupAgent],
+    edges: [['inspector', 'cleanup']],
+  })
+
+  graph.addHook(BeforeNodeCallEvent, (event) => {
+    if (event.nodeId !== 'cleanup') return
+
+    const approval = event.interrupt<string>({
+      name: 'myapp-approval',
+      reason: { resources: 'example' },
+    })
+    if (approval.toLowerCase() !== 'y') {
+      event.cancel = 'User denied permission to cleanup resources'
+    }
+  })
+
+  let result = await graph.invoke('Inspect and clean up my resources')
+
+  while (result.status === Status.INTERRUPTED) {
+    const responses = result.interrupts!.map((interrupt) => ({
+      interruptResponse: {
+        interruptId: interrupt.id,
+        // In a real app, collect user input here
+        response: 'y',
+      },
+    }))
+
+    result = await graph.invoke(responses)
+  }
+
+  console.log('MESSAGE:', JSON.stringify(result.results, null, 2))
+  // --8<-- [end:multiagent_graph]
+}
+
 // Suppress unused function warnings
 void hooksBeforeToolCallExample
 void hooksBeforeToolsExample
 void toolsExample
 void sessionManagementExample
+void swarmBeforeNodeCallExample
+void graphBeforeNodeCallExample

--- a/src/content/docs/user-guide/concepts/interrupts_imports.ts
+++ b/src/content/docs/user-guide/concepts/interrupts_imports.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+// NOTE: Type-checking is disabled because the interrupt feature is not yet published in the installed SDK.
+
+// --8<-- [start:hooks_before_tool_call_imports]
+import { Agent, tool, BeforeToolCallEvent } from '@strands-agents/sdk'
+import { z } from 'zod'
+// --8<-- [end:hooks_before_tool_call_imports]
+
+// --8<-- [start:hooks_before_tools_imports]
+import { Agent, BeforeToolsEvent } from '@strands-agents/sdk'
+// --8<-- [end:hooks_before_tools_imports]
+
+// --8<-- [start:tools_example_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { z } from 'zod'
+// --8<-- [end:tools_example_imports]
+
+// --8<-- [start:session_management_imports]
+import {
+  Agent,
+  tool,
+  SessionManager,
+  FileStorage,
+  BeforeToolCallEvent,
+} from '@strands-agents/sdk'
+import { z } from 'zod'
+// --8<-- [end:session_management_imports]
+
+// --8<-- [start:multiagent_swarm_imports]
+import { Agent, Swarm, Status, BeforeNodeCallEvent } from '@strands-agents/sdk'
+// --8<-- [end:multiagent_swarm_imports]
+
+// --8<-- [start:multiagent_graph_imports]
+import { Agent, Graph, Status, BeforeNodeCallEvent } from '@strands-agents/sdk'
+// --8<-- [end:multiagent_graph_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -324,6 +324,18 @@ response = agent("Write a short story about an AI assistant.")
 </Tab>
 </Tabs>
 
+#### TypeScript Request Timeout
+
+The TypeScript SDK applies a default `requestTimeout` of 120000 ms (120 seconds) when constructing the Bedrock Runtime client, since the underlying AWS SDK defaults to `0` (disabled), which lets a stuck connection hang. Override it by passing your own value through `clientConfig.requestHandler`:
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/amazon-bedrock_imports.ts:request_timeout_imports"
+
+--8<-- "user-guide/concepts/model-providers/amazon-bedrock.ts:request_timeout"
+```
+
+Passing a fully-constructed handler instance (rather than an options bag) bypasses the default; the handler's own timeouts apply unchanged.
+
 ## Advanced Features
 
 ### Streaming vs Non-Streaming Mode

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -426,3 +426,17 @@ async function guardrailsExample() {
   const response = await guardrailAgent.invoke('Can you tell me about the Strands SDK?')
   // --8<-- [end:guardrails]
 }
+
+async function requestTimeoutExample() {
+  // --8<-- [start:request_timeout]
+  const bedrockModel = new BedrockModel({
+    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    clientConfig: {
+      requestHandler: { requestTimeout: 60_000 },
+    },
+  })
+  // --8<-- [end:request_timeout]
+  void bedrockModel
+}
+
+void requestTimeoutExample

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -430,7 +430,7 @@ async function guardrailsExample() {
 async function requestTimeoutExample() {
   // --8<-- [start:request_timeout]
   const bedrockModel = new BedrockModel({
-    modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    modelId: 'us.anthropic.claude-sonnet-4-6',
     clientConfig: {
       requestHandler: { requestTimeout: 60_000 },
     },

--- a/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
@@ -12,3 +12,7 @@ import { z } from 'zod'
 // --8<-- [start:custom_credentials_imports]
 import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
 // --8<-- [end:custom_credentials_imports]
+
+// --8<-- [start:request_timeout_imports]
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
+// --8<-- [end:request_timeout_imports]

--- a/src/content/docs/user-guide/concepts/model-providers/google.ts
+++ b/src/content/docs/user-guide/concepts/model-providers/google.ts
@@ -57,9 +57,7 @@ async function builtInTools() {
   })
 
   const agent = new Agent({ model })
-  const response = await agent.invoke(
-    'What are the latest AI news today?'
-  )
+  const response = await agent.invoke('What are the latest AI news today?')
   console.log(response)
   // --8<-- [end:builtin_tools]
 }

--- a/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
+++ b/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
@@ -98,9 +98,17 @@ The `Graph` constructor accepts:
 - **nodes**: Array of `AgentBase`, `MultiAgentBase`, or `Node` instances
 - **edges**: Array of edge definitions (tuples or objects with handlers)
 - **sources**: Entry point node IDs (auto-detected from nodes with no incoming edges)
-- **maxSteps**: Maximum total node executions (useful for cyclic graphs)
-- **maxConcurrency**: Maximum nodes executing in parallel
+- **maxSteps**: Maximum total node executions (useful for cyclic graphs). Defaults to `Infinity`.
+- **maxConcurrency**: Maximum nodes executing in parallel. Defaults to `Infinity`.
+- **timeout**: Wall-clock ceiling for the entire graph invocation, in milliseconds. Defaults to `Infinity`. Does not propagate into nested orchestrators wrapped via `MultiAgentNode`; nested `Swarm`/`Graph` instances run under their own timeout config.
+- **nodeTimeout**: Fallback per-node wall-clock ceiling in milliseconds. Applied to any `AgentNode` that does not set its own `timeout`. Defaults to `Infinity`. Does not apply to `MultiAgentNode`.
 - **plugins**: Plugins for event-driven extensibility
+
+To bound an individual `AgentNode`, pass `timeout` to its options object instead of relying on the orchestrator's `nodeTimeout`. Per-node `timeout` overrides `nodeTimeout` for that node and must be at least 1 ms.
+
+If neither `maxSteps` nor `timeout` is set, the SDK emits a one-time warning at construction since a graph with cyclic edges and no bound can run indefinitely.
+
+Timeouts are enforced via `AbortSignal` and are cooperative. A tool that neither polls its cancel signal nor forwards it to a cancellable API can run past the deadline.
 
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
+++ b/src/content/docs/user-guide/concepts/multi-agent/swarm.mdx
@@ -123,7 +123,15 @@ The following initialization parameters control swarm behavior and safety limits
 | `start` | Agent ID that receives the initial input | First agent in `nodes` |
 | `nodes` | Array of agents (or `AgentNodeOptions`) | (required) |
 | `maxSteps` | Maximum total agent executions (including start) | Infinity |
+| `timeout` | Wall-clock ceiling for the entire swarm invocation, in milliseconds | Infinity |
+| `nodeTimeout` | Fallback per-node wall-clock ceiling in milliseconds. Applied to any node without its own `timeout` | Infinity |
 | `plugins` | Plugins for event-driven extensibility | None |
+
+To bound an individual node, pass `timeout` on its `AgentNodeOptions` entry. Per-node `timeout` overrides the orchestrator's `nodeTimeout` and must be at least 1 ms.
+
+If neither `maxSteps` nor `timeout` is set, the SDK emits a one-time warning at construction since a swarm with no bound can run indefinitely.
+
+Timeouts are enforced via `AbortSignal` and are cooperative. A tool that neither polls its cancel signal nor forwards it to a cancellable API can run past the deadline.
 
 </Tab>
 </Tabs>

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader.ts
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader.ts
@@ -6,7 +6,6 @@ import {
   S3Storage,
 } from '@strands-agents/sdk/vended-plugins/context-offloader'
 
-
 // =====================
 // Disable Retrieval Tool
 // =====================

--- a/src/content/docs/user-guide/concepts/plugins/context-offloader_imports.ts
+++ b/src/content/docs/user-guide/concepts/plugins/context-offloader_imports.ts
@@ -4,30 +4,48 @@
 
 // --8<-- [start:disable_retrieval_tool]
 import { Agent } from '@strands-agents/sdk'
-import { ContextOffloader, FileStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+import {
+  ContextOffloader,
+  FileStorage,
+} from '@strands-agents/sdk/vended-plugins/context-offloader'
 // --8<-- [end:disable_retrieval_tool]
 
 // --8<-- [start:getting_started]
 import { Agent } from '@strands-agents/sdk'
-import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+import {
+  ContextOffloader,
+  InMemoryStorage,
+} from '@strands-agents/sdk/vended-plugins/context-offloader'
 // --8<-- [end:getting_started]
 
 // --8<-- [start:custom_thresholds]
 import { Agent } from '@strands-agents/sdk'
-import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+import {
+  ContextOffloader,
+  InMemoryStorage,
+} from '@strands-agents/sdk/vended-plugins/context-offloader'
 // --8<-- [end:custom_thresholds]
 
 // --8<-- [start:in_memory_storage]
 import { Agent } from '@strands-agents/sdk'
-import { ContextOffloader, InMemoryStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+import {
+  ContextOffloader,
+  InMemoryStorage,
+} from '@strands-agents/sdk/vended-plugins/context-offloader'
 // --8<-- [end:in_memory_storage]
 
 // --8<-- [start:file_storage]
 import { Agent } from '@strands-agents/sdk'
-import { ContextOffloader, FileStorage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+import {
+  ContextOffloader,
+  FileStorage,
+} from '@strands-agents/sdk/vended-plugins/context-offloader'
 // --8<-- [end:file_storage]
 
 // --8<-- [start:s3_storage]
 import { Agent } from '@strands-agents/sdk'
-import { ContextOffloader, S3Storage } from '@strands-agents/sdk/vended-plugins/context-offloader'
+import {
+  ContextOffloader,
+  S3Storage,
+} from '@strands-agents/sdk/vended-plugins/context-offloader'
 // --8<-- [end:s3_storage]

--- a/src/content/docs/user-guide/concepts/tools/custom-tools.mdx
+++ b/src/content/docs/user-guide/concepts/tools/custom-tools.mdx
@@ -108,6 +108,8 @@ In TypeScript, the tool name and description are always provided explicitly in t
 </Tab>
 </Tabs>
 
+Tool names must match `^[a-zA-Z0-9_-]+$` and be 1 to 64 characters long. Names that do not match this format are replaced with `INVALID_TOOL_NAME` on assistant messages before they are sent to the model, so the request still succeeds but the model can no longer reference the original name.
+
 
 ### Overriding Input Schema
 


### PR DESCRIPTION
## Description

Batch documentation update covering recent TypeScript SDK changes. Each section points to the upstream PR; all TS API verified against
  the merge commits, snippet typecheck passes.

  - Multi-agent interrupts + InterruptEvent (https://github.com/strands-agents/sdk-typescript/pull/1044): TS examples for
  BeforeNodeCallEvent in Swarm/Graph, InterruptEvent row + lifecycle node on the hooks page.
  - Hook event mutability + AfterInvocationEvent.resume (https://github.com/strands-agents/sdk-typescript/pull/957): documented
  selectedTool, mutable toolUse/result, resume; replaced six "not yet available" placeholders (Tool Interception, Result Modification,
  three resume scenarios).
  - Retry strategies (https://github.com/strands-agents/sdk-typescript/pull/888): full TS support across the retry-strategies page, new
  Backoff Strategies subsection, DefaultModelRetryStrategy.isRetryable example.
  - Graph/Swarm/Bedrock timeouts (https://github.com/strands-agents/sdk-typescript/pull/1008): documented timeout/nodeTimeout and the
  Bedrock 120s default requestTimeout override.
  - Sliding window conversation manager (https://github.com/strands-agents/sdk-typescript/pull/1018): rewrote the truncation bullet for the
   new per-content-type behavior.
  - Tool name normalization (https://github.com/strands-agents/sdk-typescript/pull/1017): documented the ^[a-zA-Z0-9_-]+$ constraint and
  INVALID_TOOL_NAME substitution.
  - Interrupts page cleanup: em-dash sweep, descriptive link text, MCP Elicitation rewrite, dropped hedging.

## Related Issues

  - https://github.com/strands-agents/sdk-typescript/pull/1044
  - https://github.com/strands-agents/sdk-typescript/pull/1018
  - https://github.com/strands-agents/sdk-typescript/pull/1017
  - https://github.com/strands-agents/sdk-typescript/pull/1008
  - https://github.com/strands-agents/sdk-typescript/pull/957
  - https://github.com/strands-agents/sdk-typescript/pull/888

## Type of Change

- New content

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
