### PR TITLE
feat: add tags footer at the end of user guide pages

### DIFF
--- a/src/components/PageTags.astro
+++ b/src/components/PageTags.astro
@@ -2,13 +2,11 @@
 /**
  * Clickable tag pills at the bottom of user-guide articles.
  *
- * Pill row stays static — never reflows. Clicking a pill opens a single
- * shared panel below the row showing every other user-guide page carrying
- * that tag. Click the same pill again (or the panel's close button) to
- * collapse.
- *
- * State is driven by a small script that toggles an `is-active` class on
- * the clicked pill and the `hidden` attribute on each panel.
+ * The pill row is the only thing that ever takes layout space. Clicking a
+ * pill reveals a single shared panel that floats *over* the page below the
+ * row (absolutely positioned), so opening or closing it doesn't push the
+ * footer up or down. Click the pill again, the close button, the ESC key,
+ * or anywhere outside the panel to dismiss.
  *
  * Uses an `aria-expanded` disclosure pattern (each pill is a disclosure
  * button revealing its panel). Not a full ARIA tablist — that would
@@ -16,6 +14,7 @@
  * we don't currently implement.
  */
 import { getCollection } from 'astro:content'
+import { slug as githubSlug } from 'github-slugger'
 import { userGuidePagesWithTag } from '../util/related-docs'
 import { pathWithBase } from '../util/links'
 
@@ -25,10 +24,9 @@ const entry = starlightRoute.entry
 const allDocs = entry.collection === 'docs' ? await getCollection('docs') : []
 const tags: string[] = entry.collection === 'docs' ? (entry.data.tags ?? []) : []
 
