### PR TITLE
Add Agent Extensions category with strands-code-agent

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -257,6 +257,9 @@ sidebar:
       - label: Integrations
         items:
           - docs/community/integrations/ag-ui
+      - label: Agent Extensions
+        items:
+          - docs/community/agent-extensions/strands-code-agent
       - label: Plugins
         items:
           - docs/community/plugins/agent-control

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -91,7 +91,7 @@ export const collections = {
         // Category for TypeScript API docs (classes, interfaces, type-aliases, functions)
         category: z.string().optional(),
         // Integration type for filtering (e.g., 'model-provider' for model providers)
-        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'integration', 'plugin']).optional(),
+        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'integration', 'plugin', 'agent-extension']).optional(),
         // Short description for catalog listings
         description: z.string().optional(),
         // Array of slugs that should redirect to this page (e.g., old URLs)

--- a/src/content/docs/community/agent-extensions/strands-code-agent.mdx
+++ b/src/content/docs/community/agent-extensions/strands-code-agent.mdx
@@ -1,0 +1,71 @@
+---
+title: strands-code-agent
+community: true
+description: A coding agent that replaces tool-calling with code generation in a persistent Python REPL
+integrationType: agent-extension
+languages: Python
+sidebar:
+  label: "Code Agent"
+project:
+  pypi: https://pypi.org/project/strands-code-agent/
+  github: https://github.com/aws-samples/sample-strands-code-agent
+  maintainer: aws-samples
+---
+
+[strands-code-agent](https://github.com/aws-samples/sample-strands-code-agent) provides a `CodeAgent` that replaces the tool-calling paradigm with code generation as the agent's primary action interface. Rather than invoking structured tools, the agent writes Python code in a persistent REPL where domain capabilities are exposed as importable library functions. This keeps intermediate data as native Python objects in memory and lets the agent compose multi-step logic in a single code block.
+
+In empirical evaluations on the Data Agent Benchmark, this approach achieves higher accuracy (+7%) while consuming 78% fewer input tokens, 67% fewer output tokens, completing tasks 56% faster, and requiring 35% fewer reasoning cycles compared to an equivalent tool-calling agent.
+
+## Installation
+
+```bash
+pip install strands-code-agent
+```
+
+## Usage
+
+```python
+from strands_code_agent import CodeAgent
+
+agent = CodeAgent(system_prompt="You are a helpful data analyst.")
+
+response = agent("What is 2 ** 10?")
+```
+
+The agent receives a `python_repl` tool automatically and solves tasks by writing and executing Python code.
+
+## Toolkits
+
+A `Toolkit` bundles everything the REPL needs for a specific domain — authorized imports, initialization code, usage instructions, and domain-specific functions:
+
+```python
+from strands_code_agent import CodeAgent
+from strands_code_agent.toolkits import DATA_ANALYSIS_TOOLKIT, VISUALIZATION_TOOLKIT
+
+agent = CodeAgent(
+    system_prompt="You are a data analyst.",
+    toolkits=[DATA_ANALYSIS_TOOLKIT, VISUALIZATION_TOOLKIT],
+)
+```
+
+You can also expose your own functions as domain-specific code:
+
+```python
+from strands_code_agent import CodeAgent, Toolkit
+
+def calculate_roi(investment: float, returns: float) -> float:
+    """Calculate return on investment as a percentage."""
+    return (returns - investment) / investment * 100
+
+agent = CodeAgent(
+    system_prompt="You are a finance assistant.",
+    toolkits=[Toolkit(domain_specific_code=[calculate_roi])],
+)
+```
+
+## References
+
+- [GitHub repository](https://github.com/aws-samples/sample-strands-code-agent)
+- [PyPI package](https://pypi.org/project/strands-code-agent/)
+- [Data Analyst Agent example](https://github.com/aws-solutions-library-samples/guidance-for-agentic-data-analyst-using-amazon-bedrock-agentcore-on-aws/blob/main/agent/aws_data_analyst/data_analyst_agent.py#L92)
+- [Geospatial Agent example](https://github.com/aws-samples/sample-geospatial-code-agent/blob/main/agent/geospatial_agent/agent.py#L93)

--- a/src/content/docs/community/community-packages.mdx
+++ b/src/content/docs/community/community-packages.mdx
@@ -15,6 +15,7 @@ export const communityPlugins = getIntegrationEntries(allDocs, 'plugin', true)
 export const communityModelProviders = getIntegrationEntries(allDocs, 'model-provider', true)
 export const communitySessionManagers = getIntegrationEntries(allDocs, 'session-manager', true)
 export const communityTools = getIntegrationEntries(allDocs, 'tool', true)
+export const communityAgentExtensions = getIntegrationEntries(allDocs, 'agent-extension', true)
 
 export const packageColumns = [
   { header: "Package" },
@@ -75,6 +76,14 @@ Session managers provide alternative storage backends for conversation history. 
 Tools extend your agents with capabilities for specific services and platforms. Each package provides one or more tools you can add to your agents.
 
 <SimpleTable data={communityTools} columns={packageColumns}>
+  {renderCell}
+</SimpleTable>
+
+## Agent Extensions
+
+Agent extensions provide specialized agent subclasses that change how Strands agents reason and act. Use these when you need an alternative action paradigm beyond the default tool-calling approach.
+
+<SimpleTable data={communityAgentExtensions} columns={packageColumns}>
   {renderCell}
 </SimpleTable>
 

--- a/src/content/docs/community/get-featured.mdx
+++ b/src/content/docs/community/get-featured.mdx
@@ -15,6 +15,7 @@ We feature **reusable packages** that extend Strands Agents capabilities:
 - **Session Managers** — custom session/memory implementations
 - **Plugins** — extend or modify agent behavior during lifecycle events
 - **Integrations** — protocol implementations, framework bridges, etc.
+- **Agent Extensions** — specialized agent subclasses that change how agents reason and act
 
 We're not looking for example agents or one-off projects — the focus is on packages published to PyPI that others can `pip install` or `npm install` and use in their own agents. See [Community Packages](./community-packages.md) for guidance on creating and publishing your package.
 
@@ -40,6 +41,7 @@ Place your documentation in the right spot:
 | Session Managers | `community/session-managers/` | `agentcore-memory.mdx` |
 | Plugins | `community/plugins/` | `my-plugin.mdx` |
 | Integrations | `community/integrations/` | `ag-ui.mdx` |
+| Agent Extensions | `community/agent-extensions/` | `strands-code-agent.mdx` |
 
 ## Document Layout
 
@@ -77,7 +79,7 @@ Links to your repo, PyPI, official docs, etc.
 
 Every community page needs frontmatter with catalog fields so it appears in the [community catalog](./community-packages.md). Without `community: true`, `integrationType`, `description`, and `languages`, your page won't show up in the catalog tables.
 
-Here's the full frontmatter for a **Tool** (adapt `integrationType` for your package type — `tool`, `model-provider`, `session-manager`, `plugin`, or `integration`):
+Here's the full frontmatter for a **Tool** (adapt `integrationType` for your package type — `tool`, `model-provider`, `session-manager`, `plugin`, `integration`, or `agent-extension`):
 
 ```yaml
 ---

--- a/src/util/integration-content.ts
+++ b/src/util/integration-content.ts
@@ -16,6 +16,7 @@ export type IntegrationType =
   | 'session-manager'
   | 'integration'
   | 'plugin'
+  | 'agent-extension'
 
 /**
  * Represents language support for an integration.


### PR DESCRIPTION
Adds a new **Agent Extensions** community category for specialized agent subclasses that change how Strands agents reason and act.

## Changes
- New `agent-extension` integration type in schema and TypeScript types
- New 'Agent Extensions' section in the community catalog
- Documentation page for `strands-code-agent`
- Updated navigation and get-featured guide

## New library
[strands-code-agent](https://github.com/aws-samples/sample-strands-code-agent) replaces tool-calling with code generation in a persistent Python REPL, achieving +7% accuracy with significantly fewer tokens and faster completion.