### PR TITLE
test: verify CI triggers after monorepo restructure

### DIFF
--- a/site/CONTRIBUTING.md
+++ b/site/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
 documentation, we greatly value feedback and contributions from our community.
+<!-- CI trigger test - verifying workflow path filters -->
 
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.


### PR DESCRIPTION
## Summary
- Testing whether CI workflow path filters (`site/**`) correctly trigger after the monorepo directory restructure in #855

## Context
This is a throwaway PR to verify CI behavior. Will be closed after observation.