### PR TITLE
docs(lambda): add layer v2 mapping and remove New badge

### DIFF
--- a/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
+++ b/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
@@ -2,9 +2,6 @@
 title: Deploying Strands Agents SDK Agents to AWS Lambda
 sidebar:
   label: "AWS Lambda"
-  badge:
-    text: New
-    variant: note
 tags: [deployment, aws]
 ---
 
@@ -85,7 +82,7 @@ arn:aws:lambda:{region}:856699698935:layer:strands-agents-py{python_version}-{ar
 **Example:**
 
 ```
-arn:aws:lambda:us-east-1:856699698935:layer:strands-agents-py3_12-x86_64:1
+arn:aws:lambda:us-east-1:856699698935:layer:strands-agents-py3_12-x86_64:2
 ```
 
 | Component | Options |
@@ -98,6 +95,7 @@ arn:aws:lambda:us-east-1:856699698935:layer:strands-agents-py3_12-x86_64:1
 
 | Layer Version | SDK Version |
 |---------------|-------------|
+| 2 | strands-agents v1.40.0 |
 | 1 | strands-agents v1.23.0 |
 
 To check the details of a layer version yourself:


### PR DESCRIPTION
## Description

Adds Lambda layer version 2 (strands-agents v1.40.0) to the version mapping table on the AWS Lambda deployment page, updates the example ARN to reference the latest layer version `:2`, and removes the "New" sidebar badge now that the page is established.

## Related Issues

N/A

## Type of Change

- Content update/revision

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] My changes follow the project's documentation style
- [X] I have tested the documentation locally using `npm run dev`
- [X] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
