### PR TITLE
Add WebSDK analytics instrumentation for site sections and engagement

### DIFF
--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -20,8 +20,6 @@
 
   var scrollData = { initial: 0, max: 0, latest: 0 }
   var scrollSent = false
-  var searchObserver = null
-  var searchBodyObserver = null
 
   // --- Helpers ---
 
@@ -132,46 +130,19 @@
 
   function setupSearchTracking() {
     var searchTimeout = null
-    searchObserver = new MutationObserver(function () {
-      var resultsContainer = document.querySelector('[data-pagefind-ui] .pagefind-ui__results')
-      if (!resultsContainer) return
+
+    document.addEventListener('input', function (e) {
+      var input = e.target
+      if (!input || !input.matches || !input.matches('[data-pagefind-ui] input')) return
+
       clearTimeout(searchTimeout)
       searchTimeout = setTimeout(function () {
-        var input = document.querySelector('[data-pagefind-ui] input')
-        var term = input ? input.value : ''
+        var term = input.value
         if (!term) return
-        var items = resultsContainer.querySelectorAll('.pagefind-ui__result')
-        dispatchSearchEvent(term, items.length)
+        var results = document.querySelectorAll('[data-pagefind-ui] .pagefind-ui__result')
+        dispatchSearchEvent(term, results.length)
       }, 800)
     })
-
-    // Starlight renders search in a <dialog> with aria-label containing "Search".
-    // Partial match on "earch" handles capitalization; if the label changes, the
-    // bodyObserver fallback will still pick up [data-pagefind-ui] when it appears.
-    var searchDialog = document.querySelector('dialog[aria-label*="earch"], [data-pagefind-ui]')
-    if (searchDialog) {
-      searchObserver.observe(searchDialog, { childList: true, subtree: true })
-    } else {
-      searchBodyObserver = new MutationObserver(function (mutations) {
-        for (var i = 0; i < mutations.length; i++) {
-          var nodes = mutations[i].addedNodes
-          for (var j = 0; j < nodes.length; j++) {
-            if (nodes[j].nodeType === 1 && (nodes[j].matches('dialog') || nodes[j].querySelector('[data-pagefind-ui]'))) {
-              searchObserver.observe(nodes[j], { childList: true, subtree: true })
-              searchBodyObserver.disconnect()
-              searchBodyObserver = null
-              return
-            }
-          }
-        }
-      })
-      searchBodyObserver.observe(document.body, { childList: true })
-    }
-  }
-
-  function disconnectSearchObservers() {
-    if (searchObserver) { searchObserver.disconnect(); searchObserver = null }
-    if (searchBodyObserver) { searchBodyObserver.disconnect(); searchBodyObserver = null }
   }
 
   // --- 4. Scroll Depth ---
@@ -239,12 +210,7 @@
 
   // --- 5. SPA / View Transition Support ---
 
-  document.addEventListener('astro:before-swap', function () {
-    disconnectSearchObservers()
-  })
-
   document.addEventListener('astro:page-load', function () {
-    setupSearchTracking()
     trackPageView()
     resetScrollData()
   })

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -1,0 +1,223 @@
+---
+/**
+ * Analytics instrumentation via AWS WebSDK (Adobe Analytics under the hood).
+ * Dispatches custom events through the WebSDK's event listener system.
+ * Included in Head.astro for all pages.
+ */
+---
+
+<script is:inline>
+;(function () {
+  'use strict'
+
+  const CUSTOM_EVENT_LISTENER = 'custom-awsm-acs-analytics-event-listener'
+  const SEARCH_EVENT_LISTENER = 'custom-awsm-acs-search-event-listener'
+
+  // --- Helpers ---
+
+  function deriveSections(pathname) {
+    const segments = pathname.replace(/^\/|\/$/g, '').split('/').filter(Boolean)
+    // Skip leading "docs" segment if present
+    const start = segments[0] === 'docs' ? 1 : 0
+    return {
+      siteSection: segments[start] || 'home',
+      subSection1: segments[start + 1] || '',
+      subSection2: segments[start + 2] || '',
+      hierarchy: segments.slice(start).join('|'),
+    }
+  }
+
+  function dispatchAnalyticsEvent(eventType, data, useBeacon) {
+    var detail = {
+      eventType: eventType,
+      data: data,
+      useBeacon: !!useBeacon,
+    }
+    window.dispatchEvent(new CustomEvent(CUSTOM_EVENT_LISTENER, { detail: detail }))
+  }
+
+  function dispatchCTAClick(name, type) {
+    dispatchAnalyticsEvent('web.awsm.customCTAClick', {
+      pageInteraction: {
+        click: { name: name, type: type || 'customClick' },
+      },
+    })
+  }
+
+  function dispatchSearchEvent(searchTerm, resultCount) {
+    window.dispatchEvent(
+      new CustomEvent(SEARCH_EVENT_LISTENER, {
+        detail: {
+          eventType: 'web.awsm.search',
+          data: {
+            searchOperations: {
+              searchTerm: searchTerm,
+              searchFilter: [],
+              resultCount: resultCount,
+            },
+          },
+        },
+      })
+    )
+  }
+
+  // --- 1. Page View with Site Sections ---
+
+  function trackPageView() {
+    var sections = deriveSections(window.location.pathname)
+    dispatchAnalyticsEvent('web.awsm.pageInteraction', {
+      pageInteraction: {
+        name: 'pageView',
+        siteSection: sections.siteSection,
+        subSection1: sections.subSection1,
+        subSection2: sections.subSection2,
+        hierarchy: sections.hierarchy,
+      },
+    })
+  }
+
+  // --- 2. Anchor / In-Page Section Clicks ---
+
+  function setupAnchorTracking() {
+    document.addEventListener('click', function (e) {
+      var link = e.target.closest('a[href^="#"]')
+      if (!link) return
+      var anchor = link.getAttribute('href').replace('#', '')
+      if (!anchor) return
+      var isToc = !!link.closest('nav.right-sidebar, [class*="toc"], starlight-toc')
+      var prefix = isToc ? 'toc-click' : 'anchor-click'
+      dispatchCTAClick(prefix + ':' + anchor, 'linkClick')
+    })
+  }
+
+  // --- 3. Search Events ---
+
+  function setupSearchTracking() {
+    var searchTimeout = null
+    var observer = new MutationObserver(function () {
+      var resultsContainer = document.querySelector('[data-pagefind-ui] .pagefind-ui__results')
+      if (!resultsContainer) return
+      clearTimeout(searchTimeout)
+      searchTimeout = setTimeout(function () {
+        var input = document.querySelector('[data-pagefind-ui] input')
+        var term = input ? input.value : ''
+        if (!term) return
+        var items = resultsContainer.querySelectorAll('.pagefind-ui__result')
+        dispatchSearchEvent(term, items.length)
+      }, 800)
+    })
+
+    // Starlight uses a dialog for search; observe when it appears
+    var searchDialog = document.querySelector('dialog[aria-label*="earch"], [data-pagefind-ui]')
+    if (searchDialog) {
+      observer.observe(searchDialog, { childList: true, subtree: true })
+    } else {
+      // Fallback: observe body for dialog insertion
+      var bodyObserver = new MutationObserver(function (mutations) {
+        for (var i = 0; i < mutations.length; i++) {
+          var nodes = mutations[i].addedNodes
+          for (var j = 0; j < nodes.length; j++) {
+            if (nodes[j].nodeType === 1 && (nodes[j].matches('dialog') || nodes[j].querySelector('[data-pagefind-ui]'))) {
+              observer.observe(nodes[j], { childList: true, subtree: true })
+              bodyObserver.disconnect()
+              return
+            }
+          }
+        }
+      })
+      bodyObserver.observe(document.body, { childList: true })
+    }
+  }
+
+  // --- 4. Scroll Depth ---
+
+  function setupScrollTracking() {
+    var scrollData = { initial: 0, max: 0, latest: 0 }
+
+    function updateScroll() {
+      var scrollTop = window.pageYOffset || document.documentElement.scrollTop
+      var docHeight = document.documentElement.scrollHeight - window.innerHeight
+      var depth = docHeight > 0 ? Math.round((scrollTop / docHeight) * 100) : 0
+      scrollData.latest = depth
+      if (depth > scrollData.max) scrollData.max = depth
+    }
+
+    var debounceTimer
+    window.addEventListener('scroll', function () {
+      clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(updateScroll, 200)
+    }, { passive: true })
+
+    // Capture initial position
+    setTimeout(function () {
+      updateScroll()
+      scrollData.initial = scrollData.latest
+    }, 500)
+
+    // Send on page unload via beacon
+    window.addEventListener('beforeunload', function () {
+      updateScroll()
+      dispatchAnalyticsEvent(
+        'web.awsm.pageInteraction',
+        {
+          pageInteraction: {
+            name: 'scroll',
+            scrollDepths: {
+              initial: scrollData.initial,
+              max: scrollData.max,
+              latest: scrollData.latest,
+            },
+          },
+        },
+        true // useBeacon
+      )
+    })
+  }
+
+  // --- 5. Navigation Tab & Outbound Link Clicks ---
+
+  function setupNavTracking() {
+    document.addEventListener('click', function (e) {
+      // Nav tab clicks
+      var navTab = e.target.closest('.nav-tab, .mobile-nav-link')
+      if (navTab) {
+        var label = navTab.textContent.trim().replace(/\s*↗$/, '')
+        dispatchCTAClick('nav-tab:' + label, 'click')
+        return
+      }
+
+      // Code copy button
+      var copyBtn = e.target.closest('.copy button, button.copy, [data-code] button')
+      if (copyBtn) {
+        var sections = deriveSections(window.location.pathname)
+        dispatchCTAClick('code-copy:' + sections.hierarchy, 'customClick')
+        return
+      }
+
+      // Outbound links
+      var link = e.target.closest('a[href]')
+      if (link && link.hostname && link.hostname !== window.location.hostname) {
+        dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick')
+      }
+    })
+  }
+
+  // --- 6. SPA / View Transition Support ---
+
+  function init() {
+    trackPageView()
+    setupScrollTracking()
+  }
+
+  // Run on initial load
+  setupAnchorTracking()
+  setupSearchTracking()
+  setupNavTracking()
+  init()
+
+  // Re-run page-level tracking on Astro client-side navigation
+  document.addEventListener('astro:page-load', function () {
+    init()
+  })
+})()
+</script>

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -10,18 +10,18 @@
 ;(function () {
   'use strict'
 
-  // Prevent duplicate initialization on View Transition re-executions
-  if (window.__strandsAnalyticsInit) {
-    onPageTransition()
-    return
-  }
+  // Prevent duplicate initialization on View Transition re-executions.
+  // The astro:page-load listener (registered on first init) handles transitions.
+  if (window.__strandsAnalyticsInit) return
   window.__strandsAnalyticsInit = true
 
   var CUSTOM_EVENT_LISTENER = 'custom-awsm-acs-analytics-event-listener'
   var SEARCH_EVENT_LISTENER = 'custom-awsm-acs-search-event-listener'
 
-  // Scroll state - lives outside setupScrollTracking so it can be reset on transitions
   var scrollData = { initial: 0, max: 0, latest: 0 }
+  var scrollSent = false
+  var searchObserver = null
+  var searchBodyObserver = null
 
   // --- Helpers ---
 
@@ -87,24 +87,48 @@
     })
   }
 
-  // --- 2. Anchor / In-Page Section Clicks ---
+  // --- 2. Click Tracking (anchors, nav tabs, code copy, outbound) ---
 
-  function setupAnchorTracking() {
+  function setupClickTracking() {
     document.addEventListener('click', function (e) {
       if (!e.target || !e.target.closest) return
-      var link = e.target.closest('a[href^="#"]')
-      if (!link) return
-      var anchor = link.getAttribute('href').replace('#', '')
-      if (!anchor) return
-      var isToc = !!link.closest('nav.right-sidebar, [class*="toc"], starlight-toc')
-      var prefix = isToc ? 'toc-click' : 'anchor-click'
-      dispatchCTAClick(prefix + ':' + anchor, 'linkClick')
+
+      // Anchor / TOC clicks
+      var anchorLink = e.target.closest('a[href^="#"]')
+      if (anchorLink) {
+        var anchor = anchorLink.getAttribute('href').replace('#', '')
+        if (!anchor) return
+        var isToc = !!anchorLink.closest('nav.right-sidebar, [class*="toc"], starlight-toc')
+        var prefix = isToc ? 'toc-click' : 'anchor-click'
+        dispatchCTAClick(prefix + ':' + anchor, 'linkClick')
+        return
+      }
+
+      // Nav tab clicks
+      var navTab = e.target.closest('.nav-tab, .mobile-nav-link')
+      if (navTab) {
+        var label = navTab.textContent.trim().replace(/\s*↗$/, '')
+        dispatchCTAClick('nav-tab:' + label, 'click')
+        return
+      }
+
+      // Code copy button
+      var copyBtn = e.target.closest('.copy button, button.copy, [data-code] button')
+      if (copyBtn) {
+        var pageSections = deriveSections(window.location.pathname)
+        dispatchCTAClick('code-copy:' + pageSections.hierarchy, 'customClick')
+        return
+      }
+
+      // Outbound links
+      var link = e.target.closest('a[href]')
+      if (link && link.hostname && link.hostname !== window.location.hostname) {
+        dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick')
+      }
     })
   }
 
   // --- 3. Search Events ---
-
-  var searchObserver = null
 
   function setupSearchTracking() {
     var searchTimeout = null
@@ -121,24 +145,33 @@
       }, 800)
     })
 
