### PR TITLE
feat(docs): add human in the loop

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -82,11 +82,16 @@ sidebar:
               - docs/user-guide/concepts/tools/vended-tools
           - label: Plugins
             items:
-              - docs/user-guide/concepts/plugins
+              - label: "Overview"
+                slug: docs/user-guide/concepts/plugins
               - docs/user-guide/concepts/plugins/skills
               - docs/user-guide/concepts/plugins/steering
               - docs/user-guide/concepts/plugins/context-offloader
-          - docs/user-guide/concepts/agents/interventions
+          - label: Interventions
+            items:
+              - label: "Overview"
+                slug: docs/user-guide/concepts/agents/interventions
+              - docs/user-guide/concepts/agents/human-in-the-loop
           - label: Streaming
             items:
               - docs/user-guide/concepts/streaming/async-iterators

--- a/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.mdx
@@ -1,0 +1,118 @@
+---
+title: Human in the Loop
+tags: [hooks, tool-execution]
+description: "Gate agent tool execution behind human approval. Configurable modes for CLI, web, and custom UIs with optional session trust."
+languages: [typescript]
+sidebar:
+  badge:
+    text: New
+    variant: tip
+---
+
+The `HumanInTheLoop` intervention handler pauses agent execution before tool calls to request human approval. It provides a configurable, drop-in way to add human oversight without writing custom interrupt logic. Pass it to `interventions` and choose how you want to collect the human's response.
+
+## How It Works
+
+```mermaid
+flowchart LR
+    A[Tool call] --> B{Allowed?}
+    B -->|Yes| C[Execute]
+    B -->|No| D{Trusted?}
+    D -->|Yes| C
+    D -->|No| E{Human approves?}
+    E -->|Yes| C
+    E -->|No| F[Cancel]
+```
+
+The handler uses the [`confirm` action](./interventions) to pause for human input. Under the hood it builds on the SDK's [interrupt mechanism](../interrupts), but abstracts away the manual interrupt/resume loop when you provide an `ask` option.
+
+## Getting Started
+
+### Interrupt/Resume Mode (Default)
+
+Without an `ask` option, the handler raises an interrupt and the agent pauses. The caller presents the interrupt to the user, collects their response, and resumes the agent. This is the same [interrupt/resume pattern](../interrupts#hooks) used throughout the SDK. For stateless deployments, combine with a [session manager](./session-management) to persist state between requests.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:basic_interrupt_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:basic_interrupt"
+```
+
+### Stdio Mode
+
+For CLI applications, pass `ask: 'stdio'` to prompt the user inline via Node.js readline. The agent blocks until the user responds, so no interrupt handling is needed on the caller side.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:stdio_mode_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:stdio_mode"
+```
+
+### Custom UI Callback
+
+For web UIs, Slack bots, or other custom interfaces, pass an async function to `ask`. The function receives a prompt string describing the tool call and must return the user's response.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:custom_ask_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:custom_ask"
+```
+
+## Configuration
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `allowedTools` | `string[]` | `undefined` | Tools that bypass approval. Supports `'*'` (all) and `'!toolName'` (negation). |
+| `enableTrust` | `boolean` | `false` | When `true`, trust responses are remembered for the session. |
+| `evaluateTrust` | Function | Accepts `'t'` or `'trust'` | Custom validator for trust responses. Only evaluated when `enableTrust` is `true`. |
+| `evaluate` | Function | Accepts `true`, `'y'`, or `'yes'` | Custom validator for approval responses. |
+| `ask` | Function or `'stdio'` | `undefined` | Pass an async function for custom UIs, `'stdio'` for CLI readline, or omit for interrupt/resume. |
+
+### Allowed Tools
+
+Use `allowedTools` to skip approval for safe, read-only tools:
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:allowed_tools_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:allowed_tools"
+```
+
+### Trust Mode
+
+When `enableTrust` is `true`, a human can respond with `'t'` or `'trust'` to approve the current tool call AND remember that decision for the rest of the session. Subsequent calls to the same tool skip the prompt entirely. Trust works in all modes: interrupt/resume, stdio, and custom callbacks.
+
+Trust state is stored in `agent.appState` and persists across turns within a session but resets when the agent is re-created. Negated tools (`'!toolName'`) cannot be trusted and always prompt.
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:trust_mode_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:trust_mode"
+```
+
+### Custom Evaluate
+
+By default, the handler accepts `true`, `'y'`, or `'yes'` as approval. Use `evaluate` to define your own approval logic, for example requiring a one-time passcode:
+
+```typescript
+--8<-- "user-guide/concepts/agents/human-in-the-loop_imports.ts:custom_evaluate_imports"
+
+--8<-- "user-guide/concepts/agents/human-in-the-loop.ts:custom_evaluate"
+```
+
+## Comparison with Raw Interrupts
+
+- **Setup**: `interventions: [new HumanInTheLoop()]` vs. writing a custom hook class + resume loop
+- **Inline collection**: Built-in (`ask: 'stdio'` or callback) vs. implementing yourself
+- **Trust/remember**: Built-in (`enableTrust`) vs. manual `appState` logic
+- **Tool allow-list**: Built-in (`allowedTools`) vs. custom conditional logic
+- **Flexibility**: HITL is opinionated for approval workflows; [raw interrupts](../interrupts) give full control over any interrupt shape
+
+Use `HumanInTheLoop` when you want standard approval gating with minimal code. Use [raw interrupts](../interrupts) when you need custom interrupt shapes, multi-step interactions, or non-approval workflows.
+
+## Related Topics
+
+- [Interventions](./interventions): The intervention handler framework that HITL is built on
+- [Interrupts](../interrupts): Low-level interrupt/resume mechanism
+- [Agent State](./state): How trust decisions persist via `appState`
+- [Session Management](./session-management): Persisting interrupt state across sessions

--- a/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop.ts
@@ -1,0 +1,250 @@
+import {
+  Agent, tool, InterruptResponseContent,
+  SessionManager, FileStorage,
+} from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+
+// =====================
+// Basic (Interrupt/Resume Mode)
+// =====================
+
+async function basicInterruptExample() {
+  // --8<-- [start:basic_interrupt]
+  const deleteFiles = tool({
+    name: 'delete_files',
+    description: 'Delete files at the given paths',
+    inputSchema: z.object({ paths: z.array(z.string()) }),
+    callback: (input) => `Deleted ${input.paths.length} files`,
+  })
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [new HumanInTheLoop()],
+  })
+
+  // Agent pauses with stopReason 'interrupt' when a tool needs approval
+  let result = await agent.invoke('Delete the temp files')
+
+  if (result.stopReason === 'interrupt') {
+    // Present the interrupt to the user (web UI, Slack, etc.)
+    console.log(result.interrupts![0].reason)
+
+    // Resume with the human's response
+    result = await agent.invoke([
+      new InterruptResponseContent({
+        interruptId: result.interrupts![0].id,
+        response: 'yes', // 'y', 'yes', or true → approved
+      }),
+    ])
+  }
+
+  console.log('Result:', result.lastMessage)
+  // --8<-- [end:basic_interrupt]
+}
+
+// =====================
+// Stdio Mode
+// =====================
+
+async function stdioModeExample() {
+  // --8<-- [start:stdio_mode]
+  // const deleteFiles = tool({ ... }) — same as above
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [new HumanInTheLoop({ ask: 'stdio' })],
+  })
+
+  await agent.invoke('Delete the temp files')
+  // Terminal prompt:
+  // Tool "delete_files" requires human approval. Input: {...} (y/n):
+  // --8<-- [end:stdio_mode]
+}
+
+// =====================
+// Custom Ask Callback
+// =====================
+
+async function customAskExample() {
+  // --8<-- [start:custom_ask]
+  // const deleteFiles = tool({ ... }) — same as above
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [
+      new HumanInTheLoop({
+        ask: async (prompt) => {
+          // Your UI: Slack DM, web modal, push notification, etc.
+          return await askUserViaSlack(prompt)
+        },
+      }),
+    ],
+  })
+
+  await agent.invoke('Delete the temp files')
+  // --8<-- [end:custom_ask]
+}
+
+// =====================
+// Allowed Tools
+// =====================
+
+async function allowedToolsExample() {
+  // --8<-- [start:allowed_tools]
+  // const deleteFiles = tool({ ... }) — same as above
+  // const readFile = tool({ ... })
+
+  const agent = new Agent({
+    tools: [readFile, deleteFiles],
+    interventions: [
+      new HumanInTheLoop({
+        ask: 'stdio',
+        // Pattern syntax:
+        //   'read_file'             → runs without approval
+        //   '*'                     → all tools run freely (disables handler)
+        //   ['*', '!delete_files']  → all except delete_files
+        allowedTools: ['read_file'],
+      }),
+    ],
+  })
+
+  await agent.invoke('Read config.json then delete /tmp/old-logs')
+  // Only delete_files prompts; read_file executes immediately
+  // --8<-- [end:allowed_tools]
+}
+
+// =====================
+// Trust Mode
+// =====================
+
+async function trustModeExample() {
+  // --8<-- [start:trust_mode]
+  // const deleteFiles = tool({ ... }) — same as above
+
+  const agent = new Agent({
+    tools: [deleteFiles],
+    interventions: [
+      new HumanInTheLoop({
+        ask: 'stdio',
+        enableTrust: true,
+      }),
+    ],
+  })
+
+  await agent.invoke('Delete all log files in /tmp')
+  // First call: user responds 't' → approved AND remembered
+  // Subsequent calls: no prompt needed for the session
+  // --8<-- [end:trust_mode]
+}
+
+// =====================
+// Custom Evaluate (OTP example)
+// =====================
+
+async function customEvaluateExample() {
+  // --8<-- [start:custom_evaluate]
+  const transferFunds = tool({
+    name: 'transfer_funds',
+    description: 'Transfer funds between accounts',
+    inputSchema: z.object({
+      from: z.string(),
+      to: z.string(),
+      amount: z.number(),
+    }),
+    callback: (input) =>
+      `Transferred $${input.amount} from ${input.from} to ${input.to}`,
+  })
+
+  const expectedOtp = '483291'
+
+  const agent = new Agent({
+    tools: [transferFunds],
+    interventions: [
+      new HumanInTheLoop({
+        ask: async (prompt) => {
+          await sendOtpToUser(expectedOtp)
+          return await collectUserInput(
+            prompt + ' Enter OTP to confirm:'
+          )
+        },
+        // Only approve if the user enters the correct OTP
+        evaluate: (response) => response === expectedOtp,
+      }),
+    ],
+  })
+
+  await agent.invoke('Transfer $500 from checking to savings')
+  // --8<-- [end:custom_evaluate]
+}
+
+// =====================
+// Cloud / API Server (Interrupt/Resume with Session)
+// =====================
+
+async function cloudApiExample() {
+  // --8<-- [start:cloud_api]
+  const deleteFiles = tool({
+    name: 'delete_files',
+    description: 'Delete files at the given paths',
+    inputSchema: z.object({ paths: z.array(z.string()) }),
+    callback: (input) => `Deleted ${input.paths.length} files`,
+  })
+
+  const readFile = tool({
+    name: 'read_file',
+    description: 'Read a file',
+    inputSchema: z.object({ path: z.string() }),
+    callback: (input) => `Contents of ${input.path}`,
+  })
+
+  function createAgent() {
+    return new Agent({
+      tools: [deleteFiles, readFile],
+      interventions: [
+        new HumanInTheLoop({ allowedTools: ['read_file'] }),
+      ],
+      sessionManager: new SessionManager({
+        sessionId: 'my-session',
+        storage: {
+          snapshot: new FileStorage('/path/to/storage'),
+        },
+      }),
+    })
+  }
+
+  // Request 1: Agent tries to delete → pauses with interrupt
+  const agent = createAgent()
+  const result = await agent.invoke('Delete the temp files')
+
+  if (result.stopReason === 'interrupt') {
+    const pending = {
+      interruptId: result.interrupts![0].id,
+      reason: result.interrupts![0].reason,
+    }
+    // ... return pending to client via HTTP response
+  }
+
+  // Request 2: Client sends back approval
+  const resumedAgent = createAgent()
+  const finalResult = await resumedAgent.invoke([
+    new InterruptResponseContent({
+      interruptId: 'the-interrupt-id',
+      response: 'yes',
+    }),
+  ])
+  // --8<-- [end:cloud_api]
+}
+
+// Suppress unused function warnings
+void basicInterruptExample
+void stdioModeExample
+void customAskExample
+void allowedToolsExample
+void trustModeExample
+void customEvaluateExample
+void cloudApiExample
+
+declare function askUserViaSlack(prompt: string): Promise<string>
+declare function sendOtpToUser(otp: string): Promise<void>
+declare function collectUserInput(prompt: string): Promise<string>

--- a/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/human-in-the-loop_imports.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_interrupt_imports]
+import { Agent, tool, InterruptResponseContent } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:basic_interrupt_imports]
+
+// --8<-- [start:stdio_mode_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:stdio_mode_imports]
+
+// --8<-- [start:custom_ask_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:custom_ask_imports]
+
+// --8<-- [start:allowed_tools_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:allowed_tools_imports]
+
+// --8<-- [start:trust_mode_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:trust_mode_imports]
+
+// --8<-- [start:custom_evaluate_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:custom_evaluate_imports]
+
+// --8<-- [start:cloud_api_imports]
+import {
+  Agent, tool, InterruptResponseContent,
+  SessionManager, FileStorage,
+} from '@strands-agents/sdk'
+import { HumanInTheLoop } from '@strands-agents/sdk/vended-interventions/hitl'
+import { z } from 'zod'
+// --8<-- [end:cloud_api_imports]

--- a/site/src/content/docs/user-guide/concepts/agents/interventions.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions.mdx
@@ -98,6 +98,7 @@ Interventions return typed actions that the framework interprets. This enables:
 
 ## Related topics
 
+- [Human in the Loop](./human-in-the-loop) — Ready-to-use intervention handler for tool approval workflows
 - [Hooks](./hooks.mdx) — Low-level event callbacks for observing and modifying agent behavior
 - [Plugins](../plugins/index.mdx) — Bundle related hooks and tools into reusable modules
 - [Interrupts](../interrupts.mdx) — The interrupt/resume system that `confirm()` builds on


### PR DESCRIPTION

## Description

Adds documentation for the `HumanInTheLoop` vended intervention handler introduced in [strands-agents/sdk-typescript#1073](https://github.com/strands-agents/sdk-typescript/pull/1073).

The new page covers:
- Three collection modes: interrupt/resume (default), `ask: 'stdio'` (CLI readline), and custom async callbacks
- Configuration options: `allowedTools` (with wildcard/negation patterns), `enableTrust`, custom evaluators
- Cloud/API server example with session management
- Comparison table vs raw interrupts

Also updates the sidebar navigation to group interventions as a labeled section, and adds a cross-reference from the interventions page to the new HITL page.

## Related Issues

- strands-agents/sdk-typescript#1073
- strands-agents/sdk-typescript#883

## Type of Change

- [x] New content
- [ ] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.