### PR TITLE
docs(community): add Apify tools integration page

### DIFF
--- a/src/config/navigation.yml
+++ b/src/config/navigation.yml
@@ -227,6 +227,7 @@ sidebar:
           - docs/community/tools/utcp
       - label: Tools
         items:
+          - docs/community/tools/strands-apify
           - docs/community/tools/strands-deepgram
           - docs/community/tools/strands-hubspot
           - docs/community/tools/strands-teams

--- a/src/content/docs/community/tools/strands-apify.mdx
+++ b/src/content/docs/community/tools/strands-apify.mdx
@@ -1,0 +1,70 @@
+---
+project:
+  pypi: https://pypi.org/project/strands-apify/
+  github: https://github.com/apify/strands-apify
+  maintainer: apify
+service:
+  name: apify
+  link: https://apify.com/
+title: strands-apify
+community: true
+description: "Web scraping for social media, search engines, e-commerce, and more via Apify Actors"
+integrationType: tool
+languages: Python
+sidebar:
+  label: "Apify"
+---
+
+
+[strands-apify](https://github.com/apify/strands-apify) gives your Strands agent web scraping, search, crawling, e-commerce, and social media capabilities through the [Apify platform](https://apify.com/) and its library of thousands of pre-built Actors.
+
+## Prerequisites
+
+- An [Apify account](https://apify.com/) (free tier available)
+- [Apify API token](https://console.apify.com/account/integrations) from Apify Console > Integrations
+
+## Installation
+
+```bash
+pip install strands-apify
+```
+
+## Usage
+
+For the full tool reference, model provider setup, and more examples, see [Strands Agents on Apify docs](https://docs.apify.com/platform/integrations/strands-agents).
+
+```python
+from strands import Agent
+from strands_apify import APIFY_CORE_TOOLS, apify_google_search_scraper
+
+# Use a pre-built tool set
+agent = Agent(tools=APIFY_CORE_TOOLS)
+agent("Scrape https://docs.apify.com and summarize the page")
+
+# Or pick individual tools for a more focused agent
+agent = Agent(tools=[apify_google_search_scraper])
+agent("Find the top-rated Italian restaurants in Prague")
+```
+
+## Key Features
+
+- **18 pre-built tools** for scraping, search, social media, and e-commerce
+- **Focused tool sets** organized into `APIFY_CORE_TOOLS`, `APIFY_SEARCH_TOOLS`, and `APIFY_SOCIAL_TOOLS` for better LLM tool selection
+- **Apify Store access** to run any of thousands of Actors with a single generic tool
+- **Dataset integration** to fetch and process Actor results directly
+- **URL to markdown** conversion for any webpage
+
+## Configuration
+
+```bash
+APIFY_TOKEN=your_apify_api_token          # Required
+STRANDS_APIFY_QUIET=1                     # Optional: suppress rich panels in interactive shells
+```
+
+## Resources
+
+- [PyPI package](https://pypi.org/project/strands-apify/)
+- [GitHub repository](https://github.com/apify/strands-apify)
+- [Strands Agents on Apify docs](https://docs.apify.com/platform/integrations/strands-agents)
+- [Apify Store](https://apify.com/store)
+- [Apify API reference](https://docs.apify.com/api/v2)


### PR DESCRIPTION
## Description

Add a community tool page for [strands-apify](https://github.com/apify/strands-apify), a standalone package that gives Strands agents web scraping, search, crawling, e-commerce, and social media capabilities through the Apify platform.

**Changes:**
- **New page** (`src/content/docs/community/tools/strands-apify.mdx`): Community tool documentation covering prerequisites, installation, usage examples, key features (18 pre-built tools organized into core/search/social sets), and configuration.
- **Navigation** (`src/config/navigation.yml`): Added `strands-apify` entry to Community > Tools sidebar (alphabetical order).

**Context outside this repo:**
- The package source lives at [`apify/strands-apify`](https://github.com/apify/strands-apify) and is published to PyPI as [`strands-apify`](https://pypi.org/project/strands-apify/).
- This is a standalone community package (not part of `strands-agents-tools`), following the [New Tools Policy](https://github.com/strands-agents/tools?tab=contributing-ov-file#new-tools-policy) and [Publishing Extensions](https://strandsagents.com/docs/contribute/contributing/extensions/) guide.

## Type of Change

- [x] New content
- [ ] Content update/revision
- [ ] Structure/organization improvement
- [ ] Typo/formatting fix
- [ ] Bug fix
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes follow the project's documentation style
- [x] I have tested the documentation locally using `npm run dev`
- [x] Links in the documentation are valid and working

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.