### PR TITLE
docs: update agentcore deployment commands (launch → deploy)

### DIFF
--- a/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/python.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_bedrock_agentcore/python.mdx
@@ -140,6 +140,8 @@ curl -X POST http://localhost:8080/invocations \
 
 #### Method A: Starter Toolkit (For quick prototyping)
 
+> **Note**: The starter toolkit is being superseded by the [AgentCore CLI (`@aws/agentcore`)](https://github.com/aws/agentcore-cli), which is now the recommended tool for new projects. Install with `npm install -g @aws/agentcore`.
+
 For quick prototyping with automated deployment:
 
 ```bash
@@ -189,16 +191,16 @@ Deploy with Starter Toolkit
 agentcore configure --entrypoint agent_example.py
 
 # Optional: Local testing (requires Docker, Finch, or Podman)
-agentcore launch --local
+agentcore deploy --local
 
 # Deploy to AWS
-agentcore launch
+agentcore deploy
 
 # Test your agent with CLI
 agentcore invoke '{"prompt": "Hello"}'
 ```
 
-> **Note**: The `agentcore launch --local` command requires a container engine (Docker, Finch, or Podman) for local deployment testing. This step is optional - you can skip directly to `agentcore launch` for AWS deployment if you don't need local testing.
+> **Note**: The `agentcore deploy --local` command requires a container engine (Docker, Finch, or Podman) for local deployment testing. This step is optional - you can skip directly to `agentcore deploy` for AWS deployment if you don't need local testing.
 
 #### Method B: Manual Deployment with boto3
 


### PR DESCRIPTION

## Description
The starter toolkit renamed `agentcore launch` to `agentcore deploy` and is being superseded by the AgentCore CLI (@aws/agentcore). Update Python deployment docs with the correct command and add a note about the new CLI.

## Related Issues
<!-- Link to related issues using #issue-number format -->
 Full revamp TK in https://github.com/strands-agents/docs/issues/863

## Type of Change

- Bug fix

## Checklist
<!-- Mark completed items with an [x] -->

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
