### PR TITLE
fix(ci): update Python SDK path after sdk-python monorepo restructure

### DIFF
--- a/site/scripts/api-generation-python.py
+++ b/site/scripts/api-generation-python.py
@@ -45,7 +45,7 @@ class CustomGitSourceLinker(GitSourceLinker):
 
 
 def generate_docs():
-    input_path =  "./.build/sdk-python/src"
+    input_path =  "./.build/sdk-python/strands-py/src"
     output_path = "./.build/api-docs/python"
 
     """Generate markdown documentation for all strands modules."""
@@ -82,8 +82,8 @@ def generate_docs():
         add_module_prefix=True,
         render_toc=False,
         source_linker=CustomGitSourceLinker(
-            root=".build/sdk-python/src",
-            url_template="https://github.com/strands-agents/sdk-python/blob/main/src/{path}#L{lineno}",
+            root=".build/sdk-python/strands-py/src",
+            url_template="https://github.com/strands-agents/sdk-python/blob/main/strands-py/src/{path}#L{lineno}",
             use_branch=False,
         ),
         source_format="{url}",  # URL already contains the full formatted string


### PR DESCRIPTION
## Summary
- The `sdk-python` repo restructured its source from `src/` to `strands-py/src/`
- This broke `api-generation-python.py`, which couldn't find the source to generate API reference pages
- The missing API pages cause broken link errors in CI, blocking all PRs

## Test plan
- [ ] CI passes on this PR (proves the fix works)