-// Build a panel id that's unique to this page + tag, and safe for HTML
-// attribute use even if a tag ever contains characters outside [a-z0-9-].
-const idSlug = (s: string) => s.replace(/[^a-zA-Z0-9-]/g, '-')
-const panelId = (tag: string) => `pagetags-${idSlug(entry.id)}-${idSlug(tag)}`
+// Panel id must be unique per (page, tag) and safe for HTML attribute use.
+// github-slugger is the same library Astro uses internally for slugs.
+const panelId = (tag: string) => `pagetags-${githubSlug(entry.id)}-${githubSlug(tag)}`
 
 const items = tags.map((tag) => ({
   tag,
@@ -41,41 +39,43 @@ const items = tags.map((tag) => ({
   <aside class="page-tags not-content" aria-label="Tags">
     <div class="page-tags__label">Tags</div>
 
-    <div class="page-tags__row">
+    <div class="page-tags__anchor">
+      <div class="page-tags__row">
+        {items.map(({ tag, matches, panelId }) => (
+          <button
+            type="button"
+            class="page-tags__pill"
+            data-tag={tag}
+            aria-expanded="false"
+            aria-controls={panelId}
+          >
+            <span class="page-tags__name">{tag}</span>
+            <span class="page-tags__count" aria-hidden="true">{matches.length}</span>
+          </button>
+        ))}
+      </div>
+
       {items.map(({ tag, matches, panelId }) => (
-        <button
-          type="button"
-          class="page-tags__pill"
-          data-tag={tag}
-          aria-expanded="false"
-          aria-controls={panelId}
-        >
-          <span class="page-tags__name">{tag}</span>
-          <span class="page-tags__count" aria-hidden="true">{matches.length}</span>
-        </button>
+        <div class="page-tags__panel" id={panelId} data-tag={tag} hidden>
+          <div class="page-tags__panel-header">
+            <span class="page-tags__panel-tag">{tag}</span>
+            <span class="page-tags__panel-count">{`${matches.length} ${matches.length === 1 ? 'page' : 'pages'}`}</span>
+            <button type="button" class="page-tags__close" data-action="close" aria-label="Close">×</button>
+          </div>
+          {matches.length > 0 ? (
+            <ul class="page-tags__matches">
+              {matches.map((m) => (
+                <li>
+                  <a href={pathWithBase(`/${m.slug}/`)}>{m.title}</a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p class="page-tags__empty">No other pages with this tag.</p>
+          )}
+        </div>
       ))}
     </div>
-
-    {items.map(({ tag, matches, panelId }) => (
-      <div class="page-tags__panel" id={panelId} data-tag={tag} hidden>
-        <div class="page-tags__panel-header">
-          <span class="page-tags__panel-tag">{tag}</span>
-          <span class="page-tags__panel-count">{`${matches.length} ${matches.length === 1 ? 'page' : 'pages'}`}</span>
-          <button type="button" class="page-tags__close" data-action="close" aria-label="Close">×</button>
-        </div>
-        {matches.length > 0 ? (
-          <ul class="page-tags__matches">
-            {matches.map((m) => (
-              <li>
-                <a href={pathWithBase(`/${m.slug}/`)}>{m.title}</a>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p class="page-tags__empty">No other pages with this tag.</p>
-        )}
-      </div>
-    ))}
   </aside>
 )}
 
@@ -95,10 +95,12 @@ const items = tags.map((tag) => ({
         panels.forEach((p) => {
           p.hidden = p.dataset.tag !== tag
         })
+        root.classList.toggle('is-open', tag !== null)
       }
 
       pills.forEach((pill) => {
-        pill.addEventListener('click', () => {
+        pill.addEventListener('click', (e) => {
+          e.stopPropagation()
           const isActive = pill.classList.contains('is-active')
           setActive(isActive ? null : pill.dataset.tag ?? null)
         })
@@ -107,6 +109,20 @@ const items = tags.map((tag) => ({
       closeButtons.forEach((b) =>
         b.addEventListener('click', () => setActive(null))
       )
+
+      // Click outside the aside dismisses the panel. Clicks inside (on a
+      // matched-page link, the panel itself, etc.) are left alone.
+      document.addEventListener('click', (e) => {
+        if (!root.classList.contains('is-open')) return
+        if (e.target instanceof Node && root.contains(e.target)) return
+        setActive(null)
+      })
+
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && root.classList.contains('is-open')) {
+          setActive(null)
+        }
+      })
     })
   }
 
@@ -129,6 +145,13 @@ const items = tags.map((tag) => ({
     text-transform: uppercase;
     color: var(--sl-color-gray-3);
     margin-bottom: 0.625rem;
+  }
+
+  /* The anchor establishes the positioning context for the floating panel,
+     so the panel hangs from the bottom of the pill row regardless of how
+     much vertical content sits below it. */
+  .page-tags__anchor {
+    position: relative;
   }
 
   .page-tags__row {
@@ -180,11 +203,19 @@ const items = tags.map((tag) => ({
     opacity: 0.7;
   }
 
+  /* Floating panel: anchored to the bottom of the pill row, layered over
+     content below. Page does not reflow when it opens or closes. */
   .page-tags__panel {
-    margin-top: 0.75rem;
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    right: 0;
+    z-index: 5;
     padding: 0.625rem 1rem 0.75rem;
     border: 1px solid var(--sl-color-hairline);
     border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+    box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.25);
   }
 
   .page-tags__panel-header {

--- a/src/components/PageTags.astro
+++ b/src/components/PageTags.astro
@@ -1,0 +1,265 @@
+---
+/**
+ * Clickable tag pills at the bottom of user-guide articles.
+ *
+ * Pill row stays static — never reflows. Clicking a pill opens a single
+ * shared panel below the row showing every other user-guide page carrying
+ * that tag. Click the same pill again (or the panel's close button) to
+ * collapse.
+ *
+ * State is driven by a small script that toggles an `is-active` class on
+ * the clicked pill and the `hidden` attribute on each panel.
+ *
+ * Uses an `aria-expanded` disclosure pattern (each pill is a disclosure
+ * button revealing its panel). Not a full ARIA tablist — that would
+ * require arrow-key navigation, focus management, and `tabindex` shuffling
+ * we don't currently implement.
+ */
+import { getCollection } from 'astro:content'
+import { userGuidePagesWithTag } from '../util/related-docs'
+import { pathWithBase } from '../util/links'
+
+const { starlightRoute } = Astro.locals
+const entry = starlightRoute.entry
+
+const allDocs = entry.collection === 'docs' ? await getCollection('docs') : []
+const tags: string[] = entry.collection === 'docs' ? (entry.data.tags ?? []) : []
+
+// Build a panel id that's unique to this page + tag, and safe for HTML
+// attribute use even if a tag ever contains characters outside [a-z0-9-].
+const idSlug = (s: string) => s.replace(/[^a-zA-Z0-9-]/g, '-')
+const panelId = (tag: string) => `pagetags-${idSlug(entry.id)}-${idSlug(tag)}`
+
+const items = tags.map((tag) => ({
+  tag,
+  matches: userGuidePagesWithTag(tag, entry, allDocs),
+  panelId: panelId(tag),
+}))
+---
+
+{items.length > 0 && (
+  <aside class="page-tags not-content" aria-label="Tags">
+    <div class="page-tags__label">Tags</div>
+
+    <div class="page-tags__row">
+      {items.map(({ tag, matches, panelId }) => (
+        <button
+          type="button"
+          class="page-tags__pill"
+          data-tag={tag}
+          aria-expanded="false"
+          aria-controls={panelId}
+        >
+          <span class="page-tags__name">{tag}</span>
+          <span class="page-tags__count" aria-hidden="true">{matches.length}</span>
+        </button>
+      ))}
+    </div>
+
+    {items.map(({ tag, matches, panelId }) => (
+      <div class="page-tags__panel" id={panelId} data-tag={tag} hidden>
+        <div class="page-tags__panel-header">
+          <span class="page-tags__panel-tag">{tag}</span>
+          <span class="page-tags__panel-count">{`${matches.length} ${matches.length === 1 ? 'page' : 'pages'}`}</span>
+          <button type="button" class="page-tags__close" data-action="close" aria-label="Close">×</button>
+        </div>
+        {matches.length > 0 ? (
+          <ul class="page-tags__matches">
+            {matches.map((m) => (
+              <li>
+                <a href={pathWithBase(`/${m.slug}/`)}>{m.title}</a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p class="page-tags__empty">No other pages with this tag.</p>
+        )}
+      </div>
+    ))}
+  </aside>
+)}
+
+<script>
+  function init() {
+    document.querySelectorAll<HTMLElement>('aside.page-tags').forEach((root) => {
+      const pills = root.querySelectorAll<HTMLButtonElement>('.page-tags__pill')
+      const panels = root.querySelectorAll<HTMLElement>('.page-tags__panel')
+      const closeButtons = root.querySelectorAll<HTMLButtonElement>('[data-action="close"]')
+
+      function setActive(tag: string | null) {
+        pills.forEach((p) => {
+          const isActive = p.dataset.tag === tag
+          p.setAttribute('aria-expanded', String(isActive))
+          p.classList.toggle('is-active', isActive)
+        })
+        panels.forEach((p) => {
+          p.hidden = p.dataset.tag !== tag
+        })
+      }
+
+      pills.forEach((pill) => {
+        pill.addEventListener('click', () => {
+          const isActive = pill.classList.contains('is-active')
+          setActive(isActive ? null : pill.dataset.tag ?? null)
+        })
+      })
+
+      closeButtons.forEach((b) =>
+        b.addEventListener('click', () => setActive(null))
+      )
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+</script>
+
+<style>
+  .page-tags {
+    margin-top: 2.5rem;
+  }
+
+  .page-tags__label {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--sl-color-gray-3);
+    margin-bottom: 0.625rem;
+  }
+
+  .page-tags__row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .page-tags__pill {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem 0.375rem 0.875rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.3;
+    color: var(--sl-color-text);
+    background: transparent;
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+  }
+
+  .page-tags__pill:hover {
+    border-color: var(--sl-color-text-accent);
+    color: var(--sl-color-text-accent);
+  }
+
+  /* Selected pill matches Starlight's own active-link pattern (used on
+     [aria-current='page'] in the left sidebar): accent fill with inverted
+     text. These are theme-aware tokens, so light/dark mode adapt for free. */
+  .page-tags__pill.is-active,
+  .page-tags__pill.is-active:hover {
+    border-color: var(--sl-color-text-accent);
+    background-color: var(--sl-color-text-accent);
+    color: var(--sl-color-text-invert);
+  }
+
+  /* Plain-text count next to the tag name. No bubble — quieter visual. */
+  .page-tags__count {
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-3);
+  }
+
+  /* Inside the active pill the inverted-text color carries through */
+  .page-tags__pill.is-active .page-tags__count {
+    color: inherit;
+    opacity: 0.7;
+  }
+
+  .page-tags__panel {
+    margin-top: 0.75rem;
+    padding: 0.625rem 1rem 0.75rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+  }
+
+  .page-tags__panel-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .page-tags__panel-tag {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--sl-color-text);
+  }
+
+  /* Slightly de-emphasized count next to the tag name */
+  .page-tags__panel-count {
+    font-size: 0.6875rem;
+    color: var(--sl-color-gray-4);
+    font-weight: 500;
+  }
+
+  .page-tags__close {
+    margin-left: auto;
+    width: 1.75rem;
+    height: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--sl-color-gray-3);
+    cursor: pointer;
+    font-size: 1.25rem;
+    line-height: 1;
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+  .page-tags__close:hover {
+    background-color: var(--sl-color-gray-5);
+    color: var(--sl-color-text);
+  }
+
+  /* Constrain link grid width so the two columns feel connected,
+     not floating in a wide-page sea. Caps at ~content width. */
+  .page-tags__matches {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    columns: 2;
+    column-gap: 1.5rem;
+    max-width: 44rem;
+  }
+  .page-tags__matches li {
+    margin: 0;
+    padding: 0.1875rem 0;
+    break-inside: avoid;
+  }
+  .page-tags__matches a {
+    color: var(--sl-color-text-accent);
+    text-decoration: none;
+    font-size: 0.875rem;
+  }
+  .page-tags__matches a:hover {
+    text-decoration: underline;
+  }
+
+  .page-tags__empty {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--sl-color-gray-3);
+    font-style: italic;
+  }
+
+  @media (max-width: 768px) {
+    .page-tags__matches { columns: 1; }
+  }
+</style>

--- a/src/components/PageTags.astro
+++ b/src/components/PageTags.astro
@@ -2,11 +2,13 @@
 /**
  * Clickable tag pills at the bottom of user-guide articles.
  *
- * The pill row is the only thing that ever takes layout space. Clicking a
- * pill reveals a single shared panel that floats *over* the page below the
- * row (absolutely positioned), so opening or closing it doesn't push the
- * footer up or down. Click the pill again, the close button, the ESC key,
- * or anywhere outside the panel to dismiss.
+ * Pill row stays static — never reflows. Clicking a pill opens a single
+ * shared panel below the row showing every other user-guide page carrying
+ * that tag. Click the same pill again (or the panel's close button) to
+ * collapse.
+ *
+ * State is driven by a small script that toggles an `is-active` class on
+ * the clicked pill and the `hidden` attribute on each panel.
  *
  * Uses an `aria-expanded` disclosure pattern (each pill is a disclosure
  * button revealing its panel). Not a full ARIA tablist — that would
@@ -39,43 +41,41 @@ const items = tags.map((tag) => ({
   <aside class="page-tags not-content" aria-label="Tags">
     <div class="page-tags__label">Tags</div>
 
-    <div class="page-tags__anchor">
-      <div class="page-tags__row">
-        {items.map(({ tag, matches, panelId }) => (
-          <button
-            type="button"
-            class="page-tags__pill"
-            data-tag={tag}
-            aria-expanded="false"
-            aria-controls={panelId}
-          >
-            <span class="page-tags__name">{tag}</span>
-            <span class="page-tags__count" aria-hidden="true">{matches.length}</span>
-          </button>
-        ))}
-      </div>
-
+    <div class="page-tags__row">
       {items.map(({ tag, matches, panelId }) => (
-        <div class="page-tags__panel" id={panelId} data-tag={tag} hidden>
-          <div class="page-tags__panel-header">
-            <span class="page-tags__panel-tag">{tag}</span>
-            <span class="page-tags__panel-count">{`${matches.length} ${matches.length === 1 ? 'page' : 'pages'}`}</span>
-            <button type="button" class="page-tags__close" data-action="close" aria-label="Close">×</button>
-          </div>
-          {matches.length > 0 ? (
-            <ul class="page-tags__matches">
-              {matches.map((m) => (
-                <li>
-                  <a href={pathWithBase(`/${m.slug}/`)}>{m.title}</a>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p class="page-tags__empty">No other pages with this tag.</p>
-          )}
-        </div>
+        <button
+          type="button"
+          class="page-tags__pill"
+          data-tag={tag}
+          aria-expanded="false"
+          aria-controls={panelId}
+        >
+          <span class="page-tags__name">{tag}</span>
+          <span class="page-tags__count" aria-hidden="true">{matches.length}</span>
+        </button>
       ))}
     </div>
+
+    {items.map(({ tag, matches, panelId }) => (
+      <div class="page-tags__panel" id={panelId} data-tag={tag} hidden>
+        <div class="page-tags__panel-header">
+          <span class="page-tags__panel-tag">{tag}</span>
+          <span class="page-tags__panel-count">{`${matches.length} ${matches.length === 1 ? 'page' : 'pages'}`}</span>
+          <button type="button" class="page-tags__close" data-action="close" aria-label="Close">×</button>
+        </div>
+        {matches.length > 0 ? (
+          <ul class="page-tags__matches">
+            {matches.map((m) => (
+              <li>
+                <a href={pathWithBase(`/${m.slug}/`)}>{m.title}</a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p class="page-tags__empty">No other pages with this tag.</p>
+        )}
+      </div>
+    ))}
   </aside>
 )}
 
@@ -95,12 +95,10 @@ const items = tags.map((tag) => ({
         panels.forEach((p) => {
           p.hidden = p.dataset.tag !== tag
         })
-        root.classList.toggle('is-open', tag !== null)
       }
 
       pills.forEach((pill) => {
-        pill.addEventListener('click', (e) => {
-          e.stopPropagation()
+        pill.addEventListener('click', () => {
           const isActive = pill.classList.contains('is-active')
           setActive(isActive ? null : pill.dataset.tag ?? null)
         })
@@ -109,20 +107,6 @@ const items = tags.map((tag) => ({
       closeButtons.forEach((b) =>
         b.addEventListener('click', () => setActive(null))
       )
-
-      // Click outside the aside dismisses the panel. Clicks inside (on a
-      // matched-page link, the panel itself, etc.) are left alone.
-      document.addEventListener('click', (e) => {
-        if (!root.classList.contains('is-open')) return
-        if (e.target instanceof Node && root.contains(e.target)) return
-        setActive(null)
-      })
-
-      document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && root.classList.contains('is-open')) {
-          setActive(null)
-        }
-      })
     })
   }
 
@@ -145,13 +129,6 @@ const items = tags.map((tag) => ({
     text-transform: uppercase;
     color: var(--sl-color-gray-3);
     margin-bottom: 0.625rem;
-  }
-
-  /* The anchor establishes the positioning context for the floating panel,
-     so the panel hangs from the bottom of the pill row regardless of how
-     much vertical content sits below it. */
-  .page-tags__anchor {
-    position: relative;
   }
 
   .page-tags__row {
@@ -203,19 +180,11 @@ const items = tags.map((tag) => ({
     opacity: 0.7;
   }
 
-  /* Floating panel: anchored to the bottom of the pill row, layered over
-     content below. Page does not reflow when it opens or closes. */
   .page-tags__panel {
-    position: absolute;
-    top: calc(100% + 0.5rem);
-    left: 0;
-    right: 0;
-    z-index: 5;
+    margin-top: 0.75rem;
     padding: 0.625rem 1rem 0.75rem;
     border: 1px solid var(--sl-color-hairline);
     border-radius: 0.5rem;
-    background: var(--sl-color-bg);
-    box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.25);
   }
 
   .page-tags__panel-header {
@@ -269,10 +238,15 @@ const items = tags.map((tag) => ({
     column-gap: 1.5rem;
     max-width: 44rem;
   }
+  /* Space between separate items comes from li padding; space between
+     wrapped lines of a single long title comes from the li's
+     line-height (an inline anchor's own line-height doesn't size the
+     line box — the line-box parent does). */
   .page-tags__matches li {
     margin: 0;
     padding: 0.1875rem 0;
     break-inside: avoid;
+    line-height: 1.2;
   }
   .page-tags__matches a {
     color: var(--sl-color-text-accent);

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -3,6 +3,7 @@ import '@astrojs/starlight/style/markdown.css';
 import CommunityContributionAside from '../CommunityContributionAside.astro';
 import LanguageSupportAside from '../LanguageSupportAside.astro';
 import ExperimentalAside from '../ExperimentalAside.astro';
+import PageTags from '../PageTags.astro';
 
 const { starlightRoute } = Astro.locals;
 const { languages, community, experimental } = starlightRoute.entry.data;
@@ -15,4 +16,5 @@ const { languages, community, experimental } = starlightRoute.entry.data;
       contextualizes the page, and language support is listed in the community catalog table instead. */}
   {languages && !community && <LanguageSupportAside languages={languages} />}
   <slot />
+  <PageTags />
 </div>

--- a/src/util/related-docs.ts
+++ b/src/util/related-docs.ts
@@ -140,7 +140,10 @@ export function relatedUserGuideFor(
 }
 
 /**
- * Other user-guide pages carrying a given tag, sorted alphabetically by title.
+ * Other user-guide pages carrying a given tag, ranked by relevance to the
+ * current page (specificity-weighted Jaccard, the same scorer used for the
+ * headless Related Pages list). Ties break alphabetically by title.
+ *
  * Used by the clickable-tags UI to populate per-tag expansion content.
  * Excludes the current page so a tag never lists itself.
  */
@@ -149,8 +152,7 @@ export function userGuidePagesWithTag(
   current: CollectionEntry<'docs'>,
   allDocs: readonly CollectionEntry<'docs'>[],
 ): { slug: string; title: string }[] {
-  return allDocs
-    .filter((d) => d.id !== current.id && isUserGuide(d) && (d.data.tags ?? []).includes(tag))
-    .map((d) => ({ slug: d.id, title: d.data.title }))
-    .sort((a, b) => a.title.localeCompare(b.title))
+  return rankedCandidates(current, allDocs)
+    .filter(({ doc }) => (doc.data.tags ?? []).includes(tag))
+    .map(({ doc }) => ({ slug: doc.id, title: doc.data.title }))
 }

--- a/src/util/related-docs.ts
+++ b/src/util/related-docs.ts
@@ -138,3 +138,19 @@ export function relatedUserGuideFor(
 ): RelatedLink[] {
   return rankedCandidates(current, allDocs).slice(0, HEADLESS_MAX).map(toLink)
 }
+
+/**
+ * Other user-guide pages carrying a given tag, sorted alphabetically by title.
+ * Used by the clickable-tags UI to populate per-tag expansion content.
+ * Excludes the current page so a tag never lists itself.
+ */
+export function userGuidePagesWithTag(
+  tag: string,
+  current: CollectionEntry<'docs'>,
+  allDocs: readonly CollectionEntry<'docs'>[],
+): { slug: string; title: string }[] {
+  return allDocs
+    .filter((d) => d.id !== current.id && isUserGuide(d) && (d.data.tags ?? []).includes(tag))
+    .map((d) => ({ slug: d.id, title: d.data.title }))
+    .sort((a, b) => a.title.localeCompare(b.title))
+}

--- a/test/related-docs.test.ts
+++ b/test/related-docs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { CollectionEntry } from 'astro:content'
-import { relatedUserGuideFor } from '../src/util/related-docs'
+import { relatedUserGuideFor, userGuidePagesWithTag } from '../src/util/related-docs'
 
 function doc(id: string, title: string, tags: string[]): CollectionEntry<'docs'> {
   return { id, collection: 'docs', data: { title, tags } } as unknown as CollectionEntry<'docs'>
@@ -95,6 +95,48 @@ describe('relatedUserGuideFor (headless: top 10, specificity-weighted Jaccard)',
 
     const result = relatedUserGuideFor(current, [current, focused, coincidental])
     expect(result.map((r) => r.title)).toEqual(['Focused', 'Coincidental'])
+  })
+})
+
+describe('userGuidePagesWithTag', () => {
+  it('returns user-guide pages carrying the given tag, alphabetical by title', () => {
+    const current = doc('docs/user-guide/a', 'A', ['safety'])
+    const zebra = doc('docs/user-guide/z', 'Zebra', ['safety'])
+    const apple = doc('docs/user-guide/b', 'Apple', ['safety'])
+
+    const result = userGuidePagesWithTag('safety', current, [current, zebra, apple])
+    expect(result.map((r) => r.title)).toEqual(['Apple', 'Zebra'])
+  })
+
+  it('excludes the current page from its own results', () => {
+    const current = doc('docs/user-guide/a', 'A', ['safety'])
+    const other = doc('docs/user-guide/b', 'B', ['safety'])
+
+    const result = userGuidePagesWithTag('safety', current, [current, other])
+    expect(result.map((r) => r.slug)).toEqual(['docs/user-guide/b'])
+  })
+
+  it('returns empty when no other page carries the tag', () => {
+    const current = doc('docs/user-guide/a', 'A', ['safety'])
+    const other = doc('docs/user-guide/b', 'B', ['production'])
+
+    expect(userGuidePagesWithTag('safety', current, [current, other])).toEqual([])
+  })
+
+  it('ignores pages outside the user-guide tree', () => {
+    const current = doc('docs/user-guide/a', 'A', ['safety'])
+    const blog = doc('docs/community/b', 'Blog Post', ['safety'])
+    const guide = doc('docs/user-guide/c', 'Guide', ['safety'])
+
+    const result = userGuidePagesWithTag('safety', current, [current, blog, guide])
+    expect(result.map((r) => r.slug)).toEqual(['docs/user-guide/c'])
+  })
+
+  it('ignores pages with no tags', () => {
+    const current = doc('docs/user-guide/a', 'A', ['safety'])
+    const untagged = doc('docs/user-guide/b', 'Untagged', [])
+
+    expect(userGuidePagesWithTag('safety', current, [current, untagged])).toEqual([])
   })
 })
 

--- a/test/related-docs.test.ts
+++ b/test/related-docs.test.ts
@@ -99,7 +99,19 @@ describe('relatedUserGuideFor (headless: top 10, specificity-weighted Jaccard)',
 })
 
 describe('userGuidePagesWithTag', () => {
-  it('returns user-guide pages carrying the given tag, alphabetical by title', () => {
+  it('ranks pages by relevance score, descending', () => {
+    // Current page has the safety tag plus another. Pages sharing more
+    // weighted overlap with current should rank above ones that only carry
+    // the queried tag.
+    const current = doc('docs/user-guide/a', 'A', ['safety', 'bedrock'])
+    const richMatch = doc('docs/user-guide/b', 'Rich', ['safety', 'bedrock'])
+    const thinMatch = doc('docs/user-guide/c', 'Thin', ['safety'])
+
+    const result = userGuidePagesWithTag('safety', current, [current, thinMatch, richMatch])
+    expect(result.map((r) => r.title)).toEqual(['Rich', 'Thin'])
+  })
+
+  it('breaks score ties alphabetically by title', () => {
     const current = doc('docs/user-guide/a', 'A', ['safety'])
     const zebra = doc('docs/user-guide/z', 'Zebra', ['safety'])
     const apple = doc('docs/user-guide/b', 'Apple', ['safety'])


### PR DESCRIPTION
## Description

Footer on every user guide page with tags pills. Each pill is clickable and shows all of the related pages.

## Related Issues

n/a

## Type of Change

- Other (please describe):

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