+    // Starlight renders search in a <dialog> with aria-label containing "Search".
+    // Partial match on "earch" handles capitalization; if the label changes, the
+    // bodyObserver fallback will still pick up [data-pagefind-ui] when it appears.
     var searchDialog = document.querySelector('dialog[aria-label*="earch"], [data-pagefind-ui]')
     if (searchDialog) {
       searchObserver.observe(searchDialog, { childList: true, subtree: true })
     } else {
-      var bodyObserver = new MutationObserver(function (mutations) {
+      searchBodyObserver = new MutationObserver(function (mutations) {
         for (var i = 0; i < mutations.length; i++) {
           var nodes = mutations[i].addedNodes
           for (var j = 0; j < nodes.length; j++) {
             if (nodes[j].nodeType === 1 && (nodes[j].matches('dialog') || nodes[j].querySelector('[data-pagefind-ui]'))) {
               searchObserver.observe(nodes[j], { childList: true, subtree: true })
-              bodyObserver.disconnect()
+              searchBodyObserver.disconnect()
+              searchBodyObserver = null
               return
             }
           }
         }
       })
-      bodyObserver.observe(document.body, { childList: true })
+      searchBodyObserver.observe(document.body, { childList: true })
     }
+  }
+
+  function disconnectSearchObservers() {
+    if (searchObserver) { searchObserver.disconnect(); searchObserver = null }
+    if (searchBodyObserver) { searchBodyObserver.disconnect(); searchBodyObserver = null }
   }
 
   // --- 4. Scroll Depth ---
@@ -152,6 +185,8 @@
   }
 
   function sendScrollDepth() {
+    if (scrollSent) return
+    scrollSent = true
     updateScroll()
     dispatchAnalyticsEvent(
       'web.awsm.pageInteraction',
@@ -195,67 +230,28 @@
     scrollData.initial = 0
     scrollData.max = 0
     scrollData.latest = 0
+    scrollSent = false
     setTimeout(function () {
       updateScroll()
       scrollData.initial = scrollData.latest
     }, 500)
   }
 
-  // --- 5. Navigation Tab & Outbound Link Clicks ---
+  // --- 5. SPA / View Transition Support ---
 
-  function setupNavTracking() {
-    document.addEventListener('click', function (e) {
-      if (!e.target || !e.target.closest) return
-
-      // Nav tab clicks
-      var navTab = e.target.closest('.nav-tab, .mobile-nav-link')
-      if (navTab) {
-        var label = navTab.textContent.trim().replace(/\s*↗$/, '')
-        dispatchCTAClick('nav-tab:' + label, 'click')
-        return
-      }
-
-      // Code copy button
-      var copyBtn = e.target.closest('.copy button, button.copy, [data-code] button')
-      if (copyBtn) {
-        var pageSections = deriveSections(window.location.pathname)
-        dispatchCTAClick('code-copy:' + pageSections.hierarchy, 'customClick')
-        return
-      }
-
-      // Outbound links
-      var link = e.target.closest('a[href]')
-      if (link && link.hostname && link.hostname !== window.location.hostname) {
-        dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick')
-      }
-    })
-  }
-
-  // --- 6. SPA / View Transition Support ---
-
-  function onPageTransition() {
-    trackPageView()
-    resetScrollData()
-  }
-
-  // Disconnect search observer before page swap to prevent leaks
   document.addEventListener('astro:before-swap', function () {
-    if (searchObserver) {
-      searchObserver.disconnect()
-      searchObserver = null
-    }
+    disconnectSearchObservers()
   })
 
   document.addEventListener('astro:page-load', function () {
-    // Re-attach search observer for the new page
-    if (!searchObserver) setupSearchTracking()
-    onPageTransition()
+    setupSearchTracking()
+    trackPageView()
+    resetScrollData()
   })
 
   // --- Initial setup (runs once) ---
-  setupAnchorTracking()
+  setupClickTracking()
   setupSearchTracking()
-  setupNavTracking()
   setupScrollTracking()
   trackPageView()
 })()

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -120,8 +120,11 @@
 
       // Outbound links
       var link = e.target.closest('a[href]')
