### PR TITLE
fix(docs): astro table rendering

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -11,6 +11,7 @@ import { loadSidebarFromConfig } from "./src/sidebar.ts"
 import { sitemapWithLastmod } from "./src/plugins/sitemap-lastmod.ts"
 import AutoImport from './src/plugins/astro-auto-import.ts'
 import astroExpressiveCode from "astro-expressive-code"
+import remarkGfm from 'remark-gfm'
 import mdx from '@astrojs/mdx';
 import astroBrokenLinksChecker from './scripts/astro-broken-links-checker-index.js';
 
@@ -51,7 +52,6 @@ export default defineConfig({
         },
       },
     }),
-    mdx(),
     starlight({
       social: [],
       head: [
@@ -109,5 +109,6 @@ export default defineConfig({
         a: './src/components/PageLink.astro'
       }
     }),
+    mdx({ remarkPlugins: [remarkGfm] }),
   ],
 })

--- a/site/package.json
+++ b/site/package.json
@@ -62,6 +62,7 @@
     "js-yaml": "^4.1.1",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
     "sitemapper": "^4.1.4",


### PR DESCRIPTION

## Description

Tables in `.mdx` files across the site render as raw pipe-delimited text instead of HTML `<table>` elements. This was introduced in e1f5910d which added a manual `mdx()` integration to `site/astro.config.mjs`. When `mdx()` is registered explicitly before Starlight, it doesn't inherit Starlight's built-in remark-gfm plugin, which provides GFM table parsing.

This PR installs `remark-gfm` and passes it to the `mdx()` integration so tables render correctly on all pages.

## Related Issues

N/A

## Type of Change

- Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

---

The fix: added `remark-gfm` as a devDependency and configured `mdx({ remarkPlugins: [remarkGfm] })` in `site/astro.config.mjs`. Build passes; the `/llms-full.txt` `Tab` error is pre-existing and unrelated.