-      if (link && link.hostname && link.hostname !== window.location.hostname) {
+      if (!link || !link.hostname) return
+      if (link.hostname !== window.location.hostname) {
         dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick')
+      } else if (link.pathname !== window.location.pathname) {
+        dispatchCTAClick('inbound:' + link.pathname, 'linkClick')
       }
     })
   }

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -136,6 +136,8 @@
       if (!input || !input.matches || !input.matches('[data-pagefind-ui] input')) return
 
       clearTimeout(searchTimeout)
+      // 800ms debounce captures user intent; result count may lag if Pagefind
+      // hasn't responded yet, but this is acceptable for analytics purposes.
       searchTimeout = setTimeout(function () {
         var term = input.value
         if (!term) return
@@ -148,7 +150,7 @@
   // --- 4. Scroll Depth ---
 
   function updateScroll() {
-    var scrollTop = window.pageYOffset || document.documentElement.scrollTop
+    var scrollTop = window.scrollY || document.documentElement.scrollTop
     var docHeight = document.documentElement.scrollHeight - window.innerHeight
     var depth = docHeight > 0 ? Math.round((scrollTop / docHeight) * 100) : 0
     scrollData.latest = depth
@@ -182,11 +184,6 @@
       debounceTimer = setTimeout(updateScroll, 200)
     }, { passive: true })
 
-    setTimeout(function () {
-      updateScroll()
-      scrollData.initial = scrollData.latest
-    }, 500)
-
     window.addEventListener('beforeunload', sendScrollDepth)
 
     // visibilitychange is more reliable on mobile (iOS Safari doesn't always fire beforeunload)
@@ -216,9 +213,10 @@
   })
 
   // --- Initial setup (runs once) ---
+  // astro:page-load fires on initial load and all subsequent navigations,
+  // so it handles trackPageView() and resetScrollData() for every page.
   setupClickTracking()
   setupSearchTracking()
   setupScrollTracking()
-  trackPageView()
 })()
 </script>

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -10,15 +10,24 @@
 ;(function () {
   'use strict'
 
-  const CUSTOM_EVENT_LISTENER = 'custom-awsm-acs-analytics-event-listener'
-  const SEARCH_EVENT_LISTENER = 'custom-awsm-acs-search-event-listener'
+  // Prevent duplicate initialization on View Transition re-executions
+  if (window.__strandsAnalyticsInit) {
+    onPageTransition()
+    return
+  }
+  window.__strandsAnalyticsInit = true
+
+  var CUSTOM_EVENT_LISTENER = 'custom-awsm-acs-analytics-event-listener'
+  var SEARCH_EVENT_LISTENER = 'custom-awsm-acs-search-event-listener'
+
+  // Scroll state - lives outside setupScrollTracking so it can be reset on transitions
+  var scrollData = { initial: 0, max: 0, latest: 0 }
 
   // --- Helpers ---
 
   function deriveSections(pathname) {
-    const segments = pathname.replace(/^\/|\/$/g, '').split('/').filter(Boolean)
-    // Skip leading "docs" segment if present
-    const start = segments[0] === 'docs' ? 1 : 0
+    var segments = pathname.replace(/^\/|\/$/g, '').split('/').filter(Boolean)
+    var start = segments[0] === 'docs' ? 1 : 0
     return {
       siteSection: segments[start] || 'home',
       subSection1: segments[start + 1] || '',
@@ -27,6 +36,8 @@
     }
   }
 
+  // Consent is enforced by the WebSDK listener itself - events dispatched here
+  // are silently dropped if the user has not accepted performance cookies via Shortbread.
   function dispatchAnalyticsEvent(eventType, data, useBeacon) {
     var detail = {
       eventType: eventType,
@@ -80,6 +91,7 @@
 
   function setupAnchorTracking() {
     document.addEventListener('click', function (e) {
+      if (!e.target || !e.target.closest) return
       var link = e.target.closest('a[href^="#"]')
       if (!link) return
       var anchor = link.getAttribute('href').replace('#', '')
@@ -92,9 +104,11 @@
 
   // --- 3. Search Events ---
 
+  var searchObserver = null
+
   function setupSearchTracking() {
     var searchTimeout = null
-    var observer = new MutationObserver(function () {
+    searchObserver = new MutationObserver(function () {
       var resultsContainer = document.querySelector('[data-pagefind-ui] .pagefind-ui__results')
       if (!resultsContainer) return
       clearTimeout(searchTimeout)
@@ -107,18 +121,16 @@
       }, 800)
     })
 
-    // Starlight uses a dialog for search; observe when it appears
     var searchDialog = document.querySelector('dialog[aria-label*="earch"], [data-pagefind-ui]')
     if (searchDialog) {
-      observer.observe(searchDialog, { childList: true, subtree: true })
+      searchObserver.observe(searchDialog, { childList: true, subtree: true })
     } else {
-      // Fallback: observe body for dialog insertion
       var bodyObserver = new MutationObserver(function (mutations) {
         for (var i = 0; i < mutations.length; i++) {
           var nodes = mutations[i].addedNodes
           for (var j = 0; j < nodes.length; j++) {
             if (nodes[j].nodeType === 1 && (nodes[j].matches('dialog') || nodes[j].querySelector('[data-pagefind-ui]'))) {
-              observer.observe(nodes[j], { childList: true, subtree: true })
+              searchObserver.observe(nodes[j], { childList: true, subtree: true })
               bodyObserver.disconnect()
               return
             }
@@ -131,53 +143,70 @@
 
   // --- 4. Scroll Depth ---
 
+  function updateScroll() {
+    var scrollTop = window.pageYOffset || document.documentElement.scrollTop
+    var docHeight = document.documentElement.scrollHeight - window.innerHeight
+    var depth = docHeight > 0 ? Math.round((scrollTop / docHeight) * 100) : 0
+    scrollData.latest = depth
+    if (depth > scrollData.max) scrollData.max = depth
+  }
+
+  function sendScrollDepth() {
+    updateScroll()
+    dispatchAnalyticsEvent(
+      'web.awsm.pageInteraction',
+      {
+        pageInteraction: {
+          name: 'scroll',
+          scrollDepths: {
+            initial: scrollData.initial,
+            max: scrollData.max,
+            latest: scrollData.latest,
+          },
+        },
+      },
+      true
+    )
+  }
+
   function setupScrollTracking() {
-    var scrollData = { initial: 0, max: 0, latest: 0 }
-
-    function updateScroll() {
-      var scrollTop = window.pageYOffset || document.documentElement.scrollTop
-      var docHeight = document.documentElement.scrollHeight - window.innerHeight
-      var depth = docHeight > 0 ? Math.round((scrollTop / docHeight) * 100) : 0
-      scrollData.latest = depth
-      if (depth > scrollData.max) scrollData.max = depth
-    }
-
     var debounceTimer
     window.addEventListener('scroll', function () {
       clearTimeout(debounceTimer)
       debounceTimer = setTimeout(updateScroll, 200)
     }, { passive: true })
 
-    // Capture initial position
     setTimeout(function () {
       updateScroll()
       scrollData.initial = scrollData.latest
     }, 500)
 
-    // Send on page unload via beacon
-    window.addEventListener('beforeunload', function () {
-      updateScroll()
-      dispatchAnalyticsEvent(
-        'web.awsm.pageInteraction',
-        {
-          pageInteraction: {
-            name: 'scroll',
-            scrollDepths: {
-              initial: scrollData.initial,
-              max: scrollData.max,
-              latest: scrollData.latest,
-            },
-          },
-        },
-        true // useBeacon
-      )
+    window.addEventListener('beforeunload', sendScrollDepth)
+
+    // visibilitychange is more reliable on mobile (iOS Safari doesn't always fire beforeunload)
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'hidden') {
+        sendScrollDepth()
+      }
     })
+  }
+
+  function resetScrollData() {
+    scrollData.initial = 0
+    scrollData.max = 0
+    scrollData.latest = 0
+    setTimeout(function () {
+      updateScroll()
+      scrollData.initial = scrollData.latest
+    }, 500)
   }
 
   // --- 5. Navigation Tab & Outbound Link Clicks ---
 
   function setupNavTracking() {
     document.addEventListener('click', function (e) {
+      if (!e.target || !e.target.closest) return
+
       // Nav tab clicks
       var navTab = e.target.closest('.nav-tab, .mobile-nav-link')
       if (navTab) {
@@ -189,8 +218,8 @@
       // Code copy button
       var copyBtn = e.target.closest('.copy button, button.copy, [data-code] button')
       if (copyBtn) {
-        var sections = deriveSections(window.location.pathname)
-        dispatchCTAClick('code-copy:' + sections.hierarchy, 'customClick')
+        var pageSections = deriveSections(window.location.pathname)
+        dispatchCTAClick('code-copy:' + pageSections.hierarchy, 'customClick')
         return
       }
 
@@ -204,20 +233,30 @@
 
   // --- 6. SPA / View Transition Support ---
 
-  function init() {
+  function onPageTransition() {
     trackPageView()
-    setupScrollTracking()
+    resetScrollData()
   }
 
-  // Run on initial load
+  // Disconnect search observer before page swap to prevent leaks
+  document.addEventListener('astro:before-swap', function () {
+    if (searchObserver) {
+      searchObserver.disconnect()
+      searchObserver = null
+    }
+  })
+
+  document.addEventListener('astro:page-load', function () {
+    // Re-attach search observer for the new page
+    if (!searchObserver) setupSearchTracking()
+    onPageTransition()
+  })
+
+  // --- Initial setup (runs once) ---
   setupAnchorTracking()
   setupSearchTracking()
   setupNavTracking()
-  init()
-
-  // Re-run page-level tracking on Astro client-side navigation
-  document.addEventListener('astro:page-load', function () {
-    init()
-  })
+  setupScrollTracking()
+  trackPageView()
 })()
 </script>

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -120,11 +120,8 @@
 
       // Outbound links
       var link = e.target.closest('a[href]')
-      if (!link || !link.hostname) return
-      if (link.hostname !== window.location.hostname) {
+      if (link && link.hostname && link.hostname !== window.location.hostname) {
         dispatchCTAClick('outbound:' + link.hostname + link.pathname, 'linkClick')
-      } else if (link.pathname !== window.location.pathname) {
-        dispatchCTAClick('inbound:' + link.pathname, 'linkClick')
       }
     })
   }

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -6,6 +6,7 @@
  */
 import { getCollection } from 'astro:content'
 import SiteScripts from '../SiteScripts.astro'
+import Analytics from '../Analytics.astro'
 import { baseSchemas } from '../../util/structured-data'
 import { relatedUserGuideFor } from '../../util/related-docs'
 
@@ -122,6 +123,9 @@ const structuredData = {
 
 <!-- AWS Shortbread cookie consent -->
 <SiteScripts />
+
+<!-- Analytics instrumentation (site sections, anchors, search, scroll, nav) -->
+<Analytics />
 
 <!-- Structured Data -->
 <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -25,6 +25,7 @@ import ThemeProvider from 'virtual:starlight/components/ThemeProvider'
 
 import Header from '../components/overrides/Header.astro'
 import SiteScripts from '../components/SiteScripts.astro'
+import Analytics from '../components/Analytics.astro'
 import { pathWithBase } from '../util/links'
 import { baseSchemas } from '../util/structured-data'
 
@@ -137,6 +138,9 @@ Astro.locals.t = mockT
 
     <!-- AWS Shortbread cookie consent -->
     <SiteScripts />
+
+    <!-- Analytics instrumentation -->
+    <Analytics />
 
     <ThemeProvider />
     


### PR DESCRIPTION
## Description

Adds client-side analytics instrumentation that dispatches events through the existing AWS WebSDK. Currently the WebSDK is loaded but no custom events are being pushed. This wires up tracking for:

- Page views enriched with site section hierarchy (derived from URL path segments)
- In-page anchor and table-of-contents link clicks
- Pagefind search usage (term + result count) via delegated input listener
- Scroll depth (initial/max/latest, sent via beacon on unload + visibilitychange)
- Header nav tab clicks, code copy button clicks, and outbound link clicks
- Re-fires page-level events on Astro View Transitions for SPA navigation

All events use the standard `_aws` XDM namespace patterns (`web.awsm.customCTAClick`, `web.awsm.search`, `web.awsm.pageInteraction`) so they flow into CJA without additional schema work.

## Related Issues

N/A

## Type of Change

- Other: Analytics instrumentation

## Testing

Ran `npm run dev` and verified all event types dispatch correctly by attaching a listener to `custom-awsm-acs-analytics-event-listener` in the browser console and triggering each interaction.

### Page view with site sections

Navigated to `/docs/user-guide/quickstart/typescript/` and confirmed a single `web.awsm.pageInteraction` event fires with correct hierarchy:

```json
{
  "eventType": "web.awsm.pageInteraction",
  "data": {
    "pageInteraction": {
      "name": "pageView",
      "siteSection": "user-guide",
      "subSection1": "quickstart",
      "subSection2": "typescript",
      "hierarchy": "user-guide|quickstart|typescript"
    }
  },
  "useBeacon": false
}
```

### TOC anchor click

Clicked a `starlight-toc` link (`#language-support`). Confirmed one event:

```json
{
  "eventType": "web.awsm.customCTAClick",
  "data": {
    "pageInteraction": {
      "click": { "name": "toc-click:language-support", "type": "linkClick" }
    }
  }
}
```

### Code copy button

Clicked the copy button on a code block:

```json
{
  "eventType": "web.awsm.customCTAClick",
  "data": {
    "pageInteraction": {
      "click": { "name": "code-copy:user-guide|quickstart|typescript", "type": "customClick" }
    }
  }
}
```

### Outbound link click

Clicked an external link to `docs.npmjs.com`:

```json
{
  "eventType": "web.awsm.customCTAClick",
  "data": {
    "pageInteraction": {
      "click": { "name": "outbound:docs.npmjs.com/downloading-and-installing-node-js-and-npm", "type": "linkClick" }
    }
  }
}
```

### Nav tab click

Clicked the first `.nav-tab` element:

```json
{
  "eventType": "web.awsm.customCTAClick",
  "data": {
    "pageInteraction": {
      "click": { "name": "nav-tab:Home", "type": "click" }
    }
  }
}
```

### Init guard (no duplicate listeners)

Verified `window.__strandsAnalyticsInit` is set to `true` after first execution. On View Transition re-execution the IIFE returns early. Manually firing `astro:page-load` twice results in exactly 2 page view events (one per fire, no accumulation from duplicate listeners).

### Scroll depth

`beforeunload` and `visibilitychange` listeners are registered. Uses a `scrollSent` flag to prevent double-sending when both events fire on the same page close.

### Search

Uses a delegated `input` event listener on `document` targeting `[data-pagefind-ui] input`. Debounces at 800ms before reading result count. Full functional testing requires the Pagefind index (`npm run build`), not available in dev mode.